### PR TITLE
feat: Add pyproject URL for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,14 @@ test = [
     "moto[s3,server]>=5.0.0",
 ]
 
+[project.urls]
+Homepage = "https://eumetsat.github.io/firecube/"
+"Bug Tracker" = "https://github.com/eumetsat/firecube/issues"
+Documentation = "https://github.com/eumetsat/firecube/blob/main/README.md"
+"Source Code" = "https://github.com/eumetsat/firecube"
+Organization = "https://www.eumetsat.int/"
+"Release Notes" = "https://github.com/eumetsat/firecube/blob/main/CHANGELOG.md"
+
 [project.scripts]
 firecube = "firecube.cli.main:cli"
 


### PR DESCRIPTION
## What changed

This will fix the missing URLs on PyPI. Similar to the one below:

<img width="975" height="664" alt="image" src="https://github.com/user-attachments/assets/b39300fb-9f32-4d3a-8b17-303835bf0896" />


## Why

It's missing URLs to this project as expected by PyPI

<img width="1241" height="698" alt="image" src="https://github.com/user-attachments/assets/64093019-438a-4006-9dd5-cdcab47c96a1" />


## Affected behavior

User experience with PyPI

## Type of change

- [x] Documentation


## Follow-up work

you need to release a new version to have PyPI updated
