### PR TITLE
docs(plans): accept #27 slot-allocation mixin plan, add IDEAS §34

### DIFF
--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -1,5 +1,17 @@
 # Done
 
+Date: 2026-08-05 Task: #27
+
+Decision: Accept GitHub #27 — automate slot allocation for `DirectZarrIngestor` via an opt-in cadence mixin. Promotes IDEAS.md §21 Idea 2 to TODO.md §33 (decision-only entry; implementation follows on a feature branch, milestone v0.2.0).
+
+Context: Plugins opting into `SUPPORTS_SLOT_RANGE_PARALLELISM` must hand-implement `timestamp_to_ts_index` / `global_expected_time_count` / `slot_index_model`, and the same epoch/cadence math is duplicated near-verbatim across the tutorial, ~20 test fixtures, and both production parallel plugins (`firecube-opera-seviri-nordlis`, `firecube-mtg-fci-l1c`) — the trigger condition IDEAS.md §21 set for promotion. `SlotIndexModel` already carries `(epoch, cadence_s, mode)` per group but those fields are inert identity metadata, never consumed for arithmetic anywhere in `src/`; only the derivation behavior is missing. Design decided: an opt-in mixin (working name `CadenceSlotAllocation`) rather than base-class defaults, so the `__init_subclass__` guard at `templates/direct_zarr.py` and its tests stay untouched (the MRO satisfies the guard naturally, and the base never learns about the mixin). Scope is fixed integer-second cadence with a finite horizon in v1; irregular-cadence products (polar orbiters: non-integer periods, drifting overpass times) explicitly keep the manual three-hook contract. `ChunkManager` is unchanged — a derived model is content-addressed identically to a hand-written one. Full design constraints and acceptance criteria in TODO.md §33.
+
+Consequences: TODO.md §33 created (accepted scope + mixin design constraints); IDEAS.md §21 Idea 2 marked PROMOTED (Ideas 1 and 3 remain UNDECIDED); IDEAS.md §34 added for the unrelated gridding-extension boundary findings surfaced by the same evaluation.
+
+Source: GitHub #27 — https://github.com/eumetsat/firecube/issues/27
+
+---
+
 Date: 2026-08-03 Task: #22
 
 Decision: Ship PEP 561 `py.typed` marker for downstream IDE type support

--- a/plans/IDEAS.md
+++ b/plans/IDEAS.md
@@ -126,7 +126,7 @@ File upstream at `https://github.com/ecmwf/tensogram` if Phase 1 implementation 
 
 ### §21 Promote shared slot-range machinery to core (cross-plugin dedup)
 
-- UNDECIDED
+- Idea 2: PROMOTED (2026-08-05) — accepted via GitHub #27; see TODO.md §33 for the accepted scope and mixin design constraints, and DONE.md 2026-08-05 for the decision. Ideas 1 and 3: UNDECIDED.
 
 - **Origin:** Surfaced while reviewing `firecube-opera-seviri-nordlis` and
   `firecube-mtg-fci-l1c`. Both plugins now opt into
@@ -257,6 +257,20 @@ File upstream at `https://github.com/ecmwf/tensogram` if Phase 1 implementation 
   - `_projection.py:182-193` — `_load_history_records` that iterates all runs; pruning must not silently break this.
 
 - **Blocked on:** Wave 2 landing (the active-run index and bitmap make it safe to reason about "no active runs" without a full scan, which is a prerequisite for the quiet-period heuristic in Fix 5).
