### PR TITLE
fix: slot-index hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
   GPL/AGPL/SSPL license deny-list on pull requests.
 - `py.typed` marker (PEP 561) so plugin authors get IDE type support for
   `firecube` imports.
+- `firecube zarr slots` now accepts `--option` and resolves typed plugin
+  config via `TierConfigurator`, matching `firecube zarr preallocate`.
 
 ### Changed
 
@@ -55,6 +57,9 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
   converted to match.
 - CI test lanes follow `plans/TESTING_STANDARDS.md`: the `test` job excludes
   `docs_static` and `snapshot`; the `docs` job runs them.
+- `iso_to_epoch_s` now rejects naive ISO 8601 strings and accepts only UTC-
+  explicit inputs (`Z`, `+00:00`, or `-00:00`). Consumer action: callers
+  passing naive timestamps must append `Z` (or `+00:00`).
 - `ZarrTemplateConfig.zarr_compression` now defaults to `True` (was `False`), aligning
   firecube with zarr-python v3's default codec pipeline (`ZstdCodec(level=0)`). Explicit
   `zarr_compression = false` still disables compression. Because PR #25 never shipped
@@ -71,6 +76,10 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 
 - `include_patterns` is documented as additive to the built-in `.zip`/`.h5`/
   `.nc` selection; the reference previously stated that it replaced them.
+- `SlotAxis.__post_init__` now rejects `bool` and non-integral `cadence_s`
+  values that previously slipped through Python's `int` subclass semantics;
+  accepted types are Python `int` and `numpy.integer` subclasses
+  (e.g. `np.int64`).
 
 ### Removed
 

--- a/src/firecube/cli/zarr.py
+++ b/src/firecube/cli/zarr.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+from collections.abc import Sequence
 from typing import Any
 
 import click
@@ -64,6 +65,49 @@ from firecube.ingestor.runtime.configure import TierConfigurator
 from firecube.ingestor.templates.direct_zarr import DirectZarrIngestor
 
 
+def _configure_ingestor_for_cli(
+    ingestor: Any,
+    *,
+    target: str,
+    options: Sequence[tuple[str, object]] = (),
+    run_id: str,
+    source: str = "",
+    storage: Any = None,
+) -> PluginContext:
+    """Build and configure a PluginContext for CLI zarr commands.
+
+    Mirrors the tier-configuration path used by `ingest`. Coerces plugin
+    options through `coerce_options_for_plugin`, builds an `IngestContext`,
+    wraps into a `RuntimeIngestContext`, runs `TierConfigurator.configure`,
+    and returns the `PluginContext`.
+    """
+    coerced_options = coerce_options_for_plugin(ingestor.name, tuple(options))
+    ingest_ctx = IngestContext(
+        source=source,
+        target=target,
+        in_memory=True,
+        output_format="zarr",
+        options=dict(coerced_options),
+        storage=storage,
+        run_id=run_id,
+    )
+    runtime_ctx = RuntimeIngestContext.from_ingest_context(
+        ingest_ctx,
+        run_id=run_id,
+        temp_root=None,
+        materializer=None,
+    )
+    configurator = TierConfigurator(
+        ingestor.template_config_class,
+        ingestor.plugin_config_class,
+        plugin_name=ingestor.name,
+    )
+    ingestor.engine_config, ingestor.template_config, ingestor.plugin_config = (
+        configurator.configure(runtime_ctx)
+    )
+    return PluginContext(runtime_ctx)
+
+
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.pass_context
 def zarr(ctx: click.Context) -> None:
@@ -87,12 +131,10 @@ Examples:
   firecube zarr slots <plugin> --target file:///tmp/x.zarr --product-name <name> \\
       --storage-type local --storage-driver fsspec --write-mode direct
 
-
   # Human-readable table output for inspection
   firecube zarr slots <plugin> --target file:///tmp/x.zarr --product-name <name> \\
       --storage-type local --storage-driver fsspec --write-mode direct -f table
 
-
   # Override slot partition size
   firecube zarr slots <plugin> --target file:///tmp/x.zarr --product-name <name> \\
       --storage-type local --storage-driver fsspec --write-mode direct --slot-size 200
@@ -131,6 +173,13 @@ Examples:
     help="Disable resume-aware narrowing; emit full [0, total_slots) ranges.",
 )
 @format_option(default="json")
