### PR TITLE
chore: update package description for PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.1.4.post0] - 2026-07-24
+
+### Changed
+
+- Package metadata only: updated the PyPI package description. No code changes
+  relative to 0.1.4.
+
 ## [0.1.4] - 2026-06-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "firecube"
-version = "0.1.4"
-description = "Ingestion API for EO datasets"
+version = "0.1.4.post0"
+description = "A plugin-based batch ingestion CLI for turning Earth Observation products into analysis-ready datacubes."
 readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "firecube"
-version = "0.1.4"
+version = "0.1.4.post0"
 source = { editable = "." }
 dependencies = [
     { name = "botocore", extra = ["crt"] },


### PR DESCRIPTION
Metadata-only post release 0.1.4.post0, no code changes.