+
+### §34 Gridding extensions — boundary correctness (grid/healpix binners)
+
+- UNDECIDED
+
+- **Origin:** Surfaced 2026-08-05 while evaluating GitHub #27 (slot-allocation automation) against the existing extension/mixin surface. These are spatial-binning findings in `src/firecube/ingestor/extensions/`, orthogonal to slot allocation and not previously recorded anywhere in plans/.
+- **Findings:**
+  - **`np.arange` float endpoint jitter** (`grid.py:113-114`; same pattern in `healpix.py:125-126` `cells_in_bbox`): `arange(min, max + spacing, spacing)` with a non-binary-representable step (e.g. 0.1°) can yield N or N+1 centers depending on accumulated rounding — the "extra empty last row/col" bug class the module docstring claims fixed persists in this variant. Fix direction: `np.linspace` with an integer count.
+  - **Bounds semantics mismatch** (`grid.py:79-83` docstring vs behavior): documented as "input points outside bounds are dropped", but cell edges extend half a cell beyond the declared bounds — effective coverage is `[min − s/2, max + s/2)` — and the top edge is half-open, so a point exactly on the last edge is silently dropped while one epsilon below is kept.
+  - **No antimeridian handling:** `lon_min > lon_max` boxes (crossing ±180) are unsupported in both `build_latlon_binner` and `cells_in_bbox`; points at exactly 180 vs −180 bin differently.
+  - **`cells_in_bbox` edge-cell coverage is probabilistic** (`healpix.py:107-129`): mesh sampling at half the mean cell side guarantees a sample in every *interior* cell only; boundary cells that barely intersect the box can be missed entirely, and input points in those cells are then silently dropped by the `target_cells` filter in `build_healpix_binner`.
+- **Impact:** pinned-axis workflows (the sanctioned cross-granule append pattern per `_binning.py`) can silently lose edge samples, or produce differently-shaped axes from nominally identical bounds. No known production incident yet.
+- **Why not TODO yet:** the fixes change output grid shape/coverage for existing cubes (a `linspace` fix can alter N for previously-jittered grids), so remediation needs a compat/design discussion before acceptance.
+- **Cross-links:** TODO.md §33 design constraint 1 cites this bug class as the anti-pattern the slot mixin must exclude by construction (integer-only slot math).
 
 ## Notes
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -5,6 +5,38 @@ New decisions are recorded in [DONE.md](DONE.md) with a date.
 
 ## Active Work
 