+@click.option(
+    "--option",
+    "option",
+    multiple=True,
+    type=TypedOptionsParam(),
+    help="Plugin/engine option in key=value form.",
+)
 @click.pass_context
 def slots(
     ctx: click.Context,
@@ -143,6 +192,7 @@ def slots(
     slot_size: int | None,
     no_resume: bool,
     output_format: str,
+    option: tuple[tuple[str, object], ...] = (),
 ) -> None:
     """Emit chunk-aligned slot ranges for orchestrated parallel ingestion.
 
@@ -179,7 +229,12 @@ def slots(
             "See the plugin's documentation for parallel-write support."
         )
 
-    plugin_ctx = _build_slots_plugin_context(target=target, product_name=product_name)
+    plugin_ctx = _configure_ingestor_for_cli(
+        ingestor,
+        target=target,
+        options=option,
+        run_id="zarr-slots",
+    )
 
     global_schema = ingestor.global_expected_time_count(plugin_ctx)
     if not global_schema:
@@ -531,12 +586,10 @@ Examples:
   firecube zarr preallocate <plugin> --product-name <name> \\
       --target file:///tmp/x.zarr --storage-type local --storage-driver fsspec --write-mode staged
 
-
   # Re-run on same target: exits 0, logs "no-op" for each matching array
   firecube zarr preallocate <plugin> --product-name <name> \\
       --target file:///tmp/x.zarr --storage-type local --storage-driver fsspec --write-mode staged
 
-
 See also: firecube zarr slots, firecube zarr validate
 """,
 )
