### PR TITLE
fix(zarr): zarr_compression=True + zarr_codecs is now valid as it should

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 
 - `zarr_codecs` configuration field: a single-element list of codec entries in
   Zarr v3 metadata format (`[{"name": "...", "configuration": {...}}]`). Select
-  any codec registered via zarr's extension mechanism by name. Mutually
-  exclusive with `zarr_compression = true`. Closes #25.
+  any codec registered via zarr's extension mechanism by name.
+  Requires `zarr_compression = true`. Closes #25.
 - Versioned documentation with `mike`: each stable release publishes docs under
   its full version (for example `/0.1.5/`) with a `latest` alias as the site
   default; pre-releases publish under their own version only and never become

--- a/src/firecube/ingestor/templates/config.py
+++ b/src/firecube/ingestor/templates/config.py
@@ -108,7 +108,8 @@ class ZarrTemplateConfig(TemplateConfig):
             ``ValueError`` at construction time.
         zarr_codecs: Optional single-element list of codec entries matching the
             Zarr v3 metadata shape ``[{"name": str, "configuration": dict}]``.
-            Mutually exclusive with ``zarr_compression=True``. Structural
+            Requires ``zarr_compression=True``. When set, the codec REPLACES the
+            default preset (Blosc/zstd/5). Structural
             validation happens here; codec-specific resolution happens later.
         zarr_consolidate: Consolidate Zarr metadata after writes.
         zarr_time_encoding: Optional time encoding override.
@@ -135,12 +136,14 @@ class ZarrTemplateConfig(TemplateConfig):
                 f"{type(self.zarr_compression).__name__}: {self.zarr_compression!r}"
             )
 
-        if self.zarr_compression and self.zarr_codecs is not None:
+        if not self.zarr_compression and self.zarr_codecs is not None:
             raise ValueError(
-                f"zarr_compression=True conflicts with zarr_codecs={self.zarr_codecs!r}.\n"
-                "Set exactly one of:\n"
-                "  zarr_compression = true             # firecube's default preset (Blosc/zstd/5)\n"
-                '  zarr_codecs = [{"name": "...", "configuration": {...}}]  # explicit codec\n'
+                f"zarr_compression=False conflicts with zarr_codecs={self.zarr_codecs!r}: "
+                "specifying a codec requires compression to be enabled.\n"
+                "Either enable compression and keep the codec:\n"
+                "  zarr_compression = true\n"
+                '  zarr_codecs = [{"name": "...", "configuration": {...}}]\n'
+                "Or remove zarr_codecs for uncompressed output."
             )
 
         _validate_zarr_codecs(self.zarr_codecs)

--- a/tests/unit/test_zarr_codec_mutual_exclusion.py
+++ b/tests/unit/test_zarr_codec_mutual_exclusion.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""zarr_compression=True and zarr_codecs=[...] are mutually exclusive."""
+"""zarr_codecs=[...] requires zarr_compression=True; False+codec is a contradiction."""
 
 from __future__ import annotations
 
@@ -23,17 +23,17 @@ from firecube.ingestor.templates.config import ZarrTemplateConfig
 pytestmark = pytest.mark.unit
 
 
-def test_both_set_raises() -> None:
-    with pytest.raises(ValueError, match="zarr_compression=True conflicts with zarr_codecs"):
+def test_false_and_codecs_raises() -> None:
+    with pytest.raises(ValueError, match="zarr_compression=False conflicts with zarr_codecs"):
         ZarrTemplateConfig(
-            zarr_compression=True, zarr_codecs=[{"name": "blosc", "configuration": {}}]
+            zarr_compression=False, zarr_codecs=[{"name": "blosc", "configuration": {}}]
         )
 
 
 def test_error_names_both_fields() -> None:
     with pytest.raises(ValueError) as exc_info:
         ZarrTemplateConfig(
-            zarr_compression=True, zarr_codecs=[{"name": "blosc", "configuration": {}}]
+            zarr_compression=False, zarr_codecs=[{"name": "blosc", "configuration": {}}]
         )
 
     msg = str(exc_info.value)
@@ -41,11 +41,11 @@ def test_error_names_both_fields() -> None:
     assert "zarr_codecs" in msg
 
 
-def test_false_and_codecs_accepted() -> None:
+def test_true_and_codecs_accepted() -> None:
     entry = {"name": "blosc", "configuration": {}}
-    cfg = ZarrTemplateConfig(zarr_compression=False, zarr_codecs=[entry])
+    cfg = ZarrTemplateConfig(zarr_compression=True, zarr_codecs=[entry])
     assert cfg.zarr_codecs == [entry]
-    assert cfg.zarr_compression is False
+    assert cfg.zarr_compression is True
 
 
 def test_true_and_none_accepted() -> None:

--- a/tests/unit/test_zarr_codecs_entry_validation.py
+++ b/tests/unit/test_zarr_codecs_entry_validation.py
@@ -82,10 +82,10 @@ def test_zarr_codecs_entry_validation(
 ) -> None:
     if expected_error_substring is None:
         codecs = cast(list[dict] | None, input_value)
-        cfg = ZarrTemplateConfig(zarr_codecs=codecs)
+        cfg = ZarrTemplateConfig(zarr_compression=True, zarr_codecs=codecs)
         assert cfg.zarr_codecs == codecs
         return
 
     with pytest.raises(ValueError) as excinfo:
-        ZarrTemplateConfig(zarr_codecs=cast(list[dict] | None, input_value))
+        ZarrTemplateConfig(zarr_compression=True, zarr_codecs=cast(list[dict] | None, input_value))
     assert expected_error_substring in str(excinfo.value)


### PR DESCRIPTION
## What changed

`zarr_compression=True + zarr_codecs=[...]` is now valid. `False + zarr_codecs` errors.

## Why

Users expect `True` to mean "compression on, use this codec". Follow-up to #25.

## Affected behavior

- User / CLI: `zarr_compression=True` + `zarr_codecs=[...]` no longer errors; `False` + codecs now errors with a clear message.
- Plugin authors: N/A
- Operators / production: N/A
- Stored formats or control-plane state: N/

## Type of change

- [x] Bug fix (non-breaking)

## Checks run

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest --strict-deps -m "not slow and not s3" -q`
- [x] Docs build (if docs changed): `uv run mkdocs build --strict`

## Follow-up work

None.

## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.