### PR TITLE
fix(ci): deploy docs under full release version; backfill changelog

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -34,8 +34,7 @@ jobs:
         if: github.event_name == 'release' && !github.event.release.prerelease
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          DOCS_VERSION="$(echo "$VERSION" | cut -d. -f1,2)"
-          uv run mike deploy --push --update-aliases "$DOCS_VERSION" latest
+          uv run mike deploy --push --update-aliases "$VERSION" latest
           uv run mike set-default --push latest
       - name: Deploy pre-release docs without latest alias
         if: github.event_name == 'release' && github.event.release.prerelease

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+
+- Versioned documentation with `mike`: each stable release publishes docs under
+  its full version (for example `/0.1.5/`) with a `latest` alias as the site
+  default; pre-releases publish under their own version only and never become
+  the default; `main` is tracked as `/dev/`. New `docs-deploy` workflow deploys
+  automatically on pushes to `main` and on published GitHub releases.
+- PR-time security scanning in CI: trivy (vulnerabilities, secrets, licenses)
+  on pushes and pull requests, plus GitHub dependency review with a
+  GPL/AGPL/SSPL license deny-list on pull requests.
+- `py.typed` marker (PEP 561) so plugin authors get IDE type support for
+  `firecube` imports.
+
+### Changed
+
+- Dependency updates: `cryptography` 50.0.0, `aiohttp` 3.14.3,
+  `virtualizarr` 2.7.1, `healpix-geo` 0.2.1,
+  `opentelemetry-exporter-otlp` 1.44.0, `mkdocs-material` 9.7.7,
+  `setuptools` 83.0.0, `actions/checkout` v7.
+- README SBOM dependency tables synced with `uv.lock`; added `mike` to the
+  docs dependency group and its SBOM table entry.
+- Reorganized plugin documentation and plugin author examples.
+
+## [0.1.4.post1] - 2026-07-24
+
+### Changed
+
+- Package metadata only: added PyPI project URLs. No code changes relative
+  to 0.1.4.
+
 ## [0.1.4.post0] - 2026-07-24
 
 ### Changed


### PR DESCRIPTION
## What changed

Fixes on mike and docs. added changelog entries 

## Why

to have full versions

## Affected behavior

N/A

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (CLI flags, plugin contract, config, or stored format)
- [x] Documentation
- [x] CI / build / chore

## Checks run

N/A

## Follow-up work

N/A

## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