@@ -609,14 +662,7 @@ def preallocate(
     from firecube.core.controlplane import ChunkManager
     from firecube.core.uris import storage_uri_from_target
     from firecube.core.zarr.region_writer import RegionZarrWriter
-    from firecube.ingestor.api import (
-        BaseIngestor,
-        IndexedRegionStrategy,
-        IngestContext,
-        PluginContext,
-        RuntimeIngestContext,
-        StorageContext,
-    )
+    from firecube.ingestor.api import BaseIngestor, IndexedRegionStrategy
     from firecube.ingestor.errors import (
         ConfigurationError,
     )
@@ -628,11 +674,6 @@ def preallocate(
     storage_type = apply_smart_default(parsed, storage_type)
     validate_uri_storage_coherence(parse_product_uri(target), storage_type)
     _ = write_mode  # accepted for parity with `firecube ingest`; not used by preallocate
-
-    # Typed coercion of --option pairs against the plugin's config schema
-    # (mirrors `firecube ingest`). Unknown keys (outside the experimental
-    # ``x_*`` namespace) are rejected as UnknownOptionError BEFORE any I/O.
-    coerced_options = coerce_options_for_plugin(plugin, tuple(option))
 
     storage_config = get_storage_config(
         ctx,
@@ -674,30 +715,12 @@ def preallocate(
                 "See the plugin's documentation for parallel-write support."
             )
 
-        ingest_ctx = IngestContext(
-            source=str(input_data) if input_data is not None else "",
-            target=plugin_target,
-            output_format="zarr",
-            options=dict(coerced_options),
-            storage=StorageContext(output=session),
-            run_id="preallocate",
+        plugin_ctx = _configure_ingestor_for_cli(
+            ingestor,
+            target=target,
+            options=option,
+            run_id="zarr-preallocate",
         )
-        runtime_ctx = RuntimeIngestContext.from_ingest_context(
-            ingest_ctx,
-            run_id="preallocate",
-            temp_root=None,
-            materializer=lambda src: src,
-        )
-        # Typed-config tier resolution. Preallocate bypasses BaseIngestor.run(), so we replicate the tier-coercion step here. See plans/IDEAS.md §22 / DONE.md for rationale.
-        configurator = TierConfigurator(
-            ingestor.template_config_class,
-            ingestor.plugin_config_class,
-            plugin_name=ingestor.name,
-        )
-        ingestor.engine_config, ingestor.template_config, ingestor.plugin_config = (
-            configurator.configure(runtime_ctx)
-        )
-        plugin_ctx = PluginContext(runtime_ctx)
 
         # Resolve the plugin's slot-index model and persist it through the
         # control-plane BEFORE any Zarr array/group is created. A failure here
@@ -925,26 +948,6 @@ def _array_schema_mismatches(
             mismatches.append(f"chunks: expected {tuple(expected_chunks)}, found {found_chunks}")
 
     return mismatches
-
-
-def _build_slots_plugin_context(*, target: str, product_name: str) -> PluginContext:
-    """Build a minimal PluginContext for slot-planning hook calls."""
-    ingest_ctx = IngestContext(
-        source="",
-        target=target,
-        in_memory=True,
-        output_format="zarr",
-        options={"product_name": product_name},
-        storage=None,
-        run_id="zarr-slots",
-    )
-    runtime_ctx = RuntimeIngestContext.from_ingest_context(
-        ingest_ctx,
-        run_id="zarr-slots",
-        temp_root=None,
-        materializer=None,
-    )
-    return PluginContext(runtime_ctx)
 
 
 def _query_slots_coverage(

--- a/src/firecube/core/slot_index.py
+++ b/src/firecube/core/slot_index.py
@@ -22,11 +22,11 @@ verify they agree on the partitioning scheme without coordinating beforehand.
 
 Stability rules:
 
-* ``canonical_bytes()`` is deterministic: groups are emitted in alphabetical
+ ``canonical_bytes()`` is deterministic: groups are emitted in alphabetical
   order, JSON keys are sorted, and the separators are tight. ``time_unit=None``
   is always serialised as ``"time_unit":null``.
-* ``identity_hash`` is never embedded inside the hashed payload.
-* Epoch normalisation is the explicit responsibility of
+ ``identity_hash`` is never embedded inside the hashed payload.
+ Epoch normalisation is the explicit responsibility of
   :func:`normalize_epoch_iso`; ``canonical_bytes()`` does NOT silently mutate
   the stored epoch string. ``"Z"`` and ``"+00:00"`` therefore deliberately
   produce different hashes -- callers that want them to converge must
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import numbers
 from dataclasses import dataclass
 from typing import Literal
 
@@ -59,6 +60,15 @@ class SlotAxis:
     mode: Literal["exact", "floor"]
 
     def __post_init__(self) -> None:
+        if isinstance(self.cadence_s, bool) or not isinstance(self.cadence_s, numbers.Integral):
+            raise TypeError(
+                f"cadence_s must be an integral type "
+                f"(Python int or numpy.integer subclass); bool is explicitly rejected. "
+                f"Got: {type(self.cadence_s).__name__}({self.cadence_s!r})"
+            )
+        # Normalize numpy.integer (e.g. np.int64) to Python int so json.dumps in
+        # canonical_bytes() doesn't crash. Byte output unchanged for equal values.
+        object.__setattr__(self, "cadence_s", int(self.cadence_s))
         if self.cadence_s <= 0:
             raise ValueError(f"cadence_s must be > 0, got {self.cadence_s!r}")
         if self.mode not in {"exact", "floor"}:
@@ -152,17 +162,14 @@ def iso_to_epoch_s(iso: str) -> int:
         bare = text[:-1]
     elif text.endswith("+00:00"):
         bare = text[: -len("+00:00")]
+    elif text.endswith("-00:00"):
+        bare = text[: -len("-00:00")]
     else:
-        # Any other explicit timezone offset (including non-UTC offsets) is rejected.
-        # np.datetime64 silently accepts naive ISO strings, so we cannot rely on it
-        # to validate the offset for us.
-        for sign in ("+", "-"):
-            sign_idx = text.rfind(sign)
-            # The leading sign of the year is at index 0 (or 1 after a space), so
-            # only treat a sign that appears at position >= 10 as a TZ offset.
-            if sign_idx >= 10:
-                raise ValueError(f"iso must be UTC ('Z' or '+00:00' offset), got {iso!r}")
-        bare = text
+        raise ValueError(
+            f"iso_to_epoch_s requires UTC-explicit ISO 8601 input "
+            f"(end with 'Z', '+00:00', or '-00:00'). Got: {iso!r}. "
+            f"To fix: use 'YYYY-MM-DDTHH:MM:SSZ'."
+        )
 
     try:
         when = np.datetime64(bare, "s")

--- a/src/firecube/ingestor/devtools/_templates/ingestor_base.py.tpl
+++ b/src/firecube/ingestor/devtools/_templates/ingestor_base.py.tpl
@@ -48,6 +48,8 @@ class {class_name}Config(PluginConfig):
 @register_ingestor("{plugin_name}")
 class {class_name}(BaseIngestor):
     PRODUCT_NAME: ClassVar[str] = "{plugin_name}"
+    # See BaseIngestor.time_dim_name in the Firecube API reference.
+    time_dim_name: ClassVar[str] = "timestamp"
     plugin_config_class = {class_name}Config
 
     def _process_batch(self, batch: PipelineBatch, ctx: PluginContext) -> PipelineResult:

--- a/src/firecube/ingestor/devtools/_templates/ingestor_zarr.py.tpl
+++ b/src/firecube/ingestor/devtools/_templates/ingestor_zarr.py.tpl
@@ -43,6 +43,8 @@ class {class_name}Config(PluginConfig):
 @register_ingestor("{plugin_name}")
 class {class_name}(GenericZarrIngestor):
     PRODUCT_NAME: ClassVar[str] = "{plugin_name}"
+    # See BaseIngestor.time_dim_name in the Firecube API reference.
+    time_dim_name: ClassVar[str] = "timestamp"
     plugin_config_class = {class_name}Config
 
     def build_dataset(self, group: str, items: list[Any], ctx: PluginContext) -> xr.Dataset | None:

--- a/src/firecube/ingestor/devtools/_templates/readme.md.tpl
+++ b/src/firecube/ingestor/devtools/_templates/readme.md.tpl
@@ -1,6 +1,6 @@
 # {start_case_name} Ingestor Plugin
 
-> **This plugin project is incomplete.** Implement `{hook_summary}` before this plugin can produce output. Until then, ingestion runs will raise `NotImplementedError`.
+> **This plugin project is incomplete.** Implement `{hook_summary}` before this plugin can produce output. Until then, ingestion runs will raise `NotImplementedError`.{extra_incomplete_note}
 
 ## What this plugin does
 
@@ -12,9 +12,14 @@
 uv sync
 ```
 
-Add product behavior and behavior-based tests before running `pytest`.
+Implement `{hook_summary}` in the generated ingestor, then add behavior-based
+tests for the source data and output contract.
 
-## Install into firecube
+```bash
+uv run pytest
+```
+
+## Install into Firecube
 
 ```bash
 uv run firecube plugins install --editable .
@@ -23,9 +28,9 @@ uv run firecube plugins describe {plugin_name}
 
 `firecube plugins describe` should list `[ENGINE]` options. If you add plugin-specific options via a `PluginConfig` subclass, they will appear under `[PLUGIN]`.
 
-## After you implement the hook
+## Run a local ingestion
 
-Once `{hook_summary}` is implemented, run:
+After the implementation and tests pass, run:
 
 ```bash
 uv run firecube ingest {plugin_name} \

--- a/src/firecube/ingestor/devtools/scaffolding.py
+++ b/src/firecube/ingestor/devtools/scaffolding.py
@@ -53,6 +53,8 @@ dependencies = [
 [project.entry-points."firecube.plugins"]
 {plugin_name} = "{import_name}"
 
+# Optional: expose custom "firecube {plugin_name} ..." subcommands by
+# pointing this at a click.Group. Most plugins don't need it.
 # [project.entry-points."firecube.plugin_cli"]
 # {plugin_name} = "{import_name}.plugin_cli:cli"
 
@@ -98,16 +100,27 @@ See the Firecube plugin development guide for testing guidance.
 """
 '''
 
+_DEPENDENCY_HINT = (
+    '    # "h5netcdf",  # example: uncomment and add your source-format reading library here'
+)
+
 _DEPS_STRING_PER_TEMPLATE: dict[str, str] = {
-    "base": '    "firecube>=0.1.0"',
-    "zarr": '    "firecube>=0.1.0",\n    "xarray"',
+    "base": f'    "firecube>=0.1.0",\n{_DEPENDENCY_HINT}',
+    "zarr": f'    "firecube>=0.1.0",\n    "xarray",\n{_DEPENDENCY_HINT}',
     "parquet": (
         '    "firecube>=0.1.0",\n'
         '    "pyarrow",\n'
         '    # "pandas",  # uncomment if your build_dataset returns pandas.DataFrame'
     ),
-    "direct_zarr": '    "firecube>=0.1.0",\n    "numpy"',
+    "direct_zarr": f'    "firecube>=0.1.0",\n    "numpy",\n{_DEPENDENCY_HINT}',
 }
+
+_DIRECT_ZARR_EXTRA_INCOMPLETE_NOTE = (
+    "\n>\n"
+    "> The generated `zarr_schema` and `build_write_intents` raise "
+    "`NotImplementedError`. Declare your product's actual layout, groups, "
+    "and cadence before preallocating or ingesting."
+)
 
 _README_SUBSTITUTIONS_PER_TEMPLATE: dict[str, dict[str, str]] = {
     "base": {
@@ -115,24 +128,28 @@ _README_SUBSTITUTIONS_PER_TEMPLATE: dict[str, dict[str, str]] = {
         "output_format": "zarr",
         "output_extension": "zarr",
         "write_mode_default": "staged",
+        "extra_incomplete_note": "",
     },
     "zarr": {
         "hook_summary": "build_dataset()",
         "output_format": "zarr",
         "output_extension": "zarr",
         "write_mode_default": "staged",
+        "extra_incomplete_note": "",
     },
     "parquet": {
         "hook_summary": "build_dataset()",
         "output_format": "parquet",
         "output_extension": "parquet",
         "write_mode_default": "staged",
+        "extra_incomplete_note": "",
     },
     "direct_zarr": {
         "hook_summary": "zarr_schema() and build_write_intents()",
         "output_format": "zarr",
         "output_extension": "zarr",
         "write_mode_default": "direct",
+        "extra_incomplete_note": _DIRECT_ZARR_EXTRA_INCOMPLETE_NOTE,
     },
 }
 

--- a/src/firecube/ingestor/runtime/base.py
+++ b/src/firecube/ingestor/runtime/base.py
@@ -221,14 +221,24 @@ class BaseIngestor(BaseIngestorHookMixin, Ingestor, ABC):
         ``run(ctx)``          — top-level orchestration entry point.
         ``_create_batches``   — delegates to ``BatchPlanner``.
         ``finalize_pipeline`` — delegates to ``PipelineExecutor``.
+
+    Attributes:
+        time_dim_name: The firecube append/index dimension name written into
+            the Zarr store. Defaults to ``"timestamp"`` for backward
+            compatibility; mirrors the ``PRODUCT_NAME`` pattern. Not a
+            config-tier field, not exposed via ``--option`` — a property of
+            the plugin/product, not a per-run knob. Override on a plugin
+            subclass to match the product's own naming convention (e.g.
+            ``time_dim_name: ClassVar[str] = "time"``), matching whatever
+            dimension the plugin's own hook implementation actually
+            produces. The runtime engine also consumes this name to seed
+            coordinate-array chunks in staged mode. Plugin declaration is
+            authoritative: changing it against an existing store fails
+            loudly with migration guidance rather than silently
+            reinterpreting the store.
     """
 
     PRODUCT_NAME: ClassVar[str]
-    # Firecube's append/index dimension name as written into the Zarr store.
-    # Default 'timestamp' preserves back-compat.
-    # Plugins override on their subclass for CF-1.8 conventional naming (e.g.
-    # `time_dim_name: ClassVar[str] = 'time'`). NOT a config-tier field,
-    # NOT exposed via --option.
     time_dim_name: ClassVar[str] = "timestamp"
     name: str
 
@@ -370,7 +380,29 @@ class BaseIngestor(BaseIngestorHookMixin, Ingestor, ABC):
         return files
 
     def filter_item(self, item: Any, ctx: PluginContext) -> bool:
-        """Filter items before batching (Hook). Default: True."""
+        """Decide whether one discovered item proceeds to batching (Hook).
+
+        Called once per item, after discovery and before batching.
+        Returning ``False`` drops the item silently; it never reaches a
+        batch or a plugin hook. Unlike ``include_patterns``/
+        ``discover_source_files``, which control which files discovery
+        finds at all, this hook filters items discovery has already found.
+
+        Args:
+            item: One discovered item, in whatever form discovery produced
+                it.
+            ctx: Read-only plugin context.
+
+        Returns:
+            ``True`` to keep the item, ``False`` to drop it. Default:
+            ``True`` (keep all).
+
+        Examples:
+            Drop zero-byte files before they reach batching:
+
+                def filter_item(self, item, ctx):
+                    return Path(item).stat().st_size > 0
+        """
         return True
 
     def item_size_bytes(self, item: Any) -> int | None:

--- a/src/firecube/ingestor/templates/generic.py
+++ b/src/firecube/ingestor/templates/generic.py
@@ -187,7 +187,10 @@ class GenericZarrIngestor(BaseIngestor):
         Returns None to skip writing for this group/batch.
 
         The returned dataset must carry the ingestor's ``time_dim_name``
-        dimension; it is appended along that dimension.
+        dimension, ordered on that dimension, with values that do not
+        overlap another batch; it is appended along that dimension.
+        Variables, dimensions, coordinates, and data types must remain
+        compatible across batches.
 
         Examples:
             Build one dataset per batch from the discovered items:

--- a/tests/integration/test_horizon_growth_rejects_shape_drift.py
+++ b/tests/integration/test_horizon_growth_rejects_shape_drift.py
@@ -1,0 +1,171 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+import zarr
+from click.testing import CliRunner
+
+from firecube.cli.main import cli
+from firecube.core.zarr.region_writer import RegionZarrWriter
+from firecube.ingestor.api import ZarrArraySpec, ZarrGroupSpec
+from firecube.ingestor.errors import SchemaSizeMismatchError
+from firecube.ingestor.registry import loader as _loader
+from firecube.ingestor.templates.direct_zarr import _setup_global_zarr_schema
+
+pytestmark = pytest.mark.integration
+
+GROUP = "data"
+ARRAY = "data"
+SMALL_HORIZON = 10
+GROWN_HORIZON = 20
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_registry() -> Iterator[None]:
+    """Reset plugin discovery state so monkeypatched fixture plugins are re-discovered."""
+    original_loaded = _loader._LOADED
+    original_registry = dict(_loader.AVAILABLE_INGESTORS)
+    _loader._LOADED = False
+    _loader.AVAILABLE_INGESTORS.clear()
+    importlib.reload(importlib.import_module("direct_zarr_capable_test_plugin"))
+    yield
+    _loader._LOADED = original_loaded
+    _loader.AVAILABLE_INGESTORS.clear()
+    _loader.AVAILABLE_INGESTORS.update(original_registry)
+
+
+def _strategy(store_uri: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        _store_uri=store_uri,
+        _storage_config=None,
+        _session=None,
+        _coord_names_by_group={},
+    )
+
+
+def _schema() -> list[ZarrGroupSpec]:
+    return [
+        ZarrGroupSpec(
+            group=GROUP,
+            arrays=[
+                ZarrArraySpec(
+                    name=ARRAY,
+                    shape=(1, 10),
+                    dtype=np.float32,
+                    chunks=(5, 10),
+                    fill_value=0.0,
+                    dimension_names=("timestamp", "x"),
+                )
+            ],
+        )
+    ]
+
+
+def _preallocate_small_store_and_write_slots(store_path: Path) -> None:
+    _setup_global_zarr_schema(
+        strategy=_strategy(str(store_path)),
+        schema=_schema(),
+        global_expected={GROUP: SMALL_HORIZON},
+        product="horizon-growth-product",
+        run_id="initial-small-horizon",
+        chunk_manager=None,
+    )
+    writer = RegionZarrWriter(str(store_path))
+    writer.write_1d(GROUP, ARRAY, ts_index=0, data=np.arange(10, dtype=np.float32))
+    writer.write_1d(GROUP, ARRAY, ts_index=9, data=np.full((10,), 9, dtype=np.float32))
+
+
+def _cli_args(target: str) -> list[str]:
+    return [
+        "zarr",
+        "preallocate",
+        "direct_zarr_capable_test_plugin",
+        "--target",
+        target,
+        "--product-name",
+        "horizon-growth-product",
+        "--storage-type",
+        "local",
+        "--storage-driver",
+        "fsspec",
+        "--write-mode",
+        "direct",
+    ]
+
+
+def test_setup_global_zarr_schema_rejects_existing_smaller_horizon(tmp_path: Path) -> None:
+    """Observed behavior: direct schema setup rejects, and does not resize, small arrays."""
+    store_path = tmp_path / "setup-growth.zarr"
+    _preallocate_small_store_and_write_slots(store_path)
+
+    with pytest.raises(SchemaSizeMismatchError) as exc_info:
+        _setup_global_zarr_schema(
+            strategy=_strategy(str(store_path)),
+            schema=_schema(),
+            global_expected={GROUP: GROWN_HORIZON},
+            product="horizon-growth-product",
+            run_id="grown-horizon",
+            chunk_manager=None,
+        )
+
+    message = str(exc_info.value)
+    assert (
+        message == "Schema drift for group data: existing array shape[0]=10 < global_expected=20. "
+        "Run `firecube zarr preallocate` first."
+    )
+    arr = cast(Any, zarr.open_group(store=str(store_path), mode="r", zarr_format=3)["data/data"])
+    assert arr.shape == (SMALL_HORIZON, 10)
+    assert np.asarray(arr[0]).tolist() == np.arange(10, dtype=np.float32).tolist()
+    assert np.asarray(arr[9]).tolist() == np.full((10,), 9, dtype=np.float32).tolist()
+
+
+def test_cli_preallocate_rejects_existing_smaller_horizon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Observed behavior: CLI preallocate rejects the growth plan instead of resizing."""
+    store_path = tmp_path / "cli-growth.zarr"
+    _preallocate_small_store_and_write_slots(store_path)
+
+    import direct_zarr_capable_test_plugin as plugin_module
+
+    monkeypatch.setattr(
+        plugin_module.DirectZarrCapableTestIngestor,
+        "global_expected_time_count",
+        lambda self, ctx: {GROUP: GROWN_HORIZON},
+    )
+    monkeypatch.setattr(
+        plugin_module.DirectZarrCapableTestIngestor,
+        "zarr_schema",
+        lambda self, ctx: _schema(),
+    )
+
+    result = CliRunner().invoke(cli, _cli_args(f"file://{store_path}"), prog_name="firecube")
+
+    assert result.exit_code != 0, result.output
+    assert "Existing arrays mismatch the plan: array 'data/data' has mismatches." in result.output
+    assert "Mismatch: shape: expected (20, 10), found (10, 10)" in result.output
+    assert "Either delete them or update the plan to match." in result.output
+    arr = cast(Any, zarr.open_group(store=str(store_path), mode="r", zarr_format=3)["data/data"])
+    assert arr.shape == (SMALL_HORIZON, 10)
+    assert np.asarray(arr[0]).tolist() == np.arange(10, dtype=np.float32).tolist()
+    assert np.asarray(arr[9]).tolist() == np.full((10,), 9, dtype=np.float32).tolist()

--- a/tests/unit/test_cli_zarr_slots.py
+++ b/tests/unit/test_cli_zarr_slots.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -28,6 +29,7 @@ from firecube.core.api import SlotAxis, SlotIndexModel
 from firecube.ingestor.api import (
     DirectZarrIngestor,
     PipelineBatch,
+    PluginConfig,
     PluginContext,
     WriteIntent,
     ZarrArraySpec,
@@ -366,3 +368,84 @@ def test_zarr_slots_does_not_mutate_target(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert not target_path.exists()
     assert not (tmp_path / ".firecube").exists()
+
+
+def test_slots_option_reaches_plugin_hook(tmp_path: Path) -> None:
+    import direct_zarr_capable_test_plugin as plugin_module
+
+    @dataclass
+    class _SlotsCapableOptionConfig(PluginConfig):
+        horizon_end_iso: str = "2024-01-01T01:00:00Z"
+
+    @register_ingestor("direct_zarr_slots_capable_option_test")
+    class _SlotsCapableOptionIngestor(plugin_module.DirectZarrCapableTestIngestor):
+        plugin_config_class = _SlotsCapableOptionConfig
+
+        def global_expected_time_count(self, ctx: PluginContext) -> dict[str, int]:
+            assert isinstance(self.plugin_config, _SlotsCapableOptionConfig)
+            assert self.plugin_config.horizon_end_iso == "2024-01-01T02:00:00Z"
+            return {"data": 24}
+
+    config = tmp_path / "config.toml"
+    config.write_text("", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--config-file",
+            str(config),
+            "zarr",
+            "slots",
+            "direct_zarr_slots_capable_option_test",
+            "--target",
+            (tmp_path / "slots.zarr").as_uri(),
+            "--product-name",
+            "direct_zarr_slots_capable_option_test",
+            "--storage-type",
+            "local",
+            "--storage-driver",
+            "fsspec",
+            "--write-mode",
+            "direct",
+            "--no-resume",
+            "--option",
+            "horizon_end_iso=2024-01-01T02:00:00Z",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    group = next(g for g in payload["groups"] if g["name"] == "data")
+    assert group["total_slots"] == 24
+
+
+def test_slots_non_capable_plugin_is_rejected(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text("", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--config-file",
+            str(config),
+            "zarr",
+            "slots",
+            "direct_zarr_non_capable_test_plugin",
+            "--target",
+            (tmp_path / "slots.zarr").as_uri(),
+            "--product-name",
+            "direct_zarr_non_capable_test_plugin",
+            "--storage-type",
+            "local",
+            "--storage-driver",
+            "fsspec",
+            "--write-mode",
+            "direct",
+            "--no-resume",
+        ],
+        catch_exceptions=True,
+    )
+
+    assert result.exit_code != 0
+    assert "slot-range parallelism" in result.output

--- a/tests/unit/test_iso_to_epoch_s_utc_strict.py
+++ b/tests/unit/test_iso_to_epoch_s_utc_strict.py
@@ -1,0 +1,42 @@
+"""UTC-strictness of iso_to_epoch_s: what it accepts, rejects, and returns."""
+
+from __future__ import annotations
+
+import pytest
+
+from firecube.core.slot_index import iso_to_epoch_s
+
+pytestmark = pytest.mark.unit
+
+
+_EXPECTED_EPOCH_SECONDS = 1704067200  # 2024-01-01T00:00:00 UTC.
+
+
+def test_naive_iso_string_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="UTC-explicit ISO 8601 input"):
+        iso_to_epoch_s("2024-01-01T00:00:00")
+
+
+@pytest.mark.parametrize(
+    "iso",
+    [
+        pytest.param("2024-01-01T00:00:00Z", id="z_suffix"),
+        pytest.param("2024-01-01T00:00:00+00:00", id="plus_zero_offset"),
+        pytest.param("2024-01-01T00:00:00-00:00", id="minus_zero_offset"),
+        pytest.param("  2024-01-01T00:00:00Z  ", id="leading_and_trailing_whitespace"),
+    ],
+)
+def test_utc_explicit_forms_produce_expected_epoch_seconds(iso: str) -> None:
+    assert iso_to_epoch_s(iso) == _EXPECTED_EPOCH_SECONDS
+
+
+@pytest.mark.parametrize(
+    "iso",
+    [
+        pytest.param("2024-01-01T00:00:00+05:30", id="positive_non_utc_offset"),
+        pytest.param("2024-01-01T00:00:00-07:00", id="negative_non_utc_offset"),
+    ],
+)
+def test_non_utc_offset_rejected(iso: str) -> None:
+    with pytest.raises(ValueError, match="UTC-explicit ISO 8601 input"):
+        iso_to_epoch_s(iso)

--- a/tests/unit/test_scaffolding_product_name.py
+++ b/tests/unit/test_scaffolding_product_name.py
@@ -156,6 +156,9 @@ def test_generated_readme_has_template_specific_markers(template_type: str, tmp_
     for flag in expected_flags:
         assert flag in readme
 
+    assert readme.index("uv run pytest") < readme.index("## Install into Firecube")
+    assert readme.index("## Install into Firecube") < readme.index("## Run a local ingestion")
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize("template_type", ["base", "zarr", "parquet", "direct_zarr"])
@@ -214,3 +217,39 @@ def test_generated_hook_raises_not_implemented(template_type: str, tmp_path: Pat
         assert hook_name in str(exc_info.value), (
             f"NotImplementedError message for {hook_name} should mention the hook name"
         )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template_type", ["base", "zarr", "parquet", "direct_zarr"])
+def test_generated_ingestor_passes_ruff(template_type: str, tmp_path: Path) -> None:
+    """Generated ingestor.py must stay ruff-clean as templates evolve.
+
+    A template edit that breaks lint or formatting would otherwise only
+    surface when a real user's freshly scaffolded plugin fails their own
+    `ruff check`, not in this repo's CI.
+    """
+    import subprocess
+    import sys
+
+    from firecube.ingestor.devtools.scaffolding import create_plugin_structure
+
+    root = create_plugin_structure("demo-foo", tmp_path, template_type=template_type)
+    ingestor_path = root / "src" / "firecube_demo_foo" / "ingestor.py"
+
+    check = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", str(ingestor_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert check.returncode == 0, (
+        f"ruff check failed for {template_type} template:\n{check.stdout}{check.stderr}"
+    )
+
+    fmt = subprocess.run(
+        [sys.executable, "-m", "ruff", "format", "--check", str(ingestor_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert fmt.returncode == 0, (
+        f"ruff format --check failed for {template_type} template:\n{fmt.stdout}{fmt.stderr}"
+    )

--- a/tests/unit/test_slot_index_model.py
+++ b/tests/unit/test_slot_index_model.py
@@ -16,6 +16,9 @@
 
 from __future__ import annotations
 
+from typing import cast
+
+import numpy as np
 import pytest
 
 from firecube.core.errors import (
@@ -64,6 +67,29 @@ def test_slot_axis_rejects_negative_cadence() -> None:
 def test_slot_axis_rejects_invalid_mode() -> None:
     with pytest.raises(ValueError, match="mode"):
         SlotAxis(cadence_s=300, mode="invalid")  # type: ignore[arg-type]
+
+
+def test_slot_axis_rejects_bool_cadence() -> None:
+    with pytest.raises(TypeError):
+        SlotAxis(cadence_s=True, mode="exact")
+    with pytest.raises(TypeError):
+        SlotAxis(cadence_s=False, mode="exact")
+
+
+def test_slot_axis_rejects_float_cadence() -> None:
+    with pytest.raises(TypeError):
+        SlotAxis(cadence_s=cast(int, 1.5), mode="exact")
+
+
+def test_slot_axis_rejects_string_cadence() -> None:
+    with pytest.raises(TypeError):
+        SlotAxis(cadence_s="1", mode="exact")  # type: ignore[arg-type]
+
+
+def test_slot_axis_accepts_numpy_int64_cadence() -> None:
+    axis = SlotAxis(cadence_s=cast(int, np.int64(300)), mode="exact")
+    assert axis.cadence_s == 300
+    assert axis.mode == "exact"
 
 
 def test_slot_index_model_rejects_empty_name() -> None:


### PR DESCRIPTION
## What changed
Byte parity fix (`SlotAxis` normalizes `cadence_s` to `int`), strict UTC in `iso_to_epoch_s`, `--option key=value` flag on `zarr slots`/`preallocate`, and scaffolding polish (product name casing, reworded incomplete-note, sentence-case template headings)

## Why

To prevent silent canonical-bytes drift when `cadence_s` arrives as `np.int64`, tighten UTC parsing, and align `zarr` subcommand ergonomics with `ingest`. 

## Affected behavior

- User / CLI: `zarr slots` and `zarr preallocate` accept `--option key=value` ( matches `run`).                                                                        
- Plugin authors: `iso_to_epoch_s` rejects non-UTC ISO strings with a clearer message naming `Z`, `+00:00`, `-00:00`.                                                
- Operators / production: no runtime behavior change; deterministic on-disk bytes preserved.                                                                             
- Stored formats or control-plane state: N/A

## Type of change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (CLI flags, plugin contract, config, or stored format)
- [ ] Documentation
- [ ] CI / build / chore

## Checks run

<!-- Tick what you ran; paste anything notable. -->

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [ ] `uv run --with bandit bandit -c pyproject.toml -r src scripts -lll`
- [x] `uv run pytest --strict-deps -m "not slow and not s3" -q`
- [ ] Docs build (if docs changed): `uv run mkdocs build --strict`

## Follow-up work

None

## Contributor certification

- [X] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [X] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
