### PR TITLE
feat(packaging): add py.typed marker for PEP 561 type support

### DIFF
--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -1,5 +1,23 @@
 # Done
 
+Date: 2026-08-03 Task: #22
+
+Decision: Ship PEP 561 `py.typed` marker for downstream IDE type support
+
+Context: Downstream plugin authors' type checkers (pyright, mypy) could not resolve firecube imports with type information because the package lacked a PEP 561 marker. Root-level placement at `src/firecube/py.typed` is required — subpackage-only triggers mypy #16149. The marker is zero-byte per PEP 561 standard for typed packages (`partial\n` is for stub packages only). Attribution file `py.typed.ABOUT` added per repo convention for files that cannot carry header comments. One contract test added asserting both file existence and zero-byte size.
+
+Files changed:
+- `src/firecube/py.typed` (new — zero-byte PEP 561 marker)
+- `src/firecube/py.typed.ABOUT` (new — attribution metadata)
+- `tests/sdk/test_py_typed_marker.py` (new — contract test)
+- `plans/DONE.md` (this entry)
+
+Verification: `uv run pytest tests/sdk/test_py_typed_marker.py --strict-deps -q` → 1 passed. `unzip -l dist/firecube-*.whl | awk '{print $4}' | grep -x 'firecube/py.typed' | wc -l` → 1. `uv run ruff check .` clean; `uv run pyright` clean. Regression: test fails when marker deleted, passes when restored.
+
+Source: GitHub #22 — https://github.com/eumetsat/firecube/issues/22
+
+---
+
 ## 2026-07-13 — `write_1d` numpy>=2 one-slot idiom (production blocker)
 
 OPERA-SEVIRI-NORDLIS ingest failed under the pinned `numpy>=2.3.3` runtime with `ValueError: Could not convert object to NumPy datetime` at `RegionZarrWriter.write_1d`. Root cause: `arr[scalar_int] = one_element_ndarray` on a `datetime64[s]` Zarr array is silently accepted by numpy 1.x (broadcast) but rejected by numpy 2.x (strict shape). The failing pattern was `self._open_root()[f"{group}/{array_name}"][ts_index] = data` at `src/firecube/core/zarr/region_writer.py:639`. Reproduced end-to-end against real NORDLIS NetCDFs from CloudFerro S3.

--- a/src/firecube/py.typed.ABOUT
+++ b/src/firecube/py.typed.ABOUT
@@ -1,0 +1,11 @@
+# Component information
+name: py.typed
+description: PEP 561 marker file for the firecube package; header comments are not supported for this file type.
+copyright: Copyright 2025-2026 EUMETSAT
+license_spdx: Apache-2.0
+home_url: https://github.com/eumetsat/firecube
+date: 2026-08-03
+# Package IPR documentation
+license_text_file: /LICENSE
+# File(s) associated to this component
+about_resource: py.typed

--- a/tests/sdk/test_py_typed_marker.py
+++ b/tests/sdk/test_py_typed_marker.py
@@ -1,0 +1,31 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.contract
+
+# Anchor to repo root — not cwd — so the test works from any invocation directory.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MARKER = _REPO_ROOT / "src/firecube/py.typed"
+
+
+def test_py_typed_marker_exists_and_is_empty() -> None:
+    """PEP 561 marker must be present and zero-byte (partial\n is for stub packages only)."""
+    assert _MARKER.is_file(), f"PEP 561 marker missing: {_MARKER}"
+    assert _MARKER.stat().st_size == 0, (
+        f"PEP 561 marker must be empty (got {_MARKER.stat().st_size} bytes)"
+    )


### PR DESCRIPTION
## What changed

Added `src/firecube/py.typed` (zero-byte PEP 561 marker) and `src/firecube/py.typed.ABOUT` (attribution metadata). Added one contract test asserting the marker exists and is empty.

## Why

Closes #22

## Affected behavior

N/A

## Type of change

- [ ] Bug fix (non-breaking)
- [X] New feature (non-breaking)
- [ ] Breaking change (CLI flags, plugin contract, config, or stored format)
- [ ] Documentation
- [ ] CI / build / chore

## Checks run

<!-- Tick what you ran; paste anything notable. -->

- [X] `uv run ruff check .`
- [X] `uv run ruff format --check .`
- [X] `uv run pyright`
- [X] `uv run --with bandit bandit -c pyproject.toml -r src scripts -lll`
- [X] `uv run pytest --strict-deps -m "not slow and not s3" -q`
- [X] Docs build (if docs changed): `uv run mkdocs build --strict`

## Follow-up work

N/A

## Contributor certification

- [X] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [X] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
