### PR TITLE
docs: add mike versioned docs and automated Pages deployment (#34)

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,44 @@
+name: Docs Deploy
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+      - run: uv python install 3.12
+      - run: uv sync --locked --group docs
+      - run: uv run mkdocs build --strict --site-dir /tmp/firecube-mkdocs-check
+      - name: Configure git for gh-pages commits
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Deploy dev docs
+        if: github.event_name == 'push'
+        run: uv run mike deploy --push dev
+      - name: Deploy stable release docs as latest
+        if: github.event_name == 'release' && !github.event.release.prerelease
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          DOCS_VERSION="$(echo "$VERSION" | cut -d. -f1,2)"
+          uv run mike deploy --push --update-aliases "$DOCS_VERSION" latest
+          uv run mike set-default --push latest
+      - name: Deploy pre-release docs without latest alias
+        if: github.event_name == 'release' && github.event.release.prerelease
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          uv run mike deploy --push "$VERSION"

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ documentation, or testing:
 | `mkdocs-mermaid2-plugin` | 1.2.3 | Development tools | MIT |  | https://github.com/fralau/mkdocs-mermaid2-plugin | Direct `docs` dependency group entry. |
 | `mkdocs-click` | 0.9.0 | Development tools | Apache-2.0 |  | https://github.com/mkdocs/mkdocs-click | Direct `docs` dependency group entry. |
 | `mkdocs-macros-plugin` | 1.5.0 | Development tools | MIT |  | https://github.com/fralau/mkdocs_macros_plugin | Direct `docs` dependency group entry. |
+| `mike` | 2.2.0 | Development tools | BSD-3-Clause |  | https://github.com/jimporter/mike | Direct `docs` dependency group entry. |
 
 
 ## Copyright and License

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,13 @@ site_description: A plugin-based batch ingestion CLI for turning Earth Observati
 not_in_nav: |
   concepts/plugins/index.md
   tutorials/weather-csv.md
+site_url: https://eumetsat.github.io/firecube/
 repo_url: https://github.com/eumetsat/firecube
 repo_name: eumetsat/firecube
+extra:
+  version:
+    provider: mike
+    default: latest
 theme:
   name: material
   logo: assets/firecube-amblem-white.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ docs = [
     "mkdocs-mermaid2-plugin>=0.6.0",
     "mkdocs-click>=0.9.0",
     "mkdocs-macros-plugin>=1.0,<2.0",
+    "mike>=2.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -830,6 +830,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "mike" },
     { name = "mkdocs" },
     { name = "mkdocs-click" },
     { name = "mkdocs-macros-plugin" },
@@ -883,6 +884,7 @@ dev = [
     { name = "ruff", specifier = ">=0.14.0" },
 ]
 docs = [
+    { name = "mike", specifier = ">=2.1" },
     { name = "mkdocs", specifier = ">=1.5.3,<2.0" },
     { name = "mkdocs-click", specifier = ">=0.9.0" },
     { name = "mkdocs-macros-plugin", specifier = ">=1.0,<2.0" },
@@ -1488,6 +1490,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
 ]
 
 [[package]]
@@ -3327,6 +3346,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

Versioned docs via `mike` (added to `docs` group) with a version selector in `mkdocs.yml`, plus a `docs-deploy` workflow: `main` → `/dev/`, stable releases → `/X.Y/` +  `latest` (site default), pre-releases → own version only, never `latest`. README SBOM table updated with the `mike` row.

 ## Why

 Closes #34. 

## Affected behavior

 N/A

## Type of change

- [x] Documentation
- [x] CI / build / chore

## Checks run

- [x] `uv run --with bandit bandit -c pyproject.toml -r src -lll` (clean)
- [x] Docs build: `uv run mkdocs build --strict`

## Follow-up work

One-time after merge: Settings → Pages → deploy from `gh-pages`; first stable release sets `latest` as default.

## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
