### PR TITLE
ci: add PyPI publish workflow and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: uv
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  quality-gate:
+    name: quality gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
+      - run: uv python install 3.12
+      - run: uv sync --locked --extra test --group dev
+      - name: Install test fixture plugins
+        run: |
+          uv pip install -e tests/fixtures/cli_test_plugin
+          uv pip install -e tests/fixtures/direct_zarr_capable_test_plugin
+          uv pip install -e tests/fixtures/direct_zarr_non_capable_test_plugin
+          uv pip install -e tests/fixtures/multi_group_capable_test_plugin
+          uv pip install -e tests/fixtures/cf_time_dim_test_plugin
+          uv pip install -e tests/fixtures/slot_shape_test_plugin
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+      - run: uv run pyright
+      - run: uv run pytest --strict-deps -m "not slow and not s3" -n auto --cov=firecube -q
+
+  publish:
+    name: publish to PyPI
+    runs-on: ubuntu-latest
+    needs: quality-gate
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
+      - run: uv python install 3.12
+
+      - name: Verify release tag matches pyproject version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="$(python3 -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          if [ "$RELEASE_TAG" != "v$version" ]; then
+            echo "Release tag $RELEASE_TAG does not match pyproject version v$version" >&2
+            exit 1
+          fi
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Check distributions
+        run: uvx twine check dist/*
+
+      - name: Publish distributions
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
  ## What changed

  - Added `.github/workflows/publish.yml`
  - Added `.github/dependabot.yml`

  ## Why

 Closes #4.

  ## Affected behavior

  - User / CLI: none.
  - Plugin authors: none.
  - Operators / production: none.
  - Stored formats or control-plane state: none.

  ## Type of change

  - [x] CI / build / chore

  ## Checks run

  - N/A

  ## Follow-up work

  None. 

  ## Contributor certification

  - [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
  - [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
  - [x] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