+### §33 Automated slot allocation for `DirectZarrIngestor` (cadence mixin) — GitHub #27
+
+**Goal:** Let fixed-cadence DirectZarr plugins declare `(epoch/start, per-group slot duration, finite horizon)` and inherit the three parallel-contract hooks (`timestamp_to_ts_index`, `global_expected_time_count`, `slot_index_model`) instead of hand-implementing them.
+
+**Decision (2026-08-05):** Accepted (GitHub #27, milestone v0.2.0; promoted from IDEAS.md §21 Idea 2 — see DONE.md 2026-08-05). Shape is an **opt-in mixin**, not base-class defaults: with `class MyPlugin(CadenceSlotAllocation, DirectZarrIngestor)` the MRO satisfies the existing `__init_subclass__` guard (`templates/direct_zarr.py:500-517`) without relaxing it — the guard's invariant ("the three methods must be provided by something other than the abstract base") is preserved, its tests (`test_direct_zarr_init_subclass.py`, `test_direct_zarr_parallel_contract.py`) stay unmodified, and the base never learns about the mixin (avoids the `templates/generic.py` `isinstance(self, DuckDbMixin)` inverted-dependency smell). Irregular-cadence products (polar orbiters: non-integer orbital periods, drifting overpass times, schedule-driven allocation) are explicitly out of scope and keep the manual three-hook contract — that carve-out IS the backwards-compatibility clause of #27, not just migration safety.
+
+**Evidence (duplication):**
+- Near-verbatim boilerplate across `docs/tutorials/direct-zarr-parallel.md:130-166`, ~20 test fixtures (e.g. `tests/unit/test_cli_zarr_slots.py:40-76`), and both production parallel plugins (`firecube-opera-seviri-nordlis`, `firecube-mtg-fci-l1c`) per IDEAS.md §21.
+- `SlotAxis.cadence_s` / `mode` are declared, persisted, and content-addressed (`core/slot_index.py`) but never consumed for arithmetic anywhere in `src/` — the model already carries the parameters; only the derivation behavior is missing.
+
+**Design constraints:**
+1. **Integer arithmetic only** — `iso_to_epoch_s` (int) and integer `cadence_s`; index = `(ts_epoch_s - epoch_s) // cadence_s`. No float boundary math: the `extensions/grid.py` arange/boundary bug class (IDEAS.md §34) must be structurally impossible here. This is also the principled reason non-integer orbital periods are out of scope.
+2. **Half-open boundary convention, stated in the contract:** slot `i` covers `[epoch + i*cadence, epoch + (i+1)*cadence)`; horizon is `[start, end)`; `global_expected_time_count = (end_s - start_s) // cadence_s`. Matches the engine's existing `[slot_start, slot_end)` convention.
+3. **Hard validation, never silent floor:** timestamp before epoch → raise (Python floor division would return a negative `ts_index`; generalizes OPERA's epoch-mismatch guard). `mode="exact"` + misaligned timestamp → raise. `mode="floor"` documents the collision consequence (two granules in one slot → same `ts_index` → per-slot `ClaimConflictError`, no retry at the dispatch site).
+4. **Finite horizon required in v1.** Open-ended end dates (the issue's 01.01.9999 case) interact with parallel pre-sizing (`firecube zarr preallocate`; no axis growth in parallel mode) — horizon extension via re-preallocate is the supported growth path; open-ended support is deferred and needs its own design.
+5. **Identity vs campaign split:** epoch + cadence are product identity → ClassVar declarations (the `time_dim_name` precedent, DONE.md 2026-06-10). Horizon/end is a per-campaign knob → typed plugin config / ctx (the OPERA `--horizon` workflow).
+6. **Class-definition-time composition validation:** the mixin's own `__init_subclass__` checks it is combined with `DirectZarrIngestor` and that the declarations are present — the DirectZarrIngestor guard pattern, not the DuckDbMixin silent-shadow defensive-`getattr` pattern.
+7. **Chunk-alignment surfacing at derivation time:** derived count not a multiple of the group's time-chunk LCM (cf. `cli/_slot_planning.py:_resolve_per_group_slot_sizes`) → warn or fail closed, matching `_chunk_aligned_remaining`'s fail-closed philosophy. Do not let the planner rediscover the Phase 3.3–3.5 terminal-partial-chunk geometry.
+8. **Base-impl caching:** `timestamp_to_ts_index(group, timestamp_val)` takes no `ctx`; the mixin caches the model (precedents: `_slot_index_model_stamped`, `_cached_zarr_schema`).
+9. **Overrides always win via MRO** — partial adoption (e.g. custom `global_expected_time_count` with mixin-derived index math) works by construction.
+10. **Public surface:** export from `firecube.ingestor.api` alongside the existing contract types. No `ChunkManager`, `IndexedRegionStrategy`, or CLI changes expected — a derived `SlotIndexModel` is content-addressed identically to a hand-written one.
+
+**Acceptance criteria:**
+- A cadence-based plugin opts into parallelism by declaring only start/cadence(/horizon) — zero hand-written slot math.
+- Existing three-hook plugins work unchanged; the `__init_subclass__` guard and its tests are unmodified.
+- Boundary tests: ts == epoch, ts == end, one step inside each edge, ts < epoch, misaligned exact-mode timestamp, chunk-misaligned horizon.
+- Docs: tutorial rewritten around the mixin; parallel-contract table in `docs/guides/plugins/direct-zarr.md` updated; polar-orbiter carve-out documented.
+
+**References:** GitHub #27; IDEAS.md §21 (Idea 2 promoted; Ideas 1 and 3 remain UNDECIDED); IDEAS.md §34 (boundary findings from the same evaluation); DONE.md 2026-08-05.
+
+---
+
 ### §29 Test suite overhaul
 
 **Goal:** Reduce noisy static/docs failures and raise behavioral bug-detection


### PR DESCRIPTION
## What changed

Plans-only update accepting GitHub #27 (automated slot allocation for`DirectZarrIngestor`): decision entry in DONE.md, new TODO.md §33 with the accepted scope and design constraints, IDEAS.md §21 Idea 2 marked promoted, and a new IDEAS.md §34 recording boundary findings in the gridding extensions surfaced during the evaluation.

## Why

Accepts and implementation plan for #27 

## Affected behavior

  - User / CLI: none
  - Plugin authors: none (planning docs only)
  - Operators / production: none
  - Stored formats or control-plane state: none

  ## Type of change

  - [x] Documentation

  ## Checks run

  None — `plans/` markdown only, no code or docs-site changes.

  ## Follow-up work

  Implementation of TODO.md §33 (milestone v0.2.0). IDEAS.md §34 stays
  UNDECIDED pending a compat discussion.

  ## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [x] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
