### PR TITLE
fix(cli): enforce URI scheme on archive create/restore --archive parameter

### DIFF
--- a/src/firecube/cli/archive.py
+++ b/src/firecube/cli/archive.py
@@ -230,9 +230,13 @@ def create(
 
     parsed_source = parse_product_uri(source)
     storage_type = apply_smart_default(parsed_source, storage_type)
+
+    # Enforce URI scheme on archive parameter (same as info/validate/list)
+    parsed_archive = parse_product_uri(archive)  # raises UsageError if bare path
+
     if is_remote_target(archive):
         raise click.ClickException("Remote .tgm artifacts not yet supported")
-    archive_abs = str(local_path_from_target(archive))
+    archive_abs = str(parsed_archive.normalized.removeprefix("file://"))
 
     storage_config = get_storage_config(
         ctx,
@@ -390,9 +394,13 @@ def restore(
     """
     parsed_target = parse_product_uri(target)
     storage_type = apply_smart_default(parsed_target, storage_type)
+
+    # Enforce URI scheme on archive parameter (same as info/validate/list)
+    parsed_archive = parse_product_uri(archive)  # raises UsageError if bare path
+
     if is_remote_target(archive):
         raise click.ClickException("Remote .tgm artifacts not yet supported")
-    archive_abs = str(local_path_from_target(archive))
+    archive_abs = str(parsed_archive.normalized.removeprefix("file://"))
 
     _require_overwrite_confirmation(overwrite=overwrite, yes_i_really_mean_it=yes_i_really_mean_it)
 

--- a/tests/cli/test_uri_scheme_policy.py
+++ b/tests/cli/test_uri_scheme_policy.py
@@ -175,3 +175,65 @@ def test_apply_smart_default_accepts_explicit_s3_storage_type() -> None:
     uri = parse_product_uri("s3://bucket/path.zarr")
 
     assert apply_smart_default(uri, "s3") == "s3"
+
+
+# ---------------------------------------------------------------------------
+# Archive subcommands: archive parameter must carry a URI scheme
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subcommand", ["create", "restore"])
+def test_archive_subcommand_rejects_bare_archive_path(
+    subcommand: str,
+    tmp_path: Path,
+) -> None:
+    """create and restore must reject bare local paths (no file:// scheme)."""
+    archive_path = tmp_path / "archive.tgm"
+    archive_path.write_bytes(b"not a real archive")
+    base = ["archive", subcommand, "--archive", str(archive_path)]
+
+    if subcommand == "create":
+        base.extend(["--source", "file:///tmp/fake.zarr"])
+        base.append("--dry-run")
+    else:
+        base.extend(["--target", "file:///tmp/restored.zarr"])
+        base.append("--dry-run")
+
+    result = CliRunner().invoke(cli, base)
+    assert result.exit_code != 0
+    assert "URI scheme required" in result.output
+
+
+def test_archive_create_accepts_file_uri(tmp_path: Path) -> None:
+    """create accepts a proper file:// URI for --archive."""
+    archive_path = tmp_path / "archive.tgm"
+    archive_path.write_bytes(b"not a real archive")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "archive", "create",
+            "--source", "file:///tmp/fake.zarr",
+            "--archive", archive_path.as_uri(),
+            "--dry-run",
+        ],
+    )
+    # Should not fail with URI-scheme error (may fail for other reasons)
+    assert "URI scheme required" not in result.output
+
+
+def test_archive_restore_accepts_file_uri(tmp_path: Path) -> None:
+    """restore accepts a proper file:// URI for --archive."""
+    archive_path = tmp_path / "archive.tgm"
+    archive_path.write_bytes(b"not a real archive")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "archive", "restore",
+            "--archive", archive_path.as_uri(),
+            "--target", "file:///tmp/restored.zarr",
+            "--dry-run",
+        ],
+    )
+    # Should not fail with URI-scheme error
+    assert "URI scheme required" not in result.output


### PR DESCRIPTION
## Summary

Adds `parse_product_uri()` validation to `archive create` and `archive restore` so they reject bare local paths, matching the behavior of `info`, `validate`, and `list`.

## Problem

The inspect-tier subcommands (`info`, `validate`, `list`) correctly enforce URI scheme via `parse_product_uri()`, which raises a helpful `UsageError` with a suggestion:

```
URI scheme required (file:// or s3://). Did you mean file:///tmp/foo.tgm?
```

But `create` and `restore` accepted bare paths silently, creating inconsistent CLI behavior.

## Fix

- Replaced validate-and-discard calls with proper ParsedUri consumption (using the parsed result for path resolution), matching how `info()` already works
- Added 3 tests in `test_uri_scheme_policy.py` asserting that:
  - `archive create` rejects bare paths
  - `archive restore` rejects bare paths  
  - Both accept valid `file://` URIs

## Changes

- `src/firecube/cli/archive.py`: 2 validation calls → 2 parsed result usages
- `tests/cli/test_uri_scheme_policy.py`: 3 new tests

Fixes #17

---

**AI Disclosure**: This PR was assisted by AI coding tools (Claude Code). I reviewed all changes, verified them against the existing codebase patterns, and take full responsibility for the contribution per the Firecube contributing guide.