### PR TITLE
chore: add issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,0 +1,101 @@
+name: Bug report
+description: Report incorrect behavior, a crash, or corrupted output in Firecube.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please give us enough detail to
+        reproduce it. Firecube requires **explicit product and storage flags** — include
+        the full command you ran so we can see them.
+
+        Do **not** paste credentials, tokens, or private data URIs. Redact them.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear, one- or two-sentence description of the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: The exact command(s), including all product/storage flags. Redact secrets.
+      placeholder: |
+        1. uv run firecube <command> --product ... --storage ... <uri>
+        2. ...
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the full error message and traceback if there is one.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Firecube version
+      description: Output of `uv run firecube --version`.
+      placeholder: "0.1.4"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: Install source
+      options:
+        - PyPI
+        - Git checkout (source)
+        - Container image
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Python version, OS, and any relevant extras installed (obstore, tensogram, healpix, virtualzarr).
+      placeholder: |
+        - Python: 3.12.x
+        - OS: Linux / macOS / Windows (+ version)
+        - Extras: e.g. obstore
+        - Storage backend: local / S3 (endpoint type)
+    validations:
+      required: true
+  - type: input
+    id: plugin
+    attributes:
+      label: Plugin involved (if any)
+      description: Package name and version of the ingest plugin, if the bug is in an ingest run.
+      placeholder: "my-firecube-plugin==1.2.0"
+    validations:
+      required: false
+  - type: textarea
+    id: data
+    attributes:
+      label: Data / state impact
+      description: >-
+        Did this affect stored output (Zarr), the `.firecube/` control plane, or resume/append
+        state? Is any output store now corrupt or partially written?
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: I removed all credentials, tokens, and private URIs from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -1,0 +1,73 @@
+name: Feature request
+description: Propose a new capability, integration, or improvement for Firecube.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement. Firecube favors small, explicit changes that
+        respect existing module boundaries (see `CONTRIBUTING.md` and `plans/DESIGN.md`).
+        Please describe the problem before the solution, and be concrete about scope.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and why is it hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should Firecube do? Sketch the CLI surface, config, or API if relevant.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of Firecube does this touch?
+      multiple: true
+      options:
+        - CLI / UX
+        - Ingest runtime / Zarr write path
+        - Control plane (.firecube / ChunkManager)
+        - Storage / filesystem backends
+        - Plugin contracts / API
+        - Compute / array backend
+        - Observability
+        - Packaging / extras / dependencies
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, existing workarounds, or why they fall short.
+    validations:
+      required: false
+  - type: textarea
+    id: compat
+    attributes:
+      label: Compatibility & scope
+      description: >-
+        Would this change public CLI flags, plugin contracts, config, or stored formats?
+        Should it be opt-in (e.g. an optional extra) to keep the default install lean?
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I would be willing to help implement this.
+          required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/eumetsat/firecube/discussions
+    about: Ask usage questions, propose ideas, or discuss plugin development here.
+  - name: Documentation
+    url: https://github.com/eumetsat/firecube/tree/main/docs
+    about: Check the docs before filing — many workflows and recovery steps are covered there.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+Thanks for contributing to Firecube. Please read CONTRIBUTING.md first.
+Keep pull requests focused: one logical change per PR.
+-->
+
+## What changed
+
+<!-- A clear description of the change. -->
+
+## Why
+
+<!-- The motivation. Link the issue this closes, e.g. "Closes #123". -->
+
+## Affected behavior
+
+<!-- Which user, operator, plugin, or maintainer behavior changes? -->
+
+- User / CLI:
+- Plugin authors:
+- Operators / production:
+- Stored formats or control-plane state:
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (CLI flags, plugin contract, config, or stored format)
+- [ ] Documentation
+- [ ] CI / build / chore
+
+## Checks run
+
+<!-- Tick what you ran; paste anything notable. -->
+
+- [ ] `uv run ruff check .`
+- [ ] `uv run ruff format --check .`
+- [ ] `uv run pyright`
+- [ ] `uv run --with bandit bandit -c pyproject.toml -r src scripts -lll`
+- [ ] `uv run pytest --strict-deps -m "not slow and not s3" -q`
+- [ ] Docs build (if docs changed): `uv run mkdocs build --strict`
+
+## Follow-up work
+
+<!-- Known gaps or planned follow-ups, or "none". -->
+
+## Contributor certification
+
+- [ ] Commits are signed off (`git commit -s`) with my real name and a reachable email.
+- [ ] No credentials, generated products, caches, or virtualenvs are included in this PR.
+- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.


### PR DESCRIPTION
 Adds .github/ templates: bug + feature issue forms, config.yml (blank issues off, links to Discussions/Docs), and a DCO-based PR template. Docs/meta only.