### PR TITLE
ci: add trivy security scan and dependency review to PRs (#32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,29 @@ jobs:
       - run: uv python install 3.12
       - run: uv sync --locked --extra test --group docs
       - run: uv run mkdocs build --strict --site-dir /tmp/firecube-mkdocs-check
+
+  security-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret,license
+          exit-code: '1'
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: low
+          deny-licenses: GPL-2.0-only, GPL-3.0-only, AGPL-3.0-only, SSPL-1.0


### PR DESCRIPTION
## What changed

Added two PR-time security jobs to `ci.yml`: `security-scan` (trivy: vuln, secret, license; fails on findings) and `dependency-review` (GitHub-native, PR-diff advisories + GPL/AGPL/SSPL license deny-list).

## Why

Closes #32. Vuln/license scanning previously ran only post-merge (Dependabot); external PRs had no automated gate before merge.

## Affected behavior

N/A

## Type of change

 - [x] CI / build / chore

## Checks run

- [x] Workflow YAML validated; identical trivy scan run locally: exit 0, no findings.

## Follow-up work

Add `main` branch ruleset requiring `security-scan` and `dependency-review` after first workflow run.

## Contributor certification

  - [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
  - [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
 - [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
