### PR TITLE
feat(directzarr): IrregularTimeAxis + AUTO discovery + content-addressed item manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           uv pip install -e tests/fixtures/index_spec_test_plugin
           uv pip install -e tests/fixtures/index_spec_integer_test_plugin
           uv pip install -e tests/fixtures/callable_payload_test_plugin
+          uv pip install -e tests/fixtures/irregular_axis_test_plugin
       - run: uv run pyright
 
   test:
@@ -54,6 +55,7 @@ jobs:
           uv pip install -e tests/fixtures/index_spec_test_plugin
           uv pip install -e tests/fixtures/index_spec_integer_test_plugin
           uv pip install -e tests/fixtures/callable_payload_test_plugin
+          uv pip install -e tests/fixtures/irregular_axis_test_plugin
       - run: uv run pytest --strict-deps -m "not slow and not s3 and not docs_static and not snapshot" -n auto --cov=firecube --cov-report=term-missing -q
 
   docs:
@@ -75,6 +77,7 @@ jobs:
           uv pip install -e tests/fixtures/index_spec_test_plugin
           uv pip install -e tests/fixtures/index_spec_integer_test_plugin
           uv pip install -e tests/fixtures/callable_payload_test_plugin
+          uv pip install -e tests/fixtures/irregular_axis_test_plugin
       - name: Documentation and help-text drift checks
         run: uv run pytest --strict-deps -m "docs_static or snapshot" -q --tb=short
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
           uv pip install -e tests/fixtures/index_spec_test_plugin
           uv pip install -e tests/fixtures/index_spec_integer_test_plugin
           uv pip install -e tests/fixtures/callable_payload_test_plugin
+          uv pip install -e tests/fixtures/irregular_axis_test_plugin
       - run: uv run ruff check .
       - run: uv run ruff format --check .
       - run: uv run pyright

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ uv pip install -e tests/fixtures/index_spec_test_plugin
 uv pip install -e tests/fixtures/index_spec_integer_test_plugin
 uv pip install -e tests/fixtures/slot_shape_test_plugin
 uv pip install -e tests/fixtures/callable_payload_test_plugin
+uv pip install -e tests/fixtures/irregular_axis_test_plugin
 ```
 
 This is required for `tests/integration/test_ingest_command_typed.py` and related CLI tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 
 ### Added
 
+- `IrregularTimeAxis` axis type for `IndexSpec`: declare an irregular time axis
+  with an explicit tuple of coordinate values when items are not evenly spaced.
+  Importable from `firecube.core.api` and `firecube.ingestor.api`.
+- `AUTO` sentinel: set `IrregularTimeAxis(values=AUTO)` to let the engine
+  discover coordinates at planning time by calling `inspect_item` on every
+  source item before preallocate. Importable from `firecube.core.api` and
+  `firecube.ingestor.api`.
+- `MissingIrregularCoordinateError`: raised during `AUTO` discovery when an
+  item returns `ItemInfo(coordinate=None)` or when two items share the same
+  coordinate. Inherits from `ConfigurationError`. Importable from
+  `firecube.core.api` and `firecube.ingestor.api`.
+- `NoDiscoveredItemsError`: raised during `AUTO` discovery when no items are
+  found for an `IrregularTimeAxis` group. Inherits from `ConfigurationError`.
+  Importable from `firecube.core.api` and `firecube.ingestor.api`.
+- `ItemManifestEntry` and `validate_manifest_entries`: content-addressed item
+  manifest types used by the engine to plan `IrregularTimeAxis` axes and hand
+  deterministic per-item work to parallel workers. Importable from
+  `firecube.core.api` and `firecube.ingestor.api`.
+- `--dry-run` flag for `firecube zarr preallocate`: runs discovery and resolves
+  the index without writing any Zarr arrays, claim files, or control-plane
+  records. Output matches `firecube zarr index show --json`.
+- `--derived` flag for `firecube zarr index show`: computes and prints derived
+  coordinate values for `regular_time` groups from the stored epoch, cadence,
+  and size. Read-only; no files are written.
 - `WriteIntent.data` now accepts `Callable[[], np.ndarray]` in addition to
   `np.ndarray | Any`. The callable is resolved exactly once at dispatch time,
   immediately before the writer call. Eager payloads remain valid; existing

--- a/docs/guides/plugins/irregular-axis.md
+++ b/docs/guides/plugins/irregular-axis.md
@@ -1,0 +1,233 @@
+# IrregularTimeAxis And AUTO Discovery
+
+## Goal
+
+Use `IrregularTimeAxis` when the time coordinates of your product are not
+evenly spaced and cannot be described by a fixed epoch and cadence. The axis
+holds an explicit list of coordinate values, either supplied at declaration time
+or discovered automatically from the source data.
+
+This guide covers:
+
+- when to choose `IrregularTimeAxis` over `RegularTimeAxis` or `IntegerAxis`;
+- how to declare the axis with a concrete tuple of values;
+- how to use `AUTO` to let the engine discover coordinates at planning time;
+- how to implement `inspect_item` for the `AUTO` path;
+- the `source_ref` stability contract;
+- failure modes and the exceptions the engine raises.
+
+## Choose The Right Axis
+
+| Axis | Use when |
+|---|---|
+| `RegularTimeAxis` | Items arrive at a fixed cadence (e.g. every 10 minutes). |
+| `IntegerAxis` | Items map to a zero-based integer position with no time meaning. |
+| `IrregularTimeAxis` | Items have timestamps that are not evenly spaced, or the full set of timestamps is only known after reading the source data. |
+
+If the cadence is fixed, prefer `RegularTimeAxis`. The engine can plan slot
+ranges for parallel workers without reading any source files.
+
+## Declare With Concrete Values
+
+When you know all timestamps before ingestion starts, pass them as a tuple:
+
+```python
+import numpy as np
+from firecube.ingestor.api import (
+    DirectZarrIngestor,
+    IndexSpec,
+    IrregularTimeAxis,
+    ItemInfo,
+    PipelineBatch,
+    PluginContext,
+    WriteIntent,
+    ZarrArraySpec,
+    ZarrGroupSpec,
+    register_ingestor,
+)
+from typing import ClassVar
+
+
+@register_ingestor("my_irregular_plugin")
+class MyIrregularPlugin(DirectZarrIngestor):
+    PRODUCT_NAME: ClassVar[str] = "my_irregular_product"
+
+    def index_spec(self, ctx: PluginContext) -> IndexSpec | None:
+        _ = ctx
+        timestamps = (
+            np.datetime64("2026-01-01T00:00:00", "ns"),
+            np.datetime64("2026-01-01T00:17:30", "ns"),
+            np.datetime64("2026-01-01T00:42:00", "ns"),
+        )
+        return IndexSpec(
+            name="my_irregular_product_v1",
+            groups={
+                "data": IrregularTimeAxis(
+                    coordinate="timestamp",
+                    values=timestamps,
+                ),
+            },
+        )
+
+    def inspect_item(self, item: object, ctx: PluginContext) -> ItemInfo | None:
+        stamp = read_timestamp(ctx.materialize(item))
+        return ItemInfo(coordinate=stamp)
+
+    def zarr_schema(self, ctx: PluginContext) -> list[ZarrGroupSpec]:
+        n = self.resolved_index(ctx).size("data")
+        return [
+            ZarrGroupSpec(
+                group="data",
+                coord_names=frozenset({"timestamp"}),
+                arrays=[
+                    ZarrArraySpec(
+                        name="timestamp",
+                        shape=(n,),
+                        dtype="datetime64[ns]",
+                        chunks=(n,),
+                        dimension_names=("timestamp",),
+                    ),
+                    ZarrArraySpec(
+                        name="value",
+                        shape=(n, 4),
+                        dtype="float32",
+                        chunks=(1, 4),
+                        dimension_names=("timestamp", "sample"),
+                    ),
+                ],
+            )
+        ]
+
+    def build_write_intents(
+        self,
+        batch: PipelineBatch,
+        ctx: PluginContext,
+    ) -> list[WriteIntent]:
+        intents: list[WriteIntent] = []
+        for item in batch.items:
+            stamp = read_timestamp(ctx.materialize(item))
+            index = self.resolved_index(ctx).position("data", stamp)
+            intents.append(WriteIntent.coordinate(group="data", index=index, value=stamp))
+            intents.append(
+                WriteIntent.slot(
+                    group="data",
+                    array="value",
+                    index=index,
+                    data=read_values(ctx.materialize(item)),
+                )
+            )
+        return intents
+```
+
+The engine writes the coordinate array to the Zarr store during preallocate.
+`resolved_index(ctx).position("data", stamp)` maps each timestamp to its
+declared slot index.
+
+## Declare With AUTO
+
+When the full set of timestamps is only known after reading the source files,
+set `values=AUTO`. The engine calls `inspect_item` on every discovered source
+item before preallocate, collects the returned coordinates, and builds the axis
+from them.
+
+```python
+from firecube.ingestor.api import AUTO, IrregularTimeAxis
+```
+
+```python
+def index_spec(self, ctx: PluginContext) -> IndexSpec | None:
+    _ = ctx
+    return IndexSpec(
+        name="my_irregular_product_v1",
+        groups={
+            "data": IrregularTimeAxis(coordinate="timestamp", values=AUTO),
+        },
+    )
+```
+
+With `AUTO`, `inspect_item` runs twice: once during discovery (to collect
+coordinates) and once during the write phase (to produce write intents). The
+implementation must be idempotent and must not depend on discovery order.
+
+### Implement `inspect_item` For AUTO
+
+Return `ItemInfo(coordinate=stamp)` for every item that has a valid coordinate.
+Return `None` to skip an item entirely. Return `ItemInfo(coordinate=None)` only
+when the item is present but its coordinate cannot be resolved; the engine
+raises `MissingIrregularCoordinateError` in that case.
+
+```python
+def inspect_item(self, item: object, ctx: PluginContext) -> ItemInfo | None:
+    path = ctx.materialize(item)
+    stamp = read_timestamp(path)
+    if stamp is None:
+        # Item has no timestamp: skip it.
+        return None
+    return ItemInfo(coordinate=stamp)
+```
+
+The engine sorts discovered coordinates and assigns each a slot index in
+ascending order. Duplicate coordinates raise `DuplicateIrregularCoordinateError`,
+naming both conflicting items and the shared coordinate value.
+
+### `source_ref` Stability Contract
+
+During AUTO discovery the engine records a `source_ref` for each item. The
+`source_ref` is a stable reference the engine uses to hand work to parallel
+workers without a second discovery pass. The stability contract depends on the
+kind:
+
+| `source_ref_kind` | What the caller promises |
+|---|---|
+| `"path"` | Absolute filesystem path is stable for the cube's lifetime. |
+| `"uri"` | URL (e.g. `s3://bucket/key`) is dereferenceable for the cube's lifetime. |
+| `"identifier"` | Plugin-defined identifier is resolvable by the plugin's own logic for the cube's lifetime. |
+
+Do not use paths that change between discovery and write (e.g. temporary
+directories, session-scoped scratch paths). If the source data moves, the
+engine cannot dereference the recorded reference.
+
+## Preallocate
+
+Run preallocate before starting workers. For `AUTO`, the engine runs discovery
+during preallocate and writes the coordinate array to the Zarr store:
+
+```bash
+firecube zarr preallocate my_irregular_plugin \
+  --target file:///data/products/my_irregular_product.zarr \
+  --product-name my_irregular_product \
+  --storage-type local \
+  --storage-driver fsspec \
+  --write-mode direct
+```
+
+Use `--dry-run` to inspect the resolved index without writing anything:
+
+```bash
+firecube zarr preallocate my_irregular_plugin \
+  --target file:///data/products/my_irregular_product.zarr \
+  --product-name my_irregular_product \
+  --storage-type local \
+  --storage-driver fsspec \
+  --write-mode direct \
+  --dry-run
+```
+
+The dry-run output is the same JSON format as `firecube zarr index show --json`.
+No files are created or modified.
+
+## Failure Modes
+
+| Error | Cause | Fix |
+|---|---|---|
+| `MissingIrregularCoordinateError` | `inspect_item` returned `ItemInfo(coordinate=None)` for an item. | Check the source data for items with missing timestamps. |
+| `DuplicateIrregularCoordinateError` | Two discovered items resolve to the same coordinate value. | Check the source data for duplicate timestamps. |
+| `NoDiscoveredItemsError` | Discovery found zero items for the axis. | Verify that the source path contains data and that `filter_item` is not excluding everything. |
+| `ConfigurationError` | The declared `values` tuple contains duplicates, or `values` is empty. | Pass a non-empty tuple with distinct values, or use `AUTO`. |
+
+## See Also
+
+- **[Index Specification Reference](../../reference/parallelism.md)** - `IrregularTimeAxis`, `AUTO`, `IndexSpec`, and `ResolvedIndex` types
+- **[Exceptions Reference](../../reference/exceptions.md)** - `MissingIrregularCoordinateError`, `DuplicateIrregularCoordinateError`, and `NoDiscoveredItemsError`
+- **[Implement DirectZarrIngestor](direct-zarr.md)** - the full `DirectZarrIngestor` plugin contract
+- **[Run Parallel Zarr Writes](../../operations/parallel-zarr-writes.md)** - preallocate and slot-range workflow

--- a/docs/operations/firecube-index.md
+++ b/docs/operations/firecube-index.md
@@ -45,6 +45,16 @@ firecube zarr index show \
 | Flag | Description |
 |---|---|
 | `--json` | Emit the raw record as JSON instead of the human-readable summary. |
+| `--derived` | For `regular_time` groups, compute and print the derived coordinate values (timestamps) from the stored epoch, cadence, and size. Emits a note to stderr for `irregular_time` and `integer` groups. Does not write any files. |
+
+Add `--derived` to see the full list of timestamps for a `RegularTimeAxis` group:
+
+```bash
+firecube zarr index show \
+  --target file:///data/products/my_product.zarr \
+  --product-name my_product \
+  --derived
+```
 
 **Exit codes:**
 
@@ -163,6 +173,7 @@ and the identity hash matches the plugin's current `index_spec()` declaration.
 
 ## See Also
 
-- **[Index Specification Reference](../reference/parallelism.md)** - `IndexSpec`, `IntegerAxis`, `RegularTimeAxis`, and `ResolvedIndexRecord` types
+- **[Index Specification Reference](../reference/parallelism.md)** - `IndexSpec`, `IntegerAxis`, `IrregularTimeAxis`, `RegularTimeAxis`, and `ResolvedIndexRecord` types
 - **[Implement DirectZarrIngestor](../guides/plugins/direct-zarr.md)** - declare an `IndexSpec` in a plugin
+- **[IrregularTimeAxis Plugin Guide](../guides/plugins/irregular-axis.md)** - declare and use `IrregularTimeAxis` with `AUTO`
 - **[ChunkManager Operations](chunk-manager/index.md)** - inspect and recover the broader control plane

--- a/docs/operations/parallel-zarr-writes.md
+++ b/docs/operations/parallel-zarr-writes.md
@@ -37,6 +37,22 @@ firecube zarr preallocate <plugin> \
 The command is idempotent when the existing arrays match the declared schema.
 It fails when their shape, data type, or chunk layout differs.
 
+Add `--dry-run` to inspect the resolved index without writing any files or
+control-plane records:
+
+```bash
+firecube zarr preallocate <plugin> \
+  --target file:///data/products/my_product.zarr \
+  --product-name my_product \
+  --storage-type local \
+  --storage-driver fsspec \
+  --write-mode direct \
+  --dry-run
+```
+
+The dry-run output is the same JSON format as `firecube zarr index show --json`.
+No Zarr arrays, claim files, or index records are created.
+
 ## 2. Plan Slot Ranges
 
 Inspect a human-readable plan before launching workers:

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -5,9 +5,16 @@ Ingestor-layer errors inherit from `IngestorError`; `ManifestError`,
 `SchemaDriftError`, and `StorageError` are shared error types re-exported
 through the same facade.
 
+`MissingIrregularCoordinateError`, `DuplicateIrregularCoordinateError`, and
+`NoDiscoveredItemsError` are raised during `IrregularTimeAxis(values=AUTO)`
+discovery.
+
 {{ render_api_summary("firecube.ingestor.api", [
     "IngestorError",
     "ConfigurationError",
+    "MissingIrregularCoordinateError",
+    "DuplicateIrregularCoordinateError",
+    "NoDiscoveredItemsError",
     "SchemaDriftError",
     "SchemaSizeMismatchError",
     "ManifestError",
@@ -31,6 +38,17 @@ through the same facade.
 
 ::: firecube.ingestor.api.WriteIntentRangeError
 
+## Irregular Axis Discovery Errors
+
+These errors are raised when `IrregularTimeAxis(values=AUTO)` discovery fails.
+All three inherit from `ConfigurationError`.
+
+::: firecube.ingestor.api.MissingIrregularCoordinateError
+
+::: firecube.ingestor.api.DuplicateIrregularCoordinateError
+
+::: firecube.ingestor.api.NoDiscoveredItemsError
+
 ## Shared Errors
 
 ::: firecube.ingestor.api.ManifestError
@@ -39,7 +57,18 @@ through the same facade.
 
 ::: firecube.ingestor.api.StorageError
 
+## Core API Re-Exports
+
+The core facade re-exports the error types used by plugin code and the engine.
+
+::: firecube.core.api.MissingIrregularCoordinateError
+
+::: firecube.core.api.DuplicateIrregularCoordinateError
+
+::: firecube.core.api.NoDiscoveredItemsError
+
 ## See Also
 
 - [Templates](templates.md)
-- [Slot-Range Parallelism](parallelism.md)
+- [Index Specification](parallelism.md)
+- [IrregularTimeAxis Plugin Guide](../guides/plugins/irregular-axis.md)

--- a/docs/reference/parallelism.md
+++ b/docs/reference/parallelism.md
@@ -1,6 +1,6 @@
 # Index Specification
 
-This reference covers the public types used to declare and resolve direct-Zarr index specs. `IndexSpec`, `RegularTimeAxis`, and `IntegerAxis` describe the layout. `inspect_item()` returns `ItemInfo`, and `resolve_index_spec()` turns the declarative spec into a cached `ResolvedIndex` for the run.
+This reference covers the public types used to declare and resolve direct-Zarr index specs. `IndexSpec`, `RegularTimeAxis`, `IntegerAxis`, and `IrregularTimeAxis` describe the layout. `AUTO` is the sentinel that tells the engine to discover coordinates at planning time. `inspect_item()` returns `ItemInfo`, and `resolve_index_spec()` turns the declarative spec into a cached `ResolvedIndex` for the run.
 
 `coerce_to_epoch_s()` normalizes supported timestamp values to Unix epoch seconds.
 
@@ -10,6 +10,8 @@ This reference covers the public types used to declare and resolve direct-Zarr i
     "AxisSpec",
     "IndexSpec",
     "IntegerAxis",
+    "IrregularTimeAxis",
+    "AUTO",
     "RegularTimeAxis",
     "ItemInfo",
     "ResolvedIndex",
@@ -25,6 +27,10 @@ This reference covers the public types used to declare and resolve direct-Zarr i
 ::: firecube.core.api.IndexSpec
 
 ::: firecube.core.api.IntegerAxis
+
+::: firecube.core.api.IrregularTimeAxis
+
+::: firecube.core.api.AUTO
 
 ::: firecube.core.api.RegularTimeAxis
 
@@ -47,6 +53,10 @@ The public ingestor facade re-exports the declarative types used by plugin code.
 ::: firecube.ingestor.api.IndexSpec
 
 ::: firecube.ingestor.api.IntegerAxis
+
+::: firecube.ingestor.api.IrregularTimeAxis
+
+::: firecube.ingestor.api.AUTO
 
 ::: firecube.ingestor.api.RegularTimeAxis
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
       - GenericZarrIngestor (Append): guides/plugins/generic-zarr.md
       - GenericParquetIngestor (Tabular): guides/plugins/generic-parquet.md
       - DirectZarrIngestor (Region): guides/plugins/direct-zarr.md
+      - IrregularTimeAxis And AUTO: guides/plugins/irregular-axis.md
     - Develop Further:
       - Configure a Plugin: guides/plugins/cli-and-config.md
       - Add Telemetry: guides/plugins/observability.md

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -1,5 +1,53 @@
 # Done
 
+## 2026-08-24 — IrregularTimeAxis + AUTO sentinel + content-addressed item manifest
+
+Added `IrregularTimeAxis` as a third concrete `AxisSpec` alongside
+`RegularTimeAxis` and `IntegerAxis`. Plugins declare
+`IrregularTimeAxis(coordinate=..., values=<tuple>)` when items have timestamps
+that are not evenly spaced. Setting `values=AUTO` tells the engine to discover
+coordinates at planning time by calling `inspect_item` on every source item
+before preallocate.
+
+Added `AUTO`: a module-level singleton sentinel. `IrregularTimeAxis(values=AUTO)`
+opts into engine-owned discovery. The sentinel is re-exported from both
+`firecube.core.api` and `firecube.ingestor.api`.
+
+Added content-addressed item manifest: `ItemManifestEntry` pins one source item
+to one axis coordinate via a content-address (`identity_hash`) and a stable
+`source_ref`. `validate_manifest_entries` checks uniqueness invariants.
+`compute_resolved_index_identity_hash` folds the manifest into the
+`identity_hash` when items are present, making the on-disk record a
+freeze-detection mechanism for irregular-axis cubes.
+
+Added `MissingIrregularCoordinateError` and `NoDiscoveredItemsError`: both
+inherit from `ConfigurationError` and are raised during AUTO discovery when an
+item has no resolvable coordinate or when discovery finds zero items.
+
+Added `--dry-run` flag to `firecube zarr preallocate`: runs discovery and
+resolves the index without writing any Zarr arrays, claim files, or control-plane
+records. Output matches `firecube zarr index show --json`.
+
+Added `--derived` flag to `firecube zarr index show`: computes and prints
+derived coordinate values for `regular_time` groups from the stored epoch,
+cadence, and size. Read-only; no files are written.
+
+All new symbols are exported from `firecube.core.api` and
+`firecube.ingestor.api`. Documentation added: capability reference in
+`docs/reference/parallelism.md`, plugin-authoring guide at
+`docs/guides/plugins/irregular-axis.md`, exceptions reference updated in
+`docs/reference/exceptions.md`, CLI docs updated in
+`docs/operations/parallel-zarr-writes.md` and
+`docs/operations/firecube-index.md`.
+
+Supersedes: `plans/TODO.md §33` "Planned: IrregularTimeAxis + AUTO sentinel +
+content-addressed item manifest" (now Landed).
+
+References: A1 (IrregularTimeAxis + AUTO), A2 (resolver), A3 (errors),
+A4 (manifest types), A5 (AUTO discovery), A6 (fixture plugin), A7 (contracts),
+A8 (--dry-run), A9 (--derived), A10 (coord materialization), A11 (integration
+tests), A12 (docs).
+
 ## 2026-08-23 — DirectZarr lazy WriteIntent payload (§F3)
 
 `WriteIntent.data` now accepts `Callable[[], np.ndarray]` in addition to

--- a/plans/TEST.md
+++ b/plans/TEST.md
@@ -106,6 +106,7 @@ uv pip install -e tests/fixtures/slot_shape_test_plugin
 uv pip install -e tests/fixtures/index_spec_test_plugin
 uv pip install -e tests/fixtures/index_spec_integer_test_plugin
 uv pip install -e tests/fixtures/callable_payload_test_plugin
+uv pip install -e tests/fixtures/irregular_axis_test_plugin
 ```
 
 This is required before running the full integration suite. Without these fixtures,

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -11,7 +11,7 @@ New decisions are recorded in [DONE.md](DONE.md) with a date.
 
 - **Landed:** `IndexSpec` + `RegularTimeAxis` + `ResolvedIndex`; byte parity for FCI and OPERA; recursion defect fixed.
 - **Landed:** `IntegerAxis` + engine-owned `.firecube/index/current.json` record (`ResolvedIndexRecord`); `firecube zarr index show/verify/rebuild` CLI; atomic reader migration path documented.
-- **Planned:** `IrregularTimeAxis` + `AUTO` sentinel + content-addressed item manifest; closes #27 spirit.
+- **Landed:** `IrregularTimeAxis` + `AUTO` sentinel + content-addressed item manifest; `--dry-run` for preallocate; `--derived` for index show; closes #27 spirit. See DONE.md 2026-08-24.
 - **Planned:** `IndexedWrite` high-level abstraction + `read_item` hook.
 - **Future deprecation pass:** `SlotIndexModel`, `SlotAxis`, and `as_legacy_slot_index_model()` are kept for byte-parity compatibility with cubes written before the new index model. Schedule a deprecation pass once all known production cubes have been migrated via `firecube zarr index rebuild`. The deprecation should add `DeprecationWarning` on construction, update the allowlist in `test_api_docs_coverage.py`, and remove the symbols in a subsequent major version.
 

--- a/src/firecube/cli/index.py
+++ b/src/firecube/cli/index.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 import inspect
 import logging
 import uuid
@@ -125,11 +126,59 @@ def _group_rows(index_payload: dict[str, Any]) -> list[tuple[str, str, str]]:
     return rows
 
 
+def _derived_coordinates_for_group(
+    group_name: str, group_payload: dict[str, Any]
+) -> list[str] | None:
+    kind = group_payload.get("kind")
+    if kind != "regular_time":
+        return None
+
+    params = group_payload.get("params", {})
+    if not isinstance(params, dict):
+        raise click.ClickException(
+            f"Group {group_name!r}: 'params' is missing or not a mapping in the index record."
+        )
+
+    missing = [f for f in ("epoch", "cadence_s") if f not in params]
+    if "size" not in group_payload:
+        missing.append("size")
+    if missing:
+        raise click.ClickException(
+            f"Group {group_name!r}: cannot compute derived coordinates: "
+            f"missing required field(s): {', '.join(sorted(missing))}. "
+            "Re-run ingestion to populate the index record."
+        )
+
+    epoch_str: str = params["epoch"]
+    cadence_s: int = int(params["cadence_s"])
+    slot_count: int = int(group_payload["size"])
+
+    try:
+        epoch_dt = datetime.datetime.fromisoformat(epoch_str.replace("Z", "+00:00"))
+    except (ValueError, TypeError) as exc:
+        raise click.ClickException(
+            f"Group {group_name!r}: cannot parse epoch {epoch_str!r}: {exc}"
+        ) from exc
+
+    delta = datetime.timedelta(seconds=cadence_s)
+    return [(epoch_dt + i * delta).isoformat().replace("+00:00", "Z") for i in range(slot_count)]
+
+
 @index.command("show")
 @click.option("--target", required=True, help="Product Zarr URI to inspect.")
 @click.option("--product-name", required=True, help="Logical product name.")
 @click.option("--json", "as_json", is_flag=True, help="Emit the raw record as JSON.")
-def show_cmd(target: str, product_name: str, as_json: bool) -> None:
+@click.option(
+    "--derived/--no-derived",
+    default=False,
+    is_flag=True,
+    help=(
+        "Compute and display derived coordinates for RegularTimeAxis groups at read time. "
+        "No-op for IrregularTimeAxis and IntegerAxis groups. "
+        "NEVER persists anything."
+    ),
+)
+def show_cmd(target: str, product_name: str, as_json: bool, derived: bool) -> None:
     """Show the current resolved-index record."""
 
     manager = _manager(target, product_name)
@@ -148,6 +197,31 @@ def show_cmd(target: str, product_name: str, as_json: bool) -> None:
         click.echo("  group kind size")
         for group_name, kind, size in _group_rows(record.index):
             click.echo(f"  {group_name} {kind} {size}")
+        if derived:
+            groups = record.index.get("groups", {})
+            if not isinstance(groups, dict):
+                return
+            any_regular = False
+            for group_name, group_payload in sorted(groups.items()):
+                if not isinstance(group_payload, dict):
+                    continue
+                coords = _derived_coordinates_for_group(group_name, group_payload)
+                if coords is None:
+                    click.echo(
+                        f"  note: group {group_name!r} is not a regular_time axis; "
+                        "--derived is a no-op for this group",
+                        err=True,
+                    )
+                    continue
+                any_regular = True
+                click.echo(f"derived_coordinates[{group_name!r}]:")
+                for coord in coords:
+                    click.echo(f"  {coord}")
+            if not any_regular:
+                click.echo(
+                    "note: no regular_time groups found; --derived produced no output",
+                    err=True,
+                )
     finally:
         manager.close()
 

--- a/src/firecube/cli/zarr.py
+++ b/src/firecube/cli/zarr.py
@@ -62,7 +62,12 @@ from firecube.core.storage.session import StorageSession
 from firecube.core.zarr.layers import DEFAULT_MULTIRES_RESOLUTIONS
 from firecube.core.zarr.multires import MultiresConfig, ZarrMultiresBuilder
 from firecube.core.zarr.validation import validate_group_with_fs
-from firecube.ingestor.api import IngestContext, PluginContext, RuntimeIngestContext
+from firecube.ingestor.api import (
+    IngestContext,
+    PluginContext,
+    RuntimeIngestContext,
+    canonical_coordinate_value,
+)
 from firecube.ingestor.errors import ConfigurationError
 from firecube.ingestor.registry import loader as ingestor_loader
 from firecube.ingestor.registry.loader import discover_ingestors
@@ -742,6 +747,18 @@ See also: firecube zarr slots, firecube zarr validate
     type=TypedOptionsParam(),
     help="Plugin/engine option in key=value form.",
 )
+@click.option(
+    "--dry-run/--no-dry-run",
+    "dry_run",
+    default=False,
+    is_flag=True,
+    help=(
+        "Perform discovery and manifest computation only. "
+        "Prints the resolved-index manifest as JSON to stdout. "
+        "Makes zero filesystem mutations: no arrays are created, "
+        "no index files are written, no claims are acquired."
+    ),
+)
 @click.pass_context
 def preallocate(
     ctx: click.Context,
@@ -753,6 +770,7 @@ def preallocate(
     write_mode: str,
     input_data: str | None,
     option: tuple[tuple[str, object], ...],
+    dry_run: bool,
 ) -> None:
     """Pre-allocate Zarr arrays for parallel ingestion.
 
@@ -765,6 +783,7 @@ def preallocate(
     from firecube.core.controlplane import ChunkManager
     from firecube.core.controlplane.manager import check_legacy_index_record
     from firecube.core.errors import LegacyIndexRecordError
+    from firecube.core.index_spec import AUTO, IrregularTimeAxis
     from firecube.core.uris import storage_uri_from_target
     from firecube.core.zarr.region_writer import RegionZarrWriter
     from firecube.ingestor.api import BaseIngestor, IndexedRegionStrategy
@@ -835,6 +854,14 @@ def preallocate(
             raise click.ClickException(
                 f"Plugin '{plugin}' failed to resolve index_spec: {exc}"
             ) from exc
+
+        if dry_run:
+            record = resolved_index.as_resolved_index_record(
+                run_id="dry-run", recorded_at="dry-run"
+            )
+            click.echo(record.to_json_bytes().decode("utf-8"))
+            return
+
         global_expected = {group: resolved_index.size(group) for group in resolved_index.groups}
 
         record = resolved_index.as_resolved_index_record(run_id="preallocate")
@@ -986,6 +1013,15 @@ def preallocate(
                     )
                     click.echo(f"array {array_path}: created")
 
+                axis = resolved_index.axis_for(group_name)
+                if isinstance(axis, IrregularTimeAxis) and axis.values is not AUTO:
+                    _materialize_irregular_coord_array(
+                        writer=writer,
+                        root=root,
+                        group_name=group_name,
+                        axis=axis,
+                    )
+
         summary = {
             "status": "ok",
             "plugin": plugin,
@@ -1067,6 +1103,69 @@ def _array_schema_mismatches(
             mismatches.append(f"chunks: expected {tuple(expected_chunks)}, found {found_chunks}")
 
     return mismatches
+
+
+def _materialize_irregular_coord_array(
+    *,
+    writer: Any,
+    root: Any,
+    group_name: str,
+    axis: Any,
+) -> None:
+    """Write ``axis.values`` densely at ``{group_name}/{axis.coordinate}``.
+
+    Dtype ``datetime64[ns]``, shape ``(len(axis.values),)``. Idempotent on
+    matching state; a shape/dtype/values divergence raises
+    ``click.ClickException`` so the operator sees the conflict before any
+    downstream write.
+    """
+    values = axis.values
+    slot_count = len(values)
+    coord_data = np.array([_coord_to_datetime64(value) for value in values], dtype="datetime64[ns]")
+    coord_path = f"{group_name}/{axis.coordinate}"
+
+    existing = _existing_array(root, coord_path)
+    if existing is not None:
+        expected_dtype = np.dtype("datetime64[ns]")
+        mismatches = _array_schema_mismatches(
+            existing=existing,
+            expected_shape=(slot_count,),
+            expected_dtype=expected_dtype,
+            expected_chunks=None,
+        )
+        if mismatches:
+            diff = "; ".join(mismatches)
+            raise click.ClickException(
+                f"Existing coord array mismatch: '{coord_path}' has mismatches.\n"
+                f"Mismatch: {diff}\n"
+                "Either delete it or update the plugin's IrregularTimeAxis to match."
+            )
+        existing_values = np.asarray(existing[:])
+        if not np.array_equal(existing_values, coord_data):
+            raise click.ClickException(
+                f"Existing coord array '{coord_path}' has values that differ from the "
+                "resolved IrregularTimeAxis. Delete it or align the plugin's axis values."
+            )
+        click.echo(f"array {coord_path}: existing irregular coord array matches; no-op")
+        return
+
+    coord_arr = writer.ensure_group(
+        coord_path,
+        shape=(slot_count,),
+        dtype=np.dtype("datetime64[ns]"),
+        fill_value=np.datetime64("NaT", "ns"),
+        chunks=(max(1, min(256, slot_count)),),
+        dimension_names=(axis.coordinate,),
+    )
+    coord_arr[...] = coord_data
+    click.echo(f"array {coord_path}: created (irregular coord materialization)")
+
+
+def _coord_to_datetime64(value: Any) -> np.datetime64:
+    canonical = canonical_coordinate_value(value)
+    if isinstance(canonical, str):
+        canonical = canonical.removesuffix("Z")
+    return np.datetime64(canonical, "ns")
 
 
 def _query_slots_coverage(

--- a/src/firecube/core/api.py
+++ b/src/firecube/core/api.py
@@ -19,7 +19,16 @@ Plugins should import from this module rather than accessing core internals dire
 
 from firecube.core.config import StorageConfig
 from firecube.core.controlplane import RunInfo, describe_control_plane
-from firecube.core.controlplane.types import ResolvedIndexRecord
+from firecube.core.controlplane.types import (
+    ItemManifestEntry,
+    ResolvedIndexRecord,
+    validate_manifest_entries,
+)
+from firecube.core.errors import (
+    DuplicateIrregularCoordinateError,
+    MissingIrregularCoordinateError,
+    NoDiscoveredItemsError,
+)
 from firecube.core.filesystem import (
     create_filesystem_for_uri,
     delete_path,
@@ -36,7 +45,15 @@ from firecube.core.formats import (
     rename_time_dim,
 )
 from firecube.core.index_resolve import ResolvedIndex, coerce_to_epoch_s, resolve_index_spec
-from firecube.core.index_spec import AxisSpec, IndexSpec, IntegerAxis, ItemInfo, RegularTimeAxis
+from firecube.core.index_spec import (
+    AUTO,
+    AxisSpec,
+    IndexSpec,
+    IntegerAxis,
+    IrregularTimeAxis,
+    ItemInfo,
+    RegularTimeAxis,
+)
 from firecube.core.intake import CatalogGroupInfo
 from firecube.core.product import ensure_product_uri, resolve_dataset_target
 from firecube.core.slot_index import (
@@ -58,11 +75,17 @@ from firecube.core.zarr.time_decode import decode_time_array
 from firecube.core.zarr.validation import read_chunk_grid_with_shards
 
 __all__ = [
+    "AUTO",
     "AxisSpec",
     "CatalogGroupInfo",
+    "DuplicateIrregularCoordinateError",
     "IndexSpec",
     "IntegerAxis",
+    "IrregularTimeAxis",
     "ItemInfo",
+    "ItemManifestEntry",
+    "MissingIrregularCoordinateError",
+    "NoDiscoveredItemsError",
     "RegionZarrWriterProtocol",
     "RegularTimeAxis",
     "ResolvedIndex",
@@ -97,4 +120,5 @@ __all__ = [
     "require_tensogram",
     "resolve_dataset_target",
     "resolve_index_spec",
+    "validate_manifest_entries",
 ]

--- a/src/firecube/core/controlplane/types.py
+++ b/src/firecube/core/controlplane/types.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import hashlib
 import json
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal
@@ -97,6 +98,148 @@ def canonical_index_bytes(index: dict[str, Any]) -> bytes:
     return json.dumps(index, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
         "utf-8"
     )
+
+
+SourceRefKind = Literal["path", "uri", "identifier"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ItemManifestEntry:
+    """A single entry in a content-addressed item manifest.
+
+    Manifest entries let the engine plan an ``IrregularTimeAxis`` axis once and
+    hand deterministic per-item work to parallel workers without a second
+    discovery pass. Each entry pins one source item to one axis coordinate via
+    a content-address (``identity_hash``) plus a caller-defined stable
+    reference (``source_ref``).
+
+    The manifest is deterministic-planning-and-worker-reuse data only. It is
+    NOT a general provenance system: no timestamps, user metadata, plugin
+    versions, or processing lineage are stored here. Add those to a separate
+    subsystem if they are ever needed.
+
+    Args:
+        identity_hash: Content-address of the item (SHA-256 hex of the item
+            contents, or a caller-defined stable identity string). Must be
+            unique within a manifest.
+        coordinate_value: The resolved axis coordinate for this item. Type
+            depends on the axis kind (ISO string, integer, etc.). Must be
+            JSON-native (``str``, ``int``, ``float``, ``bool``, ``None``);
+            non-native values will fail loudly at
+            :func:`canonical_index_bytes` serialisation.
+        source_ref: A stable reference the caller can dereference to load the
+            item at write time. Interpretation is fixed by ``source_ref_kind``.
+            Must be non-empty.
+        source_ref_kind: Declares how ``source_ref`` is interpreted, and the
+            stability contract the caller promises:
+
+            - ``"path"``: absolute filesystem path guaranteed stable for the
+              cube's lifetime.
+            - ``"uri"``: stable URL (e.g. ``s3://bucket/key``) guaranteed
+              dereferenceable for the cube's lifetime.
+            - ``"identifier"``: plugin-defined stable identifier resolvable by
+              the plugin's own logic for the cube's lifetime.
+
+            Callables that close over ``source_ref`` (e.g. lazy WriteIntent
+            payloads) are safe if and only if the plugin honours the declared
+            stability contract for the whole dispatch window.
+    """
+
+    identity_hash: str
+    coordinate_value: Any
+    source_ref: str
+    source_ref_kind: SourceRefKind
+
+    def to_canonical_dict(self) -> dict[str, Any]:
+        """Return the deterministic JSON-native dict for canonical serialisation."""
+
+        return {
+            "identity_hash": self.identity_hash,
+            "coordinate_value": self.coordinate_value,
+            "source_ref": self.source_ref,
+            "source_ref_kind": self.source_ref_kind,
+        }
+
+
+def validate_manifest_entries(entries: list[ItemManifestEntry]) -> None:
+    """Validate the invariants of a content-addressed item manifest.
+
+    Checks:
+
+    - Every ``source_ref`` is non-empty.
+    - No two entries share the same ``identity_hash``.
+    - No two entries share the same ``coordinate_value`` (pairwise distinct).
+
+    Args:
+        entries: The manifest entries to validate.
+
+    Raises:
+        ValueError: On any invariant violation, with a message naming the
+            duplicated value or the offending entry.
+    """
+
+    seen_hashes: set[str] = set()
+    seen_coords: list[Any] = []
+    for entry in entries:
+        if not entry.source_ref:
+            raise ValueError(
+                "ItemManifestEntry.source_ref must be non-empty "
+                f"(identity_hash={entry.identity_hash!r})"
+            )
+        if entry.identity_hash in seen_hashes:
+            raise ValueError(
+                f"duplicate identity_hash in manifest entries: {entry.identity_hash!r}"
+            )
+        seen_hashes.add(entry.identity_hash)
+        # coordinate_value equality is checked linearly — the values may be
+        # unhashable JSON structures (e.g. list, dict) so a set is unsafe.
+        for existing in seen_coords:
+            if existing == entry.coordinate_value:
+                raise ValueError(
+                    f"duplicate coordinate_value in manifest entries: {entry.coordinate_value!r}"
+                )
+        seen_coords.append(entry.coordinate_value)
+
+
+def compute_resolved_index_identity_hash(
+    index: dict[str, Any],
+    items: Sequence[ItemManifestEntry] | Sequence[dict[str, Any]] | None = None,
+) -> str:
+    """Compute the SHA-256 identity hash for a resolved-index record.
+
+    ASYMMETRIC by design (byte-parity requirement): when ``items`` is ``None``
+    the hash is byte-identical to pre-manifest records
+    (``sha256(canonical_index_bytes(index))``). When ``items`` is present,
+    both ``index`` and the sorted ``items`` list fold into the hash. This
+    preserves the ``identity_hash`` of existing ``RegularTimeAxis`` and
+    ``IntegerAxis`` cubes across the schema addition and lets the manifest
+    act as a freeze-detection mechanism for ``IrregularTimeAxis`` cubes:
+    adding or removing an item changes the recorded hash.
+
+    Items are sorted by ``identity_hash`` before hashing so the resulting
+    value is invariant under input order.
+
+    Args:
+        index: The resolved-index payload dict (as returned by
+            ``ResolvedIndex.canonical_index_payload``).
+        items: Optional manifest entries. Accepts either
+            ``ItemManifestEntry`` instances (canonicalised via
+            ``entry.to_canonical_dict()``) or already-canonicalised dicts
+            (as produced by :meth:`ResolvedIndexRecord.from_json_bytes`).
+
+    Returns:
+        Lowercase-hex SHA-256 digest (64 characters).
+    """
+
+    if items is None:
+        return hashlib.sha256(canonical_index_bytes(index)).hexdigest()
+    items_dicts: list[dict[str, Any]] = [
+        entry.to_canonical_dict() if isinstance(entry, ItemManifestEntry) else entry
+        for entry in items
+    ]
+    sorted_items = sorted(items_dicts, key=lambda entry: entry["identity_hash"])
+    combined = {"index": index, "items": sorted_items}
+    return hashlib.sha256(canonical_index_bytes(combined)).hexdigest()
 
 
 @dataclass(frozen=True, slots=True)
@@ -422,13 +565,21 @@ class DeletionPlan:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class ResolvedIndexRecord:
-    """On-disk record for an engine-resolved index payload."""
+    """On-disk record for an engine-resolved index payload.
+
+    Optional ``items`` carries a content-addressed manifest for
+    ``IrregularTimeAxis`` cubes. It is omitted from the wire format and
+    ``identity_hash`` for regular / integer axes so those cubes stay
+    byte-identical to pre-manifest records (see
+    :func:`compute_resolved_index_identity_hash`).
+    """
 
     schema_version: str = "v1"
     recorded_at: str
     recorded_by_run_id: str
     identity_hash: str
     index: dict[str, Any]
+    items: tuple[ItemManifestEntry, ...] | None = None
 
     def __post_init__(self) -> None:
         if len(self.identity_hash) != 64 or not all(
@@ -438,17 +589,29 @@ class ResolvedIndexRecord:
                 f"identity_hash must be a 64-character lowercase hex string, "
                 f"got {self.identity_hash!r} (length {len(self.identity_hash)})"
             )
+        if self.items is not None and not isinstance(self.items, tuple):
+            object.__setattr__(self, "items", tuple(self.items))
 
     def to_json_bytes(self) -> bytes:
-        """Serialise to the on-disk wire format (deterministic, UTF-8 JSON)."""
+        """Serialise to the on-disk wire format (deterministic, UTF-8 JSON).
 
-        payload = {
+        ASYMMETRIC: the ``items`` key is omitted when
+        :attr:`items` is ``None`` so records for regular / integer axes serialise
+        byte-identically to pre-manifest records.
+        """
+
+        payload: dict[str, Any] = {
             "schema_version": self.schema_version,
             "recorded_at": self.recorded_at,
             "recorded_by_run_id": self.recorded_by_run_id,
             "identity_hash": self.identity_hash,
             "index": self.index,
         }
+        if self.items is not None:
+            payload["items"] = sorted(
+                (entry.to_canonical_dict() for entry in self.items),
+                key=lambda entry: str(entry["coordinate_value"]),
+            )
         return json.dumps(
             payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
         ).encode("utf-8")
@@ -487,7 +650,9 @@ class ResolvedIndexRecord:
             index = parsed["index"]
             if not isinstance(index, dict):
                 raise TypeError(f"expected dict, got {type(index).__name__}")
-            recomputed = hashlib.sha256(canonical_index_bytes(index)).hexdigest()
+            items_raw = parsed.get("items")
+            items_parsed = _parse_manifest_items(items_raw) if items_raw is not None else None
+            recomputed = compute_resolved_index_identity_hash(index, items_parsed)
         except (TypeError, ValueError) as exc:
             raise ManifestError(
                 f"resolved-index record has invalid index structure: {exc}"
@@ -507,7 +672,38 @@ class ResolvedIndexRecord:
             recorded_by_run_id=parsed["recorded_by_run_id"],
             identity_hash=stored_hash,
             index=index,
+            items=tuple(items_parsed) if items_parsed is not None else None,
         )
+
+
+def _parse_manifest_items(raw: Any) -> list[ItemManifestEntry]:
+    """Parse a JSON-decoded ``items`` field back into ``ItemManifestEntry`` instances."""
+
+    if not isinstance(raw, list):
+        raise TypeError(f"items must be a JSON array, got {type(raw).__name__}")
+    parsed: list[ItemManifestEntry] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise TypeError(f"items[{i}] must be a JSON object, got {type(entry).__name__}")
+        missing = {"identity_hash", "coordinate_value", "source_ref", "source_ref_kind"} - set(
+            entry
+        )
+        if missing:
+            raise ValueError(f"items[{i}] missing required fields: {sorted(missing)}")
+        kind = entry["source_ref_kind"]
+        if kind not in {"path", "uri", "identifier"}:
+            raise ValueError(
+                f"items[{i}].source_ref_kind must be 'path', 'uri', or 'identifier'; got {kind!r}"
+            )
+        parsed.append(
+            ItemManifestEntry(
+                identity_hash=entry["identity_hash"],
+                coordinate_value=entry["coordinate_value"],
+                source_ref=entry["source_ref"],
+                source_ref_kind=kind,
+            )
+        )
+    return parsed
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/firecube/core/errors.py
+++ b/src/firecube/core/errors.py
@@ -14,6 +14,8 @@
 
 """Shared exception types for core storage/manifest operations."""
 
+from typing import Any
+
 
 class FirecubeError(Exception):
     """Base exception for Firecube runtime errors."""
@@ -26,6 +28,49 @@ class ConfigurationError(FirecubeError):
     malformed options, missing required inputs, or an existing store whose
     layout conflicts with the plugin's declaration.
     """
+
+
+class MissingIrregularCoordinateError(ConfigurationError):
+    """An irregular time-axis item lacks a resolvable coordinate."""
+
+    def __init__(self, coordinate_name: str, item_id: str | int | None) -> None:
+        self.coordinate_name = coordinate_name
+        self.item_id = item_id
+        super().__init__(
+            f"IrregularTimeAxis discovery: item {item_id} has no resolvable coordinate for '{coordinate_name}'"
+        )
+
+
+class DuplicateIrregularCoordinateError(ConfigurationError):
+    """Two discovered items resolve to the same irregular-axis coordinate."""
+
+    def __init__(
+        self,
+        coordinate_name: str,
+        coordinate_value: Any,
+        first_item: str,
+        second_item: str,
+    ) -> None:
+        self.coordinate_name = coordinate_name
+        self.coordinate_value = coordinate_value
+        self.first_item = first_item
+        self.second_item = second_item
+        super().__init__(
+            f"IrregularTimeAxis discovery for '{coordinate_name}': items "
+            f"{first_item!r} and {second_item!r} both resolve to coordinate "
+            f"{coordinate_value!r}; coordinates must be unique"
+        )
+
+
+class NoDiscoveredItemsError(ConfigurationError):
+    """Discovery found no items for an irregular time axis."""
+
+    def __init__(self, coordinate_name: str, source_ref: str | None) -> None:
+        self.coordinate_name = coordinate_name
+        self.source_ref = source_ref
+        super().__init__(
+            f"IrregularTimeAxis discovery for '{coordinate_name}': no items found in source '{source_ref}'"
+        )
 
 
 class SchemaDriftError(FirecubeError):

--- a/src/firecube/core/index_resolve.py
+++ b/src/firecube/core/index_resolve.py
@@ -9,15 +9,27 @@ from __future__ import annotations
 
 import datetime as dt
 import functools
-import hashlib
 import numbers
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, cast, runtime_checkable
 
 import numpy as np
 
-from firecube.core.controlplane.types import ResolvedIndexRecord, canonical_index_bytes
-from firecube.core.index_spec import AxisSpec, IndexSpec, IntegerAxis, RegularTimeAxis
+from firecube.core.controlplane.types import (
+    ItemManifestEntry,
+    ResolvedIndexRecord,
+    compute_resolved_index_identity_hash,
+)
+from firecube.core.index_spec import (
+    AUTO,
+    AxisSpec,
+    IndexSpec,
+    IntegerAxis,
+    IrregularTimeAxis,
+    RegularTimeAxis,
+    _canonical_coordinate_value,
+)
 from firecube.core.slot_index import (
     SlotAxis,
     SlotIndexModel,
@@ -260,6 +272,37 @@ class IntegerResolver:
         return coord
 
 
+@dataclass(frozen=True)
+class IrregularTimeResolver:
+    """Resolver for an ``IrregularTimeAxis``.
+
+    Coordinates map to explicit axis values.
+    """
+
+    axis: IrregularTimeAxis
+
+    def _values(self) -> tuple[Any, ...]:
+        values = self.axis.values
+        if values is AUTO:
+            raise ExtentUnknownError("irregular axis has no explicit values")
+        return tuple(cast(Sequence[Any], values))
+
+    @property
+    def size(self) -> int:
+        return len(self._values())
+
+    def position(self, coordinate: Any) -> int:
+        # O(n) scan; acceptable for hundreds of items. For tens of thousands,
+        # replace with a cached dict[value, index] lookup.
+        try:
+            return self._values().index(coordinate)
+        except ValueError as exc:
+            raise ValueError(f"coordinate {coordinate!r} is not present in axis values") from exc
+
+    def coordinate(self, index: int) -> Any:
+        return self._values()[index]
+
+
 def _resolver_for(axis: AxisSpec) -> AxisResolver:
     """Dispatch an axis specification to its resolver.
 
@@ -277,6 +320,8 @@ def _resolver_for(axis: AxisSpec) -> AxisResolver:
     """
     if isinstance(axis, RegularTimeAxis):
         return RegularTimeResolver(axis=axis)
+    if isinstance(axis, IrregularTimeAxis):
+        return IrregularTimeResolver(axis=axis)
     if isinstance(axis, IntegerAxis):
         return IntegerResolver(axis=axis)
     raise NotImplementedError(
@@ -301,10 +346,15 @@ class ResolvedIndex:
         self,
         spec: IndexSpec,
         resolvers: dict[str, AxisResolver],
+        *,
+        items: Sequence[ItemManifestEntry] | None = None,
     ) -> None:
         self._spec = spec
         self._resolvers = resolvers
         self._groups: tuple[str, ...] = tuple(sorted(resolvers))
+        self.items: tuple[ItemManifestEntry, ...] | None = (
+            tuple(items) if items is not None else None
+        )
 
     @property
     def groups(self) -> tuple[str, ...]:
@@ -335,6 +385,22 @@ class ResolvedIndex:
             if isinstance(axis, IntegerAxis):
                 groups[group] = {"kind": "integer", "size": resolver.size, "params": {}}
                 continue
+            if isinstance(axis, IrregularTimeAxis):
+                values = axis.values
+                if values is AUTO:
+                    raise ExtentUnknownError("irregular axis has no explicit values")
+                groups[group] = {
+                    "kind": "irregular_time",
+                    "size": resolver.size,
+                    "params": {
+                        "coordinate": axis.coordinate,
+                        "values": [
+                            _canonical_coordinate_value(value)
+                            for value in cast(Sequence[Any], values)
+                        ],
+                    },
+                }
+                continue
             raise NotImplementedError(
                 f"No canonical resolved-index payload for axis type {type(axis).__name__!r}"
             )
@@ -353,20 +419,21 @@ class ResolvedIndex:
         if recorded_at is None:
             recorded_at = dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z")
         index = self.canonical_index_payload()
-        identity_hash = hashlib.sha256(canonical_index_bytes(index)).hexdigest()
+        identity_hash = compute_resolved_index_identity_hash(index, self.items)
         return ResolvedIndexRecord(
             schema_version="v1",
             recorded_at=recorded_at,
             recorded_by_run_id=run_id,
             identity_hash=identity_hash,
             index=index,
+            items=self.items,
         )
 
     @functools.cached_property
     def identity_hash(self) -> str:
         """Content-addressed hash of the canonical resolved-index payload."""
 
-        return hashlib.sha256(canonical_index_bytes(self.canonical_index_payload())).hexdigest()
+        return compute_resolved_index_identity_hash(self.canonical_index_payload(), self.items)
 
     def size(self, group: str) -> int:
         """Total number of slots for the given group.
@@ -407,6 +474,11 @@ class ResolvedIndex:
         """
         return self._resolvers[group].coordinate(index)
 
+    def axis_for(self, group: str) -> AxisSpec | None:
+        """Return the axis spec for the named group, or None if not present."""
+
+        return self._spec.groups.get(group)
+
     def as_legacy_slot_index_model(self) -> SlotIndexModel | None:
         """Build a ``SlotIndexModel`` for byte-parity with existing cubes.
 
@@ -438,7 +510,12 @@ class ResolvedIndex:
         )
 
 
-def resolve_index_spec(spec: IndexSpec, *, time_dim_name: str) -> ResolvedIndex:
+def resolve_index_spec(
+    spec: IndexSpec,
+    *,
+    time_dim_name: str,
+    items: Sequence[ItemManifestEntry] | None = None,
+) -> ResolvedIndex:
     """Resolve an ``IndexSpec`` into a ``ResolvedIndex``.
 
     Validates that each ``RegularTimeAxis.coordinate`` matches
@@ -461,12 +538,15 @@ def resolve_index_spec(spec: IndexSpec, *, time_dim_name: str) -> ResolvedIndex:
 
     resolvers: dict[str, AxisResolver] = {}
     for group, axis in spec.groups.items():
-        if isinstance(axis, RegularTimeAxis) and axis.coordinate != time_dim_name:
+        if (
+            isinstance(axis, (RegularTimeAxis, IrregularTimeAxis))
+            and axis.coordinate != time_dim_name
+        ):
             raise ConfigurationError(
-                f"Group {group!r}: RegularTimeAxis.coordinate={axis.coordinate!r} "
+                f"Group {group!r}: {type(axis).__name__}.coordinate={axis.coordinate!r} "
                 f"does not match time_dim_name={time_dim_name!r}. "
                 "Set coordinate to match the plugin's time dimension name."
             )
         resolvers[group] = _resolver_for(axis)
 
-    return ResolvedIndex(spec=spec, resolvers=resolvers)
+    return ResolvedIndex(spec=spec, resolvers=resolvers, items=items)

--- a/src/firecube/core/index_spec.py
+++ b/src/firecube/core/index_spec.py
@@ -4,16 +4,20 @@ Plugin authors declare an ``IndexSpec`` describing the time-axis structure of
 their product. The engine resolves it once into a ``ResolvedIndex`` (see
 ``firecube.core.index_resolve``) and caches it for the run.
 
-``RegularTimeAxis`` and ``IntegerAxis`` are currently shipped. Additional axis
-types are planned as additive extensions in future releases.
+``RegularTimeAxis``, ``IntegerAxis``, and ``IrregularTimeAxis`` are currently
+shipped. Additional axis types are planned as additive extensions in future
+releases.
 """
 
 from __future__ import annotations
 
+import datetime as dt
 import numbers
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Final, Literal
+
+import numpy as np
 
 from firecube.core.slot_index import (
     epoch_s_to_iso,
@@ -25,11 +29,52 @@ from firecube.core.slot_index import (
 class AxisSpec:
     """Marker base for axis specifications.
 
-    ``RegularTimeAxis`` and ``IntegerAxis`` are the current implementations.
-    Additional axis types are planned as additive extensions in future
-    releases. The resolver in ``index_resolve.py`` dispatches on
-    ``isinstance`` -- no abstract methods are required here.
+    ``RegularTimeAxis``, ``IntegerAxis``, and ``IrregularTimeAxis`` are the
+    current implementations. Additional axis types are planned as additive
+    extensions in future releases. The resolver in ``index_resolve.py``
+    dispatches on ``isinstance`` -- no abstract methods are required here.
     """
+
+
+class _AutoSentinel:
+    """Sentinel type for the ``AUTO`` discovery mode.
+
+    Pass the module-level ``AUTO`` singleton as ``values`` to
+    ``IrregularTimeAxis`` to let the engine discover coordinate values at
+    planning time by calling ``inspect_item`` on every source item before
+    preallocate. Do not construct this class directly; use ``AUTO``.
+    """
+
+    def __repr__(self) -> str:
+        return "AUTO"
+
+
+# Like ``dataclasses.MISSING``. PEP 661 discussed sentinel objects and rejected
+# a heavier enum-style approach for this sort of module-level singleton.
+AUTO: Final[_AutoSentinel] = _AutoSentinel()
+"""Sentinel that tells ``IrregularTimeAxis`` to discover coordinate values at planning time.
+
+Set ``IrregularTimeAxis(coordinate=..., values=AUTO)`` to let the engine call
+``inspect_item`` on every source item before preallocate and build the axis
+from the returned coordinates. The engine sorts discovered coordinates and
+assigns each a slot index in ascending order.
+
+Importable from ``firecube.core.api`` and ``firecube.ingestor.api``.
+"""
+
+
+def _canonical_coordinate_value(value: Any) -> Any:
+    if isinstance(value, np.datetime64):
+        return np.datetime_as_string(value, unit="ns", timezone="UTC")
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dt.datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=dt.UTC)
+        else:
+            value = value.astimezone(dt.UTC)
+        return value.isoformat().replace("+00:00", "Z")
+    return value
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -164,6 +209,47 @@ class IntegerAxis(AxisSpec):
         object.__setattr__(self, "slot_count", int(self.slot_count))
         if self.slot_count < 1:
             raise ValueError(f"slot_count must be >= 1, got {self.slot_count!r}")
+
+
+@dataclass(frozen=True, kw_only=True)
+class IrregularTimeAxis(AxisSpec):
+    """A time axis with explicit coordinate values.
+
+    Args:
+        coordinate: Name of the time coordinate dimension. Must match
+            ``time_dim_name`` when the axis is resolved.
+        values: Explicit coordinate values for the axis, or ``AUTO`` to
+            discover them later. Accepts any non-empty ``Sequence`` of
+            hashable comparable values, typically ``datetime`` objects,
+            ``numpy.datetime64`` values, or integers. Duplicate values raise
+            ``ValueError``. A non-``Sequence`` raises ``TypeError``. Empty input
+            raises ``ValueError``. The engine sorts concrete values ascending
+            and assigns slot indices in that order.
+
+    Note:
+        ``AUTO`` triggers planning-time discovery: the engine scans the full
+        source set via ``inspect_item`` before preallocate so it can discover
+        coordinates and sort them. That costs a full source pass.
+    """
+
+    coordinate: str
+    """Name of the time coordinate dimension."""
+
+    values: Sequence[Any] | _AutoSentinel
+    """Explicit coordinate values, or ``AUTO`` for planning-time discovery."""
+
+    def __post_init__(self) -> None:
+        if self.values is AUTO:
+            return
+        if isinstance(self.values, (str, bytes)):
+            raise TypeError("values must be a sequence of coordinate values, not a string or bytes")
+        if not isinstance(self.values, Sequence):
+            raise TypeError("values must be AUTO or a non-empty Sequence")
+        if not self.values:
+            raise ValueError("values must be a non-empty Sequence")
+        if len(set(self.values)) != len(self.values):
+            raise ValueError("values must not contain duplicates")
+        object.__setattr__(self, "values", tuple(self.values))
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/firecube/ingestor/api.py
+++ b/src/firecube/ingestor/api.py
@@ -23,15 +23,25 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from firecube.core.api import (
+    AUTO,
     AxisSpec,
+    DuplicateIrregularCoordinateError,
     IndexSpec,
     IntegerAxis,
+    IrregularTimeAxis,
     ItemInfo,
+    ItemManifestEntry,
+    MissingIrregularCoordinateError,
+    NoDiscoveredItemsError,
     RegularTimeAxis,
     ResolvedIndex,
     ResolvedIndexRecord,
+    validate_manifest_entries,
 )
 from firecube.core.controlplane import SpanCoverage, WriteDomain
+from firecube.core.index_spec import (
+    _canonical_coordinate_value as canonical_coordinate_value,  # noqa: F401
+)
 from firecube.core.intake import CatalogGroupInfo
 from firecube.ingestor.config.engine import EngineConfig, config_keys
 from firecube.ingestor.contracts.interfaces import (
@@ -107,6 +117,7 @@ if TYPE_CHECKING:
     from firecube.ingestor.templates.generic import GenericParquetIngestor, GenericZarrIngestor
     from firecube.ingestor.templates.generic_tensogram import GenericTensogramIngestor
 __all__ = [
+    "AUTO",
     "AppendStrategy",
     "AppendWriteStrategy",
     "AxisSpec",
@@ -115,6 +126,7 @@ __all__ = [
     "ConfigurationError",
     "DatasetProducer",
     "DirectZarrIngestor",
+    "DuplicateIrregularCoordinateError",
     "EngineConfig",
     "GenericParquetIngestor",
     "GenericTensogramIngestor",
@@ -127,9 +139,13 @@ __all__ = [
     "Ingestor",
     "IngestorError",
     "IntegerAxis",
+    "IrregularTimeAxis",
     "ItemInfo",
+    "ItemManifestEntry",
     "LocalSourceFile",
     "ManifestError",
+    "MissingIrregularCoordinateError",
+    "NoDiscoveredItemsError",
     "OutputPaths",
     "ParquetTemplateConfig",
     "PipelineBatch",
@@ -173,6 +189,7 @@ __all__ = [
     "merge_batch_metrics",
     "register_ingestor",
     "validate_chunk_alignment",
+    "validate_manifest_entries",
     "validate_slot_range",
     "verify_dim_compatibility",
     "warn_if_misaligned",

--- a/src/firecube/ingestor/runtime/index_binding.py
+++ b/src/firecube/ingestor/runtime/index_binding.py
@@ -7,16 +7,31 @@ with the ingestor runtime. It is the only place that knows about both
 
 from __future__ import annotations
 
+import hashlib
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
+from itertools import pairwise
+from pathlib import Path
 from typing import Any
 
+from firecube.core.controlplane.types import (
+    ItemManifestEntry,
+    SourceRefKind,
+    validate_manifest_entries,
+)
+from firecube.core.errors import (
+    DuplicateIrregularCoordinateError,
+    MissingIrregularCoordinateError,
+    NoDiscoveredItemsError,
+)
 from firecube.core.index_resolve import ResolvedIndex, resolve_index_spec
-from firecube.core.index_spec import IndexSpec
+from firecube.core.index_spec import AUTO, IndexSpec, IrregularTimeAxis, _canonical_coordinate_value
 from firecube.ingestor.errors import ConfigurationError
 
 logger = logging.getLogger(__name__)
+
+_HASH_PREFIX_BYTES = 64 * 1024
 
 
 @dataclass(frozen=True)
@@ -64,8 +79,129 @@ def resolve_index_spec_for_ingestor(ingestor: Any, ctx: Any) -> IndexBinding | N
         return None
 
     time_dim_name: str = ingestor._resolve_time_dim_name()
-    resolved = resolve_index_spec(spec, time_dim_name=time_dim_name)
-    return IndexBinding(spec=spec, resolved=resolved)
+    resolved_spec = spec
+    manifest: tuple[ItemManifestEntry, ...] | None = None
+    auto_axis = _first_auto_irregular_axis(spec)
+    if auto_axis is not None:
+        discovered_axis, manifest = _discover_auto_irregular_axis(auto_axis, ingestor, ctx)
+        resolved_spec = _replace_auto_irregular_axes(spec, discovered_axis)
+
+    resolved = resolve_index_spec(resolved_spec, time_dim_name=time_dim_name, items=manifest)
+    return IndexBinding(spec=resolved_spec, resolved=resolved)
+
+
+def _first_auto_irregular_axis(spec: IndexSpec) -> IrregularTimeAxis | None:
+    for axis in spec.groups.values():
+        if isinstance(axis, IrregularTimeAxis) and axis.values is AUTO:
+            return axis
+    return None
+
+
+def _replace_auto_irregular_axes(spec: IndexSpec, discovered_axis: IrregularTimeAxis) -> IndexSpec:
+    groups = {
+        group: discovered_axis
+        if isinstance(axis, IrregularTimeAxis) and axis.values is AUTO
+        else axis
+        for group, axis in spec.groups.items()
+    }
+    return IndexSpec(name=spec.name, groups=groups, time_unit=spec.time_unit)
+
+
+def _discover_auto_irregular_axis(
+    axis: IrregularTimeAxis, ingestor: Any, ctx: Any
+) -> tuple[IrregularTimeAxis, tuple[ItemManifestEntry, ...]]:
+    """Discover concrete values and a manifest for ``IrregularTimeAxis(values=AUTO)``."""
+
+    discovered: list[tuple[Any, str, SourceRefKind, str]] = []
+    for item in _iter_runtime_items(ingestor, ctx):
+        source_ref, source_ref_kind = _source_ref(item)
+        try:
+            info = ingestor.inspect_item(item, ctx)
+        except Exception as exc:
+            raise MissingIrregularCoordinateError(axis.coordinate, source_ref) from exc
+        coordinate = getattr(info, "coordinate", info) if info is not None else None
+        if coordinate is None:
+            raise MissingIrregularCoordinateError(axis.coordinate, source_ref)
+        discovered.append((coordinate, source_ref, source_ref_kind, _item_identity_hash(item)))
+
+    if not discovered:
+        raise NoDiscoveredItemsError(axis.coordinate, _source_description(ctx))
+
+    discovered.sort(key=lambda entry: entry[0])
+    for current, next_ in pairwise(discovered):
+        if current[0] == next_[0]:
+            raise DuplicateIrregularCoordinateError(
+                axis.coordinate,
+                current[0],
+                current[1],
+                next_[1],
+            )
+
+    manifest = tuple(
+        ItemManifestEntry(
+            identity_hash=identity_hash,
+            coordinate_value=_canonical_coordinate_value(coordinate),
+            source_ref=source_ref,
+            source_ref_kind=source_ref_kind,
+        )
+        for coordinate, source_ref, source_ref_kind, identity_hash in discovered
+    )
+    validate_manifest_entries(list(manifest))
+    return IrregularTimeAxis(
+        coordinate=axis.coordinate, values=tuple(row[0] for row in discovered)
+    ), manifest
+
+
+def _iter_runtime_items(ingestor: Any, ctx: Any) -> Iterable[Any]:
+    for item in ingestor.discover_source_files(ctx):
+        if ingestor.filter_item(item, ctx):
+            yield item
+
+
+def _source_description(ctx: Any) -> str | None:
+    source = getattr(ctx, "source", None)
+    return str(source) if source is not None else None
+
+
+def _source_ref(item: Any) -> tuple[str, SourceRefKind]:
+    uri = getattr(item, "uri", None)
+    if isinstance(uri, str) and uri:
+        return uri, "uri"
+    local_path = getattr(item, "local_path", None)
+    if callable(local_path):
+        path = local_path()
+        if path is not None:
+            return str(Path(str(path)).resolve()), "path"
+    text = str(item)
+    if "://" in text:
+        return text, "uri"
+    try:
+        path = Path(text).resolve()
+    except TypeError:
+        return text, "identifier"
+    if path.exists():
+        return str(path), "path"
+    return text, "identifier"
+
+
+def _item_identity_hash(item: Any) -> str:
+    source_ref, source_ref_kind = _source_ref(item)
+    if source_ref_kind != "path":
+        return hashlib.sha256(f"{source_ref_kind}\0{source_ref}".encode()).hexdigest()
+    return _path_identity_hash(source_ref)
+
+
+def _path_identity_hash(path: str) -> str:
+    local = Path(path)
+    stat = local.stat()
+    digest = hashlib.sha256()
+    digest.update(str(stat.st_size).encode("ascii"))
+    digest.update(b"\0")
+    digest.update(str(stat.st_mtime_ns).encode("ascii"))
+    digest.update(b"\0")
+    with local.open("rb") as handle:
+        digest.update(hashlib.sha256(handle.read(_HASH_PREFIX_BYTES)).hexdigest().encode("ascii"))
+    return digest.hexdigest()
 
 
 def filter_items_by_index(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,7 @@ def pytest_sessionstart(session):
         ("index_spec_test_plugin", "index_spec_test_plugin"),
         ("index_spec_integer_test_plugin", "index_spec_integer_test_plugin"),
         ("callable_payload_test_plugin", "callable_payload_test_plugin"),
+        ("irregular_axis_test_plugin", "irregular_axis_test_plugin"),
     )
     missing_plugins = []
 

--- a/tests/fixtures/irregular_axis_test_plugin/pyproject.toml
+++ b/tests/fixtures/irregular_axis_test_plugin/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "irregular-axis-test-plugin"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["firecube"]
+
+[project.entry-points."firecube.plugins"]
+irregular_axis_safe = "irregular_axis_test_plugin:IrregularAxisSafeIngestor"
+irregular_axis_reverse_order = "irregular_axis_test_plugin:IrregularAxisReverseOrderIngestor"
+irregular_axis_duplicate = "irregular_axis_test_plugin:IrregularAxisDuplicateIngestor"
+irregular_axis_empty = "irregular_axis_test_plugin:IrregularAxisEmptyIngestor"
+irregular_axis_missing_coord = "irregular_axis_test_plugin:IrregularAxisMissingCoordIngestor"
+irregular_axis_concrete = "irregular_axis_test_plugin:IrregularAxisConcreteIngestor"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/irregular_axis_test_plugin"]

--- a/tests/fixtures/irregular_axis_test_plugin/src/irregular_axis_test_plugin/__init__.py
+++ b/tests/fixtures/irregular_axis_test_plugin/src/irregular_axis_test_plugin/__init__.py
@@ -1,0 +1,309 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test fixture plugins for IrregularTimeAxis AUTO discovery.
+
+Six ingestor variants covering safe operation and all failure modes exercised by
+the A7-A12 integration tests for IrregularTimeAxis(coordinate=..., values=AUTO):
+
+* ``IrregularAxisSafeIngestor`` -- happy path, five monotonically-ordered items.
+* ``IrregularAxisReverseOrderIngestor`` -- same coordinates in reverse insertion
+  order, verifies sort determinism.
+* ``IrregularAxisDuplicateIngestor`` -- two items claim the same coordinate,
+  triggers duplicate rejection during discovery.
+* ``IrregularAxisEmptyIngestor`` -- zero items reach the discovery hook,
+  triggers ``NoDiscoveredItemsError``.
+* ``IrregularAxisMissingCoordIngestor`` -- one item's ``inspect_item`` returns
+  ``ItemInfo(coordinate=None)``, triggers
+  ``MissingIrregularCoordinateError``.
+* ``IrregularAxisConcreteIngestor`` -- same five coordinates supplied as a
+  concrete tuple instead of ``AUTO``, used for concrete-vs-AUTO equivalence
+  parity tests.
+
+Fixtures use pure in-memory integer items; no network I/O or private data is
+required.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, ClassVar
+
+import numpy as np
+
+from firecube.core.api import AUTO, IndexSpec, IrregularTimeAxis, ItemInfo
+from firecube.ingestor.api import (
+    DirectZarrIngestor,
+    PipelineBatch,
+    PluginContext,
+    WriteIntent,
+    ZarrArraySpec,
+    ZarrGroupSpec,
+    register_ingestor,
+)
+
+# Canonical fixture dataset: five items at 2026-01-01T00:00:00Z + i*600s
+# (i in 0..4). All ingestors share this set so concrete-vs-AUTO parity tests
+# compare like with like.
+_BASE_TIMESTAMP: np.datetime64 = np.datetime64("2026-01-01T00:00:00", "ns")
+_CADENCE_S: int = 600
+_ITEM_COUNT: int = 5
+
+
+def _canonical_timestamps() -> tuple[np.datetime64, ...]:
+    """Return the five monotonically-ordered coordinate values as ``datetime64[ns]``."""
+    step = np.timedelta64(_CADENCE_S, "s").astype("timedelta64[ns]")
+    return tuple(_BASE_TIMESTAMP + i * step for i in range(_ITEM_COUNT))
+
+
+def _build_zarr_schema(slot_count: int, group: str = "data") -> list[ZarrGroupSpec]:
+    """Small (slot_count, 3, 4) float32 payload shell for all irregular-axis fixtures."""
+    return [
+        ZarrGroupSpec(
+            group=group,
+            arrays=[
+                ZarrArraySpec(
+                    name="values",
+                    shape=(slot_count, 3, 4),
+                    dtype="float32",
+                    chunks=(1, 3, 4),
+                    fill_value=0.0,
+                    expected_time_count=slot_count,
+                    time_indexed=True,
+                    dimension_names=("timestamp", "y", "x"),
+                )
+            ],
+        )
+    ]
+
+
+@register_ingestor("irregular_axis_safe")
+class IrregularAxisSafeIngestor(DirectZarrIngestor):
+    """Happy-path fixture: 5 items with monotonically-ordered timestamps and AUTO discovery."""
+
+    PRODUCT_NAME: ClassVar[str] = "irregular_axis_safe"
+
+    def discover_source_files(self, ctx: PluginContext) -> Iterable[Any]:
+        return list(range(_ITEM_COUNT))
+
+    def index_spec(self, ctx: PluginContext) -> IndexSpec:
+        return IndexSpec(
+            name="irregular_axis_safe_v1",
+            groups={
+                "data": IrregularTimeAxis(coordinate="timestamp", values=AUTO),
+            },
+        )
+
+    def inspect_item(self, item: Any, ctx: PluginContext) -> ItemInfo | None:
+        if not isinstance(item, int):
+            return None
+        return ItemInfo(coordinate=_canonical_timestamps()[item])
+
+    def zarr_schema(self, ctx: PluginContext) -> list[ZarrGroupSpec]:
+        return _build_zarr_schema(_ITEM_COUNT)
+
+    def build_write_intents(self, batch: PipelineBatch, ctx: PluginContext) -> list[WriteIntent]:
+        intents: list[WriteIntent] = []
+        resolved = self.resolved_index(ctx)
+        for item in batch.items:
+            info = self.inspect_item(item, ctx)
+            if info is None:
+                continue
+            slot = resolved.position("data", info.coordinate)
+            intents.append(WriteIntent.slot(group="data", array="values", index=slot, data=None))
+        return intents
+
+
+@register_ingestor("irregular_axis_reverse_order")
+class IrregularAxisReverseOrderIngestor(DirectZarrIngestor):
+    """Sort-determinism fixture: 5 items presented in reverse (index 4..0) with AUTO discovery."""
+
+    PRODUCT_NAME: ClassVar[str] = "irregular_axis_reverse_order"
+
+    def discover_source_files(self, ctx: PluginContext) -> Iterable[Any]:
+        return list(reversed(range(_ITEM_COUNT)))
+
+    def index_spec(self, ctx: PluginContext) -> IndexSpec:
+        return IndexSpec(
+            name="irregular_axis_reverse_order_v1",
+            groups={
+                "data": IrregularTimeAxis(coordinate="timestamp", values=AUTO),
+            },
+        )
+
+    def inspect_item(self, item: Any, ctx: PluginContext) -> ItemInfo | None:
+        if not isinstance(item, int):
+            return None
+        return ItemInfo(coordinate=_canonical_timestamps()[item])
+
+    def zarr_schema(self, ctx: PluginContext) -> list[ZarrGroupSpec]:
+        return _build_zarr_schema(_ITEM_COUNT)
+
+    def build_write_intents(self, batch: PipelineBatch, ctx: PluginContext) -> list[WriteIntent]:
+        intents: list[WriteIntent] = []
+        resolved = self.resolved_index(ctx)
+        for item in batch.items:
+            info = self.inspect_item(item, ctx)
+            if info is None:
+                continue
+            slot = resolved.position("data", info.coordinate)
+            intents.append(WriteIntent.slot(group="data", array="values", index=slot, data=None))
+        return intents
+
+
+@register_ingestor("irregular_axis_duplicate")
+class IrregularAxisDuplicateIngestor(DirectZarrIngestor):
+    """Duplicate-rejection fixture: item 1 reuses item 0's coordinate under AUTO discovery."""
+
+    PRODUCT_NAME: ClassVar[str] = "irregular_axis_duplicate"
+
+    def discover_source_files(self, ctx: PluginContext) -> Iterable[Any]:
+        return [0, 0, 2, 3, 4]
+
+    def index_spec(self, ctx: PluginContext) -> IndexSpec:
+        return IndexSpec(
+            name="irregular_axis_duplicate_v1",
+            groups={
+                "data": IrregularTimeAxis(coordinate="timestamp", values=AUTO),
+            },
+        )
+
+    def inspect_item(self, item: Any, ctx: PluginContext) -> ItemInfo | None:
+        if not isinstance(item, int):
+            return None
+        return ItemInfo(coordinate=_canonical_timestamps()[item])
+
+    def zarr_schema(self, ctx: PluginContext) -> list[ZarrGroupSpec]:
+        return _build_zarr_schema(_ITEM_COUNT)
+
+    def build_write_intents(self, batch: PipelineBatch, ctx: PluginContext) -> list[WriteIntent]:
+        intents: list[WriteIntent] = []
+        resolved = self.resolved_index(ctx)
+        for item in batch.items:
+            info = self.inspect_item(item, ctx)
+            if info is None:
+                continue
+            slot = resolved.position("data", info.coordinate)
+            intents.append(WriteIntent.slot(group="data", array="values", index=slot, data=None))
+        return intents
+
+
+@register_ingestor("irregular_axis_empty")
+class IrregularAxisEmptyIngestor(DirectZarrIngestor):
+    """Empty-source fixture: zero items reach discovery, exercises ``NoDiscoveredItemsError``."""
+
+    PRODUCT_NAME: ClassVar[str] = "irregular_axis_empty"
+
+    def discover_source_files(self, ctx: PluginContext) -> Iterable[Any]:
+        return []
+
+    def index_spec(self, ctx: PluginContext) -> IndexSpec:
+        return IndexSpec(
+            name="irregular_axis_empty_v1",
+            groups={
+                "data": IrregularTimeAxis(coordinate="timestamp", values=AUTO),
+            },
+        )
+
+    def inspect_item(self, item: Any, ctx: PluginContext) -> ItemInfo | None:
+        return None
+
+    def zarr_schema(self, ctx: PluginContext) -> list[ZarrGroupSpec]:
+        # Schema declares one placeholder slot; the empty-source path fails before write.
+        return _build_zarr_schema(1)
+
+    def build_write_intents(self, batch: PipelineBatch, ctx: PluginContext) -> list[WriteIntent]:
+        return []
+
+
+@register_ingestor("irregular_axis_missing_coord")
+class IrregularAxisMissingCoordIngestor(DirectZarrIngestor):
+    """Missing-coordinate fixture: item 2 returns ``ItemInfo(coordinate=None)`` under AUTO.
+
+    Exercises the ``MissingIrregularCoordinateError`` path when a plugin fails
+    to resolve a coordinate for a discovered item.
+    """
+
+    PRODUCT_NAME: ClassVar[str] = "irregular_axis_missing_coord"
+    _MISSING_INDEX: ClassVar[int] = 2
+
+    def discover_source_files(self, ctx: PluginContext) -> Iterable[Any]:
+        return list(range(_ITEM_COUNT))
+
+    def index_spec(self, ctx: PluginContext) -> IndexSpec:
+        return IndexSpec(
+            name="irregular_axis_missing_coord_v1",
+            groups={
+                "data": IrregularTimeAxis(coordinate="timestamp", values=AUTO),
+            },
+        )
+
+    def inspect_item(self, item: Any, ctx: PluginContext) -> ItemInfo | None:
+        if not isinstance(item, int):
+            return None
+        if item == self._MISSING_INDEX:
+            return ItemInfo(coordinate=None)
+        return ItemInfo(coordinate=_canonical_timestamps()[item])
+
+    def zarr_schema(self, ctx: PluginContext) -> list[ZarrGroupSpec]:
+        return _build_zarr_schema(_ITEM_COUNT)
+
+    def build_write_intents(self, batch: PipelineBatch, ctx: PluginContext) -> list[WriteIntent]:
+        # Never reached in success paths -- resolution fails at discovery time.
+        return []
+
+
+@register_ingestor("irregular_axis_concrete")
+class IrregularAxisConcreteIngestor(DirectZarrIngestor):
+    """Concrete-values fixture: the same 5 coordinates supplied as a tuple, no AUTO.
+
+    Used by concrete-vs-AUTO equivalence tests: this ingestor must produce a
+    ``ResolvedIndex`` byte-identical to ``IrregularAxisSafeIngestor`` when its
+    axis is discovered.
+    """
+
+    PRODUCT_NAME: ClassVar[str] = "irregular_axis_concrete"
+
+    def discover_source_files(self, ctx: PluginContext) -> Iterable[Any]:
+        return list(range(_ITEM_COUNT))
+
+    def index_spec(self, ctx: PluginContext) -> IndexSpec:
+        return IndexSpec(
+            name="irregular_axis_concrete_v1",
+            groups={
+                "data": IrregularTimeAxis(
+                    coordinate="timestamp",
+                    values=_canonical_timestamps(),
+                ),
+            },
+        )
+
+    def inspect_item(self, item: Any, ctx: PluginContext) -> ItemInfo | None:
+        if not isinstance(item, int):
+            return None
+        return ItemInfo(coordinate=_canonical_timestamps()[item])
+
+    def zarr_schema(self, ctx: PluginContext) -> list[ZarrGroupSpec]:
+        return _build_zarr_schema(_ITEM_COUNT)
+
+    def build_write_intents(self, batch: PipelineBatch, ctx: PluginContext) -> list[WriteIntent]:
+        intents: list[WriteIntent] = []
+        resolved = self.resolved_index(ctx)
+        for item in batch.items:
+            info = self.inspect_item(item, ctx)
+            if info is None:
+                continue
+            slot = resolved.position("data", info.coordinate)
+            intents.append(WriteIntent.slot(group="data", array="values", index=slot, data=None))
+        return intents

--- a/tests/fixtures/irregular_axis_test_plugin/tests/test_ingestor.py
+++ b/tests/fixtures/irregular_axis_test_plugin/tests/test_ingestor.py
@@ -1,0 +1,184 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fixture-owned tests for the irregular-axis test plugin.
+
+These tests exercise each ingestor's ``inspect_item`` and ``index_spec`` hooks
+on the canonical synthetic dataset so that failures in the fixture itself are
+caught before the shared A7-A12 integration tests run against it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from irregular_axis_test_plugin import (
+    IrregularAxisConcreteIngestor,
+    IrregularAxisDuplicateIngestor,
+    IrregularAxisEmptyIngestor,
+    IrregularAxisMissingCoordIngestor,
+    IrregularAxisReverseOrderIngestor,
+    IrregularAxisSafeIngestor,
+    _canonical_timestamps,  # type: ignore[attr-defined]
+)
+
+from firecube.core.api import (
+    AUTO,
+    IndexSpec,
+    IrregularTimeAxis,
+    ItemInfo,
+)
+
+
+def _fake_ctx() -> Any:
+    return SimpleNamespace(options={}, source=None, storage=None)
+
+
+def _bare[T](cls: type[T]) -> T:
+    """Return an instance of ``cls`` bypassing ``__init__``.
+
+    ``BaseIngestor.__init__`` requires a runtime context this fixture-level
+    suite does not construct; the six ingestors' hook methods depend only on
+    class-level constants, so a bare instance is sufficient.
+    """
+    return cast(T, object.__new__(cls))
+
+
+@pytest.mark.parametrize(
+    ("cls", "expected_name"),
+    [
+        (IrregularAxisSafeIngestor, "irregular_axis_safe_v1"),
+        (IrregularAxisReverseOrderIngestor, "irregular_axis_reverse_order_v1"),
+        (IrregularAxisDuplicateIngestor, "irregular_axis_duplicate_v1"),
+        (IrregularAxisEmptyIngestor, "irregular_axis_empty_v1"),
+        (IrregularAxisMissingCoordIngestor, "irregular_axis_missing_coord_v1"),
+    ],
+)
+def test_auto_ingestors_declare_irregular_time_axis_with_auto(
+    cls: type, expected_name: str
+) -> None:
+    spec = _bare(cls).index_spec(_fake_ctx())
+    assert isinstance(spec, IndexSpec)
+    assert spec.name == expected_name
+    axis = spec.groups["data"]
+    assert isinstance(axis, IrregularTimeAxis)
+    assert axis.coordinate == "timestamp"
+    assert axis.values is AUTO
+
+
+def test_concrete_ingestor_declares_five_timestamps_not_auto() -> None:
+    spec = _bare(IrregularAxisConcreteIngestor).index_spec(_fake_ctx())
+    axis = spec.groups["data"]
+    assert isinstance(axis, IrregularTimeAxis)
+    assert axis.coordinate == "timestamp"
+    assert axis.values is not AUTO
+    values = axis.values
+    assert values is not AUTO
+    assert tuple(cast(tuple[Any, ...], values)) == _canonical_timestamps()
+
+
+def test_safe_ingestor_discovers_five_monotonic_timestamps() -> None:
+    ingestor = _bare(IrregularAxisSafeIngestor)
+    ctx = _fake_ctx()
+    items = list(ingestor.discover_source_files(ctx))
+    assert items == [0, 1, 2, 3, 4]
+    assert len(items) == 5
+    coords = [ingestor.inspect_item(item, ctx) for item in items]
+    assert all(isinstance(info, ItemInfo) for info in coords)
+    values: list[Any] = []
+    for info in coords:
+        assert info is not None
+        values.append(info.coordinate)
+    expected = list(_canonical_timestamps())
+    assert values == expected
+    assert values == sorted(values)
+
+
+def test_reverse_order_ingestor_yields_items_in_reversed_order() -> None:
+    ingestor = _bare(IrregularAxisReverseOrderIngestor)
+    ctx = _fake_ctx()
+    items = list(ingestor.discover_source_files(ctx))
+    assert items == [4, 3, 2, 1, 0]
+    values: list[Any] = []
+    for item in items:
+        info = ingestor.inspect_item(item, ctx)
+        assert info is not None
+        values.append(info.coordinate)
+    expected = list(reversed(_canonical_timestamps()))
+    assert values == expected
+
+
+def test_duplicate_ingestor_maps_two_items_to_same_coordinate() -> None:
+    ingestor = _bare(IrregularAxisDuplicateIngestor)
+    ctx = _fake_ctx()
+    items = list(ingestor.discover_source_files(ctx))
+    assert len(items) == 5
+    assert items == [0, 0, 2, 3, 4]
+    coords: list[Any] = []
+    for item in items:
+        info = ingestor.inspect_item(item, ctx)
+        assert info is not None
+        coords.append(info.coordinate)
+    canonical = _canonical_timestamps()
+    assert coords[0] == canonical[0]
+    assert coords[1] == canonical[0]
+    assert coords[2] == canonical[2]
+    assert len(set(coords)) == 4
+
+
+def test_empty_ingestor_discovers_zero_items() -> None:
+    ingestor = _bare(IrregularAxisEmptyIngestor)
+    ctx = _fake_ctx()
+    assert list(ingestor.discover_source_files(ctx)) == []
+
+
+def test_missing_coord_ingestor_returns_none_for_item_two() -> None:
+    ingestor = _bare(IrregularAxisMissingCoordIngestor)
+    ctx = _fake_ctx()
+    items = list(ingestor.discover_source_files(ctx))
+    assert items == [0, 1, 2, 3, 4]
+    coords = [ingestor.inspect_item(item, ctx) for item in items]
+    info_missing = coords[2]
+    assert info_missing is not None
+    assert info_missing.coordinate is None
+    canonical = _canonical_timestamps()
+    for idx in (0, 1, 3, 4):
+        info = coords[idx]
+        assert info is not None
+        assert info.coordinate == canonical[idx]
+
+
+def test_concrete_and_safe_agree_on_discovered_coordinates() -> None:
+    safe = _bare(IrregularAxisSafeIngestor)
+    concrete = _bare(IrregularAxisConcreteIngestor)
+    ctx = _fake_ctx()
+    safe_coords: list[Any] = []
+    safe_items = list(safe.discover_source_files(ctx))
+    concrete_items = list(concrete.discover_source_files(ctx))
+    assert safe_items == [0, 1, 2, 3, 4]
+    assert concrete_items == [0, 1, 2, 3, 4]
+    for it in safe_items:
+        info = safe.inspect_item(it, ctx)
+        assert info is not None
+        safe_coords.append(info.coordinate)
+    concrete_coords: list[Any] = []
+    for it in concrete_items:
+        info = concrete.inspect_item(it, ctx)
+        assert info is not None
+        concrete_coords.append(info.coordinate)
+    assert safe_coords == concrete_coords
+    assert all(v.dtype == np.dtype("datetime64[ns]") for v in safe_coords)

--- a/tests/integration/test_auto_discovery.py
+++ b/tests/integration/test_auto_discovery.py
@@ -1,0 +1,78 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration placeholder for the irregular-axis AUTO fixture plugin.
+
+The A6 fixture plugin is optional until that task lands. This file becomes an
+integration lane as soon as ``irregular_axis_test_plugin`` is installed.
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from firecube.core.errors import (
+    DuplicateIrregularCoordinateError,
+    NoDiscoveredItemsError,
+)
+from firecube.ingestor.runtime.index_binding import resolve_index_spec_for_ingestor
+
+pytestmark = pytest.mark.integration
+
+plugin = pytest.importorskip(
+    "irregular_axis_test_plugin",
+    reason="irregular_axis_test_plugin fixture is installed by A6",
+)
+
+
+def _ctx() -> SimpleNamespace:
+    return SimpleNamespace(source="fixture-source", options={}, storage=None)
+
+
+def _bare(cls: type[Any]) -> Any:
+    return cast(Any, object.__new__(cls))
+
+
+def test_fixture_safe_ingestor_discovers_manifest_and_sorted_axis() -> None:
+    binding = resolve_index_spec_for_ingestor(_bare(plugin.IrregularAxisSafeIngestor), _ctx())
+
+    assert binding is not None
+    assert binding.resolved.size("data") == 5
+    assert binding.resolved.items is not None
+    assert len(binding.resolved.items) == 5
+    assert [entry.coordinate_value for entry in binding.resolved.items] == sorted(
+        entry.coordinate_value for entry in binding.resolved.items
+    )
+
+
+def test_fixture_reverse_order_ingestor_resolves_to_sorted_axis() -> None:
+    binding = resolve_index_spec_for_ingestor(
+        _bare(plugin.IrregularAxisReverseOrderIngestor), _ctx()
+    )
+
+    assert binding is not None
+    assert [binding.resolved.coordinate("data", index) for index in range(5)] == sorted(
+        binding.resolved.coordinate("data", index) for index in range(5)
+    )
+
+
+def test_fixture_duplicate_ingestor_raises_duplicate_error() -> None:
+    with pytest.raises(DuplicateIrregularCoordinateError, match="coordinates must be unique"):
+        resolve_index_spec_for_ingestor(_bare(plugin.IrregularAxisDuplicateIngestor), _ctx())
+
+
+def test_fixture_empty_ingestor_raises_empty_error() -> None:
+    with pytest.raises(NoDiscoveredItemsError):
+        resolve_index_spec_for_ingestor(_bare(plugin.IrregularAxisEmptyIngestor), _ctx())

--- a/tests/integration/test_frozen_index_safety.py
+++ b/tests/integration/test_frozen_index_safety.py
@@ -1,0 +1,310 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Frozen-index safety contracts for ``IrregularTimeAxis(values=AUTO)`` discovery.
+
+Each test names one safety contract that ``resolve_index_spec_for_ingestor``
+MUST honour for the AUTO discovery path. The contracts protect the on-disk
+frozen manifest from silent corruption when a plugin's discovered items
+drift, arrive out of order, collide, or vanish between runs.
+
+Contracts covered:
+
+1. Deterministic ordering -- identical input yields identical ``identity_hash``.
+2. Duplicate rejection -- coordinate collision names BOTH offending items.
+3. Freeze-then-late-arrival refusal (persistence-wired, xfail until A10).
+4. Empty discovery refusal -- zero items raises ``NoDiscoveredItemsError``.
+5. Non-monotonic to canonical order -- reverse input sorts to forward manifest.
+6. Path stability contract -- every manifest entry carries a non-empty
+   ``source_ref`` that a lazy WriteIntent callable can safely close over.
+7. Identity-hash equality across dry-run vs preallocate (xfail until A8).
+
+All tests exercise the real fixture ingestors from
+``irregular_axis_test_plugin`` (installed by A6). No mocks fake
+``inspect_item``: the contract being guarded is precisely the contract
+between a real plugin and the runtime binding, so faking either side would
+prove nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from click.testing import CliRunner
+
+from firecube.cli.main import cli
+from firecube.core.errors import (
+    DuplicateIrregularCoordinateError,
+    NoDiscoveredItemsError,
+    ResolvedIndexConflictError,
+)
+from firecube.ingestor.runtime.index_binding import resolve_index_spec_for_ingestor
+
+pytestmark = pytest.mark.integration
+
+plugin = pytest.importorskip(
+    "irregular_axis_test_plugin",
+    reason="irregular_axis_test_plugin fixture is installed by A6",
+)
+
+
+def _ctx() -> SimpleNamespace:
+    """Return a minimal PluginContext-shaped namespace sufficient for AUTO discovery."""
+    return SimpleNamespace(source="fixture-source", options={}, storage=None)
+
+
+def _bare(cls: type[Any]) -> Any:
+    """Construct an ingestor instance without invoking ``BaseIngestor.__init__``.
+
+    ``BaseIngestor.__init__`` requires a runtime ``ChunkManager`` and a full
+    plugin context. Discovery-time hooks only touch class-level constants and
+    pure ``Path`` computations, so a bare instance is sufficient for
+    ``resolve_index_spec_for_ingestor`` to exercise the AUTO discovery path.
+    """
+    return cast(Any, object.__new__(cls))
+
+
+def test_deterministic_ordering_produces_byte_identical_identity_hash() -> None:
+    """Safety contract 1: identical source state MUST produce byte-identical identity_hash.
+
+    Two invocations of ``resolve_index_spec_for_ingestor`` against the same
+    fixture in the same directory MUST return ``IndexBinding`` values whose
+    ``resolved.identity_hash`` are byte-equal. Any deviation (unstable dict
+    iteration, unsorted manifests, unstable coordinate canonicalisation)
+    would silently break freeze detection because a re-resolve with the same
+    inputs would produce a different hash than the persisted one and either
+    trigger a false conflict or overwrite the frozen record.
+    """
+    binding1 = resolve_index_spec_for_ingestor(
+        _bare(plugin.IrregularAxisReverseOrderIngestor), _ctx()
+    )
+    binding2 = resolve_index_spec_for_ingestor(
+        _bare(plugin.IrregularAxisReverseOrderIngestor), _ctx()
+    )
+
+    assert binding1 is not None
+    assert binding2 is not None
+    assert binding1.resolved.identity_hash == binding2.resolved.identity_hash
+
+
+def test_duplicate_rejection_names_both_conflicting_item_identities() -> None:
+    """Safety contract 2: a coordinate collision MUST raise naming BOTH offending items.
+
+    ``IrregularAxisDuplicateIngestor`` maps two discovered item identities to
+    the same timestamp coordinate. Discovery MUST refuse this with
+    ``DuplicateIrregularCoordinateError`` (a subclass of ``ConfigurationError``),
+    and the message MUST expose both offending item references so the
+    operator can locate the collision without re-reading source data.
+    """
+    with pytest.raises(DuplicateIrregularCoordinateError) as excinfo:
+        resolve_index_spec_for_ingestor(_bare(plugin.IrregularAxisDuplicateIngestor), _ctx())
+
+    exc = excinfo.value
+    assert exc.coordinate_name == "timestamp"
+    assert "2026-01-01T00:00:00" in str(exc.coordinate_value)
+    assert exc.first_item
+    assert exc.second_item
+    assert exc.first_item == "0"
+    assert exc.second_item == "0"
+
+
+def test_freeze_then_late_arrival_refuses_via_identity_hash_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Safety contract 3: a persisted manifest MUST refuse a late-arriving item.
+
+    The first ``firecube zarr preallocate`` call freezes the AUTO-discovered
+    irregular axis into ``.firecube/index/current.json``. The second call runs
+    against the same target after the fixture source set gains a sixth item.
+    That changes the resolved-index ``identity_hash`` and MUST raise a
+    ``ResolvedIndexConflictError`` instead of silently replacing the frozen
+    record.
+    """
+
+    target_dir = tmp_path / "out.zarr"
+    base_args = [
+        "zarr",
+        "preallocate",
+        "irregular_axis_safe",
+        "--target",
+        f"file://{target_dir}",
+        "--product-name",
+        "irregular_axis_safe",
+        "--storage-type",
+        "local",
+        "--storage-driver",
+        "fsspec",
+        "--write-mode",
+        "staged",
+    ]
+
+    first_result = CliRunner().invoke(cli, base_args)
+    assert first_result.exit_code == 0, first_result.output
+
+    current_json = target_dir / ".firecube" / "index" / "current.json"
+    first_bytes = current_json.read_bytes()
+
+    monkeypatch.setattr(plugin, "_ITEM_COUNT", 6)
+
+    second_result = CliRunner().invoke(cli, base_args)
+    assert second_result.exit_code != 0, second_result.output
+    assert isinstance(second_result.exception, ResolvedIndexConflictError)
+    failure_text = f"{type(second_result.exception).__name__}: {second_result.exception}"
+    assert (
+        "ResolvedIndexConflictError" in failure_text
+        or "identity" in failure_text.lower()
+        or "conflict" in failure_text.lower()
+    ), failure_text
+    assert current_json.read_bytes() == first_bytes
+
+
+def test_empty_discovery_raises_no_discovered_items_error() -> None:
+    """Safety contract 4: zero-item discovery MUST raise NoDiscoveredItemsError.
+
+    ``IrregularAxisEmptyIngestor`` returns an empty ``discover_source_files``
+    result. Discovery MUST refuse this rather than silently freezing an
+    empty axis (which would give an all-fill Zarr store with no way to
+    distinguish "not written yet" from "no data exists"). The exception
+    MUST expose the coordinate name and source description on typed fields
+    so operators do not have to parse message prose.
+    """
+    with pytest.raises(NoDiscoveredItemsError) as excinfo:
+        resolve_index_spec_for_ingestor(_bare(plugin.IrregularAxisEmptyIngestor), _ctx())
+
+    exc = excinfo.value
+    assert exc.coordinate_name == "timestamp"
+    assert exc.source_ref == "fixture-source"
+
+
+def test_reverse_order_input_resolves_to_sorted_manifest() -> None:
+    """Safety contract 5: manifest items MUST be in sorted coordinate order regardless of discovery order.
+
+    ``IrregularAxisReverseOrderIngestor`` yields items in reverse index
+    order (4, 3, 2, 1, 0). The resolved ``ResolvedIndex.items`` manifest
+    MUST be canonically sorted by ``coordinate_value``, and the resolver's
+    ``coordinate(group, index)`` view MUST expose the same forward order.
+    Without this invariant, ``identity_hash`` would depend on discovery
+    order and freeze detection would false-alarm on any re-run whose
+    file-system iteration order changed.
+    """
+    binding = resolve_index_spec_for_ingestor(
+        _bare(plugin.IrregularAxisReverseOrderIngestor), _ctx()
+    )
+
+    assert binding is not None
+    assert binding.resolved.items is not None
+    coord_values = [entry.coordinate_value for entry in binding.resolved.items]
+    assert coord_values == sorted(coord_values)
+    axis_coords = [
+        binding.resolved.coordinate("data", i) for i in range(binding.resolved.size("data"))
+    ]
+    assert axis_coords == sorted(axis_coords)
+
+
+def test_manifest_source_ref_present_supports_lazy_writeintent_closure() -> None:
+    """Safety contract 6: each manifest entry MUST carry a non-empty source_ref usable by a lazy closure.
+
+    Lazy ``WriteIntent`` payloads (from plan C) are callables that MUST close
+    over the manifest ``source_ref`` string, not over open file handles or
+    other lifetime-bound resources. This test documents that contract by
+    (a) asserting every entry has a truthy ``source_ref`` and a declared
+    ``source_ref_kind`` from the allowed set, and (b) exercising the safe
+    closure pattern (capture the string as a default argument, not an open
+    handle) to prove the source_ref can be dereferenced after discovery
+    returns without depending on any ambient state.
+    """
+    binding = resolve_index_spec_for_ingestor(_bare(plugin.IrregularAxisSafeIngestor), _ctx())
+
+    assert binding is not None
+    assert binding.resolved.items is not None
+    allowed_kinds = {"path", "uri", "identifier"}
+
+    captured_refs: list[str] = []
+    for entry in binding.resolved.items:
+        assert entry.source_ref, f"empty source_ref for entry {entry.identity_hash!r}"
+        assert entry.source_ref_kind in allowed_kinds
+
+        ref = entry.source_ref
+
+        def _closure(captured_ref: str = ref) -> str:
+            return captured_ref
+
+        captured_refs.append(_closure())
+
+    assert captured_refs == [entry.source_ref for entry in binding.resolved.items]
+
+
+def test_dry_run_and_preallocate_produce_equal_identity_hash(tmp_path: Any) -> None:
+    """Safety contract 7: dry-run identity_hash MUST equal the real preallocate identity_hash.
+
+    A dry-run preallocation surfaces the frozen manifest without writing
+    Zarr metadata. When the operator subsequently issues a real
+    preallocate against unchanged sources, the resolved-index
+    ``identity_hash`` MUST be byte-equal to the dry-run value so a plan
+    computed in dry-run mode is a faithful preview of the mutation.
+    """
+    import json
+
+    from click.testing import CliRunner
+
+    from firecube.cli.main import cli
+
+    target_dir = tmp_path / "out.zarr"
+    target_uri = f"file://{target_dir}"
+    base_args = [
+        "zarr",
+        "preallocate",
+        "irregular_axis_safe",
+        "--target",
+        target_uri,
+        "--product-name",
+        "irregular_axis_safe",
+        "--storage-type",
+        "local",
+        "--storage-driver",
+        "fsspec",
+        "--write-mode",
+        "staged",
+    ]
+
+    dry_result = CliRunner().invoke(cli, [*base_args, "--dry-run"])
+    assert dry_result.exit_code == 0, dry_result.output
+    dry_hash = json.loads(dry_result.output)["identity_hash"]
+
+    real_result = CliRunner().invoke(cli, base_args)
+    assert real_result.exit_code == 0, real_result.output
+
+    show_result = CliRunner().invoke(
+        cli,
+        [
+            "zarr",
+            "index",
+            "show",
+            "--target",
+            target_uri,
+            "--product-name",
+            "irregular_axis_safe",
+            "--json",
+        ],
+    )
+    assert show_result.exit_code == 0, show_result.output
+    real_hash = json.loads(show_result.output)["identity_hash"]
+
+    assert dry_hash == real_hash, (
+        f"dry-run identity_hash {dry_hash[:16]}... != "
+        f"real preallocate identity_hash {real_hash[:16]}..."
+    )

--- a/tests/integration/test_irregular_axis_pipeline.py
+++ b/tests/integration/test_irregular_axis_pipeline.py
@@ -1,0 +1,459 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Full-pipeline integration coverage for ``IrregularTimeAxis(values=AUTO)``.
+
+Exercises the composite CLI flow shipped by A8 (``firecube zarr preallocate
+--dry-run``), A9 (``firecube zarr index show --derived``), and A10 (irregular
+coord-array materialization inside ``firecube zarr preallocate``) against all
+six fixture ingestors from ``irregular_axis_test_plugin`` (A6).
+
+Existing coverage in ``tests/integration/`` already asserts single-command
+behaviour:
+
+* ``test_auto_discovery.py`` — ``resolve_index_spec_for_ingestor`` at the
+  binding boundary.
+* ``test_irregular_coord_materialization.py`` — per-command preallocate
+  behaviour (idempotency, dry-run non-mutation, coord dtype).
+* ``test_frozen_index_safety.py`` — freeze/late-arrival safety contracts.
+
+What is NOT covered elsewhere is the **composite pipeline** an operator
+actually invokes: dry-run to preview, preallocate to persist, index show to
+read back, and the failure paths that must exit non-zero and leave zero
+side-effects on disk. This file fills that gap.
+
+Failure paths use ``firecube zarr preallocate`` (which runs the discovery
+pipeline as its first step) as the reproducer: if discovery fails, no
+control-plane files or Zarr arrays land on disk. The plan's phrase
+"dry-run → preallocate → index show → ingest" refers to that pipeline
+staging — the ``firecube ingest`` command itself requires per-item payload
+data that the ``irregular_axis_test_plugin`` fixtures do not supply
+(``build_write_intents`` returns ``WriteIntent.slot(..., data=None)`` because
+those fixtures target discovery/preallocate contracts, not payload writes).
+End-to-end payload-carrying ingest coverage lives in
+``tests/integration/test_callable_payload_integration.py``; composing
+``irregular_axis_test_plugin`` with ``callable_payload_test_plugin`` would
+require a new hybrid fixture ingestor and is intentionally out of scope for
+A11.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+import zarr
+from click.testing import CliRunner
+
+from firecube.cli.main import cli
+from firecube.core.controlplane.types import INDEX_CURRENT_FILENAME, INDEX_DIRNAME
+from firecube.ingestor.registry import loader as _loader
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip(
+    "irregular_axis_test_plugin",
+    reason="irregular_axis_test_plugin fixture is installed by A6",
+)
+
+_EXPECTED_SLOT_COUNT = 5
+_BASE = np.datetime64("2026-01-01T00:00:00", "ns")
+_STEP = np.timedelta64(600, "s").astype("timedelta64[ns]")
+_EXPECTED_TIMESTAMPS = np.asarray(
+    [_BASE + i * _STEP for i in range(_EXPECTED_SLOT_COUNT)],
+    dtype="datetime64[ns]",
+)
+_EXPECTED_COORD_VALUES_JSON: list[str] = [
+    "2026-01-01T00:00:00.000000000Z",
+    "2026-01-01T00:10:00.000000000Z",
+    "2026-01-01T00:20:00.000000000Z",
+    "2026-01-01T00:30:00.000000000Z",
+    "2026-01-01T00:40:00.000000000Z",
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_registry() -> Iterator[None]:
+    """Reload ``irregular_axis_test_plugin`` around each test.
+
+    ``AVAILABLE_INGESTORS`` is process-global. Snapshotting + reloading around
+    each test matches the pattern used in
+    ``tests/integration/test_irregular_coord_materialization.py`` and prevents
+    stale registrations from earlier tests bleeding into these CLI invocations.
+    """
+    original_loaded = _loader._LOADED
+    original_registry = dict(_loader.AVAILABLE_INGESTORS)
+    _loader._LOADED = False
+    _loader.AVAILABLE_INGESTORS.clear()
+    importlib.reload(importlib.import_module("irregular_axis_test_plugin"))
+    _loader._LOADED = True
+    yield
+    _loader._LOADED = original_loaded
+    _loader.AVAILABLE_INGESTORS.clear()
+    _loader.AVAILABLE_INGESTORS.update(original_registry)
+
+
+def _preallocate_args(
+    plugin: str,
+    product: str,
+    target_path: Path,
+    *,
+    dry_run: bool = False,
+) -> list[str]:
+    args = [
+        "zarr",
+        "preallocate",
+        plugin,
+        "--target",
+        f"file://{target_path}",
+        "--product-name",
+        product,
+        "--storage-type",
+        "local",
+        "--storage-driver",
+        "fsspec",
+        "--write-mode",
+        "direct",
+        "--option",
+        "no_progress=true",
+    ]
+    if dry_run:
+        args.append("--dry-run")
+    return args
+
+
+def _index_show_args(
+    product: str,
+    target_path: Path,
+    *,
+    json_flag: bool = True,
+    derived: bool = False,
+) -> list[str]:
+    args = [
+        "zarr",
+        "index",
+        "show",
+        "--target",
+        f"file://{target_path}",
+        "--product-name",
+        product,
+    ]
+    if json_flag:
+        args.append("--json")
+    if derived:
+        args.append("--derived")
+    return args
+
+
+def _dry_run_manifest(plugin: str, product: str, target_path: Path) -> dict[str, Any]:
+    result = CliRunner().invoke(
+        cli,
+        _preallocate_args(plugin, product, target_path, dry_run=True),
+    )
+    assert result.exit_code == 0, result.output
+    return cast(dict[str, Any], json.loads(result.output))
+
+
+def _persist_and_read_hash(plugin: str, product: str, target_path: Path) -> str:
+    prealloc = CliRunner().invoke(
+        cli,
+        _preallocate_args(plugin, product, target_path),
+    )
+    assert prealloc.exit_code == 0, prealloc.output
+    show = CliRunner().invoke(
+        cli,
+        _index_show_args(product, target_path, json_flag=True),
+    )
+    assert show.exit_code == 0, show.output
+    return cast(str, json.loads(show.output)["identity_hash"])
+
+
+def _index_current_path(target_path: Path) -> Path:
+    return target_path / ".firecube" / INDEX_DIRNAME / INDEX_CURRENT_FILENAME
+
+
+def _coord_array_values(target_path: Path, group: str = "data") -> np.ndarray:
+    root = zarr.open_group(store=str(target_path), mode="r", zarr_format=3)
+    return np.asarray(cast(Any, root[f"{group}/timestamp"])[:])
+
+
+def test_full_pipeline_dry_run_then_preallocate_then_index_show_agree_on_hash(
+    tmp_path: Path,
+) -> None:
+    """A8 dry-run + A10 preallocate + A9 index show all yield the same identity_hash.
+
+    The composite pipeline an operator runs is: (1) dry-run to preview the
+    manifest without side effects, (2) real preallocate to persist the frozen
+    manifest and materialise the coord array, (3) index show to read back the
+    persisted record. All three MUST report byte-equal ``identity_hash``
+    values; a drift between any pair would mean an operator's dry-run preview
+    is not a faithful predictor of the real preallocate, or that index show
+    reads a different record than preallocate wrote. This test protects the
+    A8-A9-A10 chain end-to-end at the CLI boundary.
+    """
+    target_path = tmp_path / "out.zarr"
+
+    dry_manifest = _dry_run_manifest("irregular_axis_safe", "irregular_axis_safe", target_path)
+    assert not target_path.exists(), "dry-run must not create any filesystem state; A8 contract"
+
+    prealloc = CliRunner().invoke(
+        cli,
+        _preallocate_args("irregular_axis_safe", "irregular_axis_safe", target_path),
+    )
+    assert prealloc.exit_code == 0, prealloc.output
+    assert "resolved index: created" in prealloc.output
+    assert "irregular coord materialization" in prealloc.output, (
+        f"A10 materialization step missing from CLI output:\n{prealloc.output}"
+    )
+    assert _index_current_path(target_path).is_file(), (
+        f"preallocate must persist .firecube/index/current.json; not found under {target_path}"
+    )
+
+    show = CliRunner().invoke(
+        cli,
+        _index_show_args("irregular_axis_safe", target_path, json_flag=True),
+    )
+    assert show.exit_code == 0, show.output
+    show_hash = json.loads(show.output)["identity_hash"]
+
+    assert dry_manifest["identity_hash"] == show_hash, (
+        f"dry-run hash {dry_manifest['identity_hash'][:16]}... != "
+        f"index-show hash {show_hash[:16]}..."
+    )
+
+    coord_values = _coord_array_values(target_path)
+    assert np.array_equal(coord_values, _EXPECTED_TIMESTAMPS)
+
+
+def test_reverse_order_axis_values_and_manifest_items_match_safe_ingestor(
+    tmp_path: Path,
+) -> None:
+    """Reverse discovery order MUST produce byte-identical axis values and manifest items.
+
+    ``IrregularAxisReverseOrderIngestor`` yields items in indices 4..0 while
+    ``IrregularAxisSafeIngestor`` yields 0..4. Both plugins reach the same
+    five timestamps and same five source_ref dicts, so after
+    coordinate-value sort:
+
+    * ``groups.data.params.values`` MUST be byte-identical between plugins
+      (the sorted coordinate axis is the derived output every downstream
+      consumer sees).
+    * ``items`` (manifest entries, sorted by identity_hash) MUST be
+      byte-identical (each entry is derived only from source_ref +
+      coordinate_value, both invariant across plugins).
+
+    Note: the top-level ``identity_hash`` legitimately differs because the
+    plugins use distinct ``IndexSpec.name`` values (``irregular_axis_safe_v1``
+    vs ``irregular_axis_reverse_order_v1``) and the spec name is part of the
+    canonical bytes. This test asserts sort determinism at the axis and
+    manifest level, which is the semantically meaningful invariant.
+    """
+    safe_path = tmp_path / "safe.zarr"
+    reverse_path = tmp_path / "reverse.zarr"
+
+    safe = _dry_run_manifest("irregular_axis_safe", "irregular_axis_safe", safe_path)
+    reverse = _dry_run_manifest(
+        "irregular_axis_reverse_order", "irregular_axis_reverse_order", reverse_path
+    )
+
+    safe_values = safe["index"]["groups"]["data"]["params"]["values"]
+    reverse_values = reverse["index"]["groups"]["data"]["params"]["values"]
+    assert safe_values == reverse_values == _EXPECTED_COORD_VALUES_JSON, (
+        f"axis values diverged: safe={safe_values!r} reverse={reverse_values!r}"
+    )
+
+    safe_items = safe["items"]
+    reverse_items = reverse["items"]
+    assert safe_items == reverse_items, (
+        "manifest items diverged despite identical sources; sort determinism broken"
+    )
+
+
+def test_concrete_axis_values_match_auto_axis_values(tmp_path: Path) -> None:
+    """Concrete-tuple axis and AUTO discovery MUST produce byte-identical axis values.
+
+    ``IrregularAxisConcreteIngestor`` declares the five timestamps as a
+    literal tuple; ``IrregularAxisSafeIngestor`` discovers them from files.
+    Both paths MUST yield the exact same JSON-serialised axis values so an
+    operator can migrate from AUTO to concrete (or vice versa) without any
+    observable change in the persisted coord axis. Byte equality of the
+    ``groups.data.params.values`` list is the strongest such invariant.
+
+    Note: concrete-axis manifests intentionally OMIT the ``items`` key (A4
+    asymmetric canonical bytes) and use a different ``IndexSpec.name``, so
+    the top-level ``identity_hash`` legitimately differs. This test isolates
+    the axis-value equivalence claim from those unrelated fields.
+    """
+    auto_path = tmp_path / "auto.zarr"
+    concrete_path = tmp_path / "concrete.zarr"
+
+    auto = _dry_run_manifest("irregular_axis_safe", "irregular_axis_safe", auto_path)
+    concrete = _dry_run_manifest(
+        "irregular_axis_concrete", "irregular_axis_concrete", concrete_path
+    )
+
+    assert (
+        auto["index"]["groups"]["data"]["params"]["values"]
+        == concrete["index"]["groups"]["data"]["params"]["values"]
+        == _EXPECTED_COORD_VALUES_JSON
+    ), "concrete-vs-AUTO axis values diverged; concrete-vs-AUTO equivalence broken"
+    assert "items" not in concrete, (
+        "concrete axis manifests MUST omit 'items' (A4 asymmetric canonical bytes); "
+        f"got keys {sorted(concrete.keys())!r}"
+    )
+    assert "items" in auto and len(auto["items"]) == _EXPECTED_SLOT_COUNT
+
+    _persist_and_read_hash("irregular_axis_safe", "irregular_axis_safe", auto_path)
+    _persist_and_read_hash("irregular_axis_concrete", "irregular_axis_concrete", concrete_path)
+    assert np.array_equal(
+        _coord_array_values(auto_path),
+        _coord_array_values(concrete_path),
+    )
+
+
+def test_duplicate_ingestor_fails_preallocate_and_writes_no_cube(tmp_path: Path) -> None:
+    """Duplicate coordinate MUST fail preallocate loudly and leave zero side effects.
+
+    ``IrregularAxisDuplicateIngestor`` yields two items that map to the same
+    timestamp coordinate. The preallocate pipeline MUST:
+
+    * exit non-zero;
+    * surface the ``DuplicateIrregularCoordinateError`` message (with both
+      offending item references and the unique-coordinate marker)
+      via the CLI error channel;
+    * create NO Zarr store, NO ``.firecube`` control-plane files, and
+      NO placeholder directories at the target.
+
+    Zero-side-effects is the safety-net contract: a botched discovery must
+    not leave a half-frozen manifest that a resume would then treat as
+    authoritative.
+    """
+    target_path = tmp_path / "duplicate.zarr"
+
+    result = CliRunner().invoke(
+        cli,
+        _preallocate_args("irregular_axis_duplicate", "irregular_axis_duplicate", target_path),
+    )
+
+    assert result.exit_code != 0, result.output
+    assert "irregular_axis_duplicate" in result.output
+    assert "coordinates must be unique" in result.output
+    assert "items '0' and '0'" in result.output, (
+        "duplicate error must name the offending item identities for operator triage"
+    )
+    assert not target_path.exists(), (
+        f"failed preallocate must not leave a partial target; found "
+        f"{list(target_path.iterdir()) if target_path.exists() else '(nothing)'}"
+    )
+
+
+def test_empty_ingestor_fails_preallocate_and_writes_no_cube(tmp_path: Path) -> None:
+    """Empty discovery MUST fail preallocate with NoDiscoveredItemsError and no side effects.
+
+    ``IrregularAxisEmptyIngestor.discover_source_files`` returns ``[]``.
+    The preallocate pipeline MUST exit non-zero, name the missing coordinate
+    (``timestamp``), and create nothing on disk. A silent freeze on empty
+    input would produce an all-fill Zarr store with no way to distinguish
+    "not written yet" from "genuinely empty" — the guard is the whole point
+    of ``NoDiscoveredItemsError``.
+    """
+    target_path = tmp_path / "empty.zarr"
+
+    result = CliRunner().invoke(
+        cli,
+        _preallocate_args("irregular_axis_empty", "irregular_axis_empty", target_path),
+    )
+
+    assert result.exit_code != 0, result.output
+    assert "irregular_axis_empty" in result.output
+    assert "no items found" in result.output
+    assert "timestamp" in result.output
+    assert not target_path.exists(), (
+        f"failed preallocate must not leave a partial target; found "
+        f"{list(target_path.iterdir()) if target_path.exists() else '(nothing)'}"
+    )
+
+
+def test_missing_coord_ingestor_fails_preallocate_and_writes_no_cube(tmp_path: Path) -> None:
+    """Missing coordinate on one item MUST fail preallocate and leave no side effects.
+
+    ``IrregularAxisMissingCoordIngestor.inspect_item`` returns
+    ``ItemInfo(coordinate=None)`` for item index 2. The AUTO discovery path
+    MUST raise ``MissingIrregularCoordinateError`` naming the offending item
+    and the coordinate, exit non-zero, and create nothing on disk. Silent
+    slot skipping would misalign every downstream slot index against the
+    coordinate the operator declared.
+    """
+    target_path = tmp_path / "missing_coord.zarr"
+
+    result = CliRunner().invoke(
+        cli,
+        _preallocate_args(
+            "irregular_axis_missing_coord", "irregular_axis_missing_coord", target_path
+        ),
+    )
+
+    assert result.exit_code != 0, result.output
+    assert "irregular_axis_missing_coord" in result.output
+    assert "no resolvable coordinate" in result.output
+    assert "timestamp" in result.output
+    assert "item 2" in result.output, (
+        "missing-coord error must name the offending item (index 2) for operator triage"
+    )
+    assert not target_path.exists(), (
+        f"failed preallocate must not leave a partial target; found "
+        f"{list(target_path.iterdir()) if target_path.exists() else '(nothing)'}"
+    )
+
+
+def test_index_show_derived_flag_on_irregular_axis_is_a_documented_noop(
+    tmp_path: Path,
+) -> None:
+    """A9 --derived flag on IrregularTimeAxis groups MUST emit a documented no-op note.
+
+    The A9 flag computes derived coordinate values at read time for
+    ``RegularTimeAxis`` groups (which persist ``epoch`` + ``cadence_s`` and
+    derive the axis on the fly). For ``IrregularTimeAxis`` groups the
+    coordinate values are already materialised on disk by A10 preallocate,
+    so ``--derived`` MUST NOT recompute or overwrite them. The CLI advertises
+    this contract via a text note on the group; this test guards that
+    contract at the user-visible boundary so a future change that quietly
+    starts synthesising coordinates for irregular axes would fail here.
+    """
+    target_path = tmp_path / "derived_noop.zarr"
+
+    prealloc = CliRunner().invoke(
+        cli,
+        _preallocate_args("irregular_axis_safe", "irregular_axis_safe", target_path),
+    )
+    assert prealloc.exit_code == 0, prealloc.output
+
+    show_derived = CliRunner().invoke(
+        cli,
+        _index_show_args("irregular_axis_safe", target_path, json_flag=False, derived=True),
+    )
+    assert show_derived.exit_code == 0, show_derived.output
+    assert "data" in show_derived.output
+    assert "not a regular_time axis" in show_derived.output
+    assert "no-op" in show_derived.output
+
+    coord_values = _coord_array_values(target_path)
+    assert np.array_equal(coord_values, _EXPECTED_TIMESTAMPS), (
+        "--derived on IrregularTimeAxis must not touch the persisted coord array"
+    )

--- a/tests/integration/test_irregular_coord_materialization.py
+++ b/tests/integration/test_irregular_coord_materialization.py
@@ -1,0 +1,237 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contracts for coordinate materialization during ``firecube zarr preallocate``.
+
+``IrregularTimeAxis`` groups persist their coordinate values densely into a
+Zarr array at ``{group}/{axis.coordinate}``; ``RegularTimeAxis`` and
+``IntegerAxis`` stay lazy-derived. Dry-run must never touch the store.
+
+Fixtures come from ``irregular_axis_test_plugin`` (installed by A6) and
+``index_spec_test_plugin``. These tests exercise the real CLI wiring — no
+mocks — so a regression in the preallocate loop surfaces here.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+import zarr
+from click.testing import CliRunner
+
+from firecube.cli.main import cli
+from firecube.ingestor.registry import loader as _loader
+
+pytestmark = pytest.mark.integration
+
+irregular_plugin = pytest.importorskip(
+    "irregular_axis_test_plugin",
+    reason="irregular_axis_test_plugin fixture is installed by A6",
+)
+regular_plugin = pytest.importorskip(
+    "index_spec_test_plugin",
+    reason="index_spec_test_plugin fixture is installed by the CLI test setup",
+)
+
+_EXPECTED_SLOT_COUNT = 5
+_BASE = np.datetime64("2026-01-01T00:00:00", "ns")
+_STEP = np.timedelta64(600, "s").astype("timedelta64[ns]")
+_EXPECTED_TIMESTAMPS = np.asarray(
+    [_BASE + i * _STEP for i in range(_EXPECTED_SLOT_COUNT)],
+    dtype="datetime64[ns]",
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_registry() -> Iterator[None]:
+    original_loaded = _loader._LOADED
+    original_registry = dict(_loader.AVAILABLE_INGESTORS)
+    _loader._LOADED = False
+    _loader.AVAILABLE_INGESTORS.clear()
+    importlib.reload(importlib.import_module("irregular_axis_test_plugin"))
+    importlib.reload(importlib.import_module("index_spec_test_plugin"))
+    yield
+    _loader._LOADED = original_loaded
+    _loader.AVAILABLE_INGESTORS.clear()
+    _loader.AVAILABLE_INGESTORS.update(original_registry)
+
+
+def _preallocate_args(
+    plugin: str,
+    product: str,
+    target_path: Path,
+    *,
+    dry_run: bool = False,
+    extra_options: tuple[str, ...] = (),
+) -> list[str]:
+    args = [
+        "zarr",
+        "preallocate",
+        plugin,
+        "--target",
+        f"file://{target_path}",
+        "--product-name",
+        product,
+        "--storage-type",
+        "local",
+        "--storage-driver",
+        "fsspec",
+        "--write-mode",
+        "direct",
+        "--option",
+        "no_progress=true",
+    ]
+    for option in extra_options:
+        args.extend(["--option", option])
+    if dry_run:
+        args.append("--dry-run")
+    return args
+
+
+def _root(target_path: Path) -> Any:
+    return zarr.open_group(store=str(target_path), mode="r", zarr_format=3)
+
+
+def test_irregular_preallocate_materializes_coord_array(tmp_path: Path) -> None:
+    target_path = tmp_path / "out.zarr"
+
+    result = CliRunner().invoke(
+        cli,
+        _preallocate_args("irregular_axis_safe", "irregular_axis_safe", target_path),
+    )
+
+    assert result.exit_code == 0, result.output
+    root = _root(target_path)
+    coord = cast(Any, root["data/timestamp"])
+    assert coord.shape == (_EXPECTED_SLOT_COUNT,)
+    assert coord.dtype == np.dtype("datetime64[ns]")
+    values = np.asarray(coord[:])
+    assert np.array_equal(values, _EXPECTED_TIMESTAMPS)
+    assert coord.metadata.dimension_names == ("timestamp",)
+
+
+def test_irregular_preallocate_is_idempotent_on_matching_coord_array(tmp_path: Path) -> None:
+    target_path = tmp_path / "out.zarr"
+
+    first = CliRunner().invoke(
+        cli,
+        _preallocate_args("irregular_axis_safe", "irregular_axis_safe", target_path),
+    )
+    second = CliRunner().invoke(
+        cli,
+        _preallocate_args("irregular_axis_safe", "irregular_axis_safe", target_path),
+    )
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert "existing irregular coord array matches; no-op" in second.output
+    values = np.asarray(cast(Any, _root(target_path)["data/timestamp"])[:])
+    assert np.array_equal(values, _EXPECTED_TIMESTAMPS)
+
+
+def test_regular_axis_preallocate_does_not_materialize_coords(tmp_path: Path) -> None:
+    target_path = tmp_path / "out.zarr"
+
+    result = CliRunner().invoke(
+        cli,
+        _preallocate_args("index_spec_single", "index_spec_single", target_path),
+    )
+
+    assert result.exit_code == 0, result.output
+    root = _root(target_path)
+    assert "timestamp" not in cast(Any, root["data"])
+
+
+def test_dry_run_does_not_write_any_zarr_metadata(tmp_path: Path) -> None:
+    target_path = tmp_path / "out.zarr"
+
+    result = CliRunner().invoke(
+        cli,
+        _preallocate_args(
+            "irregular_axis_safe",
+            "irregular_axis_safe",
+            target_path,
+            dry_run=True,
+        ),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not target_path.exists(), (
+        f"dry-run must not create the target store; found {list(target_path.iterdir())}"
+    )
+
+
+def test_concrete_irregular_axis_materializes_same_values_as_auto(tmp_path: Path) -> None:
+    auto_target = tmp_path / "auto.zarr"
+    concrete_target = tmp_path / "concrete.zarr"
+
+    auto_result = CliRunner().invoke(
+        cli,
+        _preallocate_args("irregular_axis_safe", "irregular_axis_safe", auto_target),
+    )
+    concrete_result = CliRunner().invoke(
+        cli,
+        _preallocate_args(
+            "irregular_axis_concrete",
+            "irregular_axis_concrete",
+            concrete_target,
+        ),
+    )
+
+    assert auto_result.exit_code == 0, auto_result.output
+    assert concrete_result.exit_code == 0, concrete_result.output
+    auto_values = np.asarray(cast(Any, _root(auto_target)["data/timestamp"])[:])
+    concrete_values = np.asarray(cast(Any, _root(concrete_target)["data/timestamp"])[:])
+    assert np.array_equal(auto_values, concrete_values)
+    assert np.array_equal(auto_values, _EXPECTED_TIMESTAMPS)
+
+
+def test_coord_array_carries_no_reserved_attrs(tmp_path: Path) -> None:
+    from firecube.core.zarr._reserved_attrs import RESERVED_ARRAY_ATTRS
+
+    target_path = tmp_path / "out.zarr"
+    result = CliRunner().invoke(
+        cli,
+        _preallocate_args("irregular_axis_safe", "irregular_axis_safe", target_path),
+    )
+
+    assert result.exit_code == 0, result.output
+    coord = cast(Any, _root(target_path)["data/timestamp"])
+    user_attr_keys = set(coord.attrs)
+    firecube_managed = RESERVED_ARRAY_ATTRS - {"_ARRAY_DIMENSIONS", "_FillValue"}
+    assert user_attr_keys.isdisjoint(firecube_managed), (
+        f"coord attrs {user_attr_keys!r} intersect reserved names {firecube_managed!r}"
+    )
+
+
+def test_reverse_order_input_produces_sorted_coord_array(tmp_path: Path) -> None:
+    target_path = tmp_path / "out.zarr"
+
+    result = CliRunner().invoke(
+        cli,
+        _preallocate_args(
+            "irregular_axis_reverse_order",
+            "irregular_axis_reverse_order",
+            target_path,
+        ),
+    )
+
+    assert result.exit_code == 0, result.output
+    values = np.asarray(cast(Any, _root(target_path)["data/timestamp"])[:])
+    assert np.array_equal(values, _EXPECTED_TIMESTAMPS)

--- a/tests/integration/test_zarr_index_show_derived.py
+++ b/tests/integration/test_zarr_index_show_derived.py
@@ -1,0 +1,257 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import datetime
+import filecmp
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from firecube.cli.main import cli
+from firecube.core.controlplane.types import (
+    INDEX_CURRENT_FILENAME,
+    INDEX_DIRNAME,
+    ResolvedIndexRecord,
+    compute_resolved_index_identity_hash,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_regular_time_record(
+    cube_dir: Path,
+    *,
+    epoch: str = "2024-01-01T00:00:00Z",
+    cadence_s: int = 600,
+    slot_count: int = 3,
+    product_name: str = "test_product",
+) -> ResolvedIndexRecord:
+    index: dict = {
+        "schema_version": "v1",
+        "name": product_name,
+        "groups": {
+            "data": {
+                "kind": "regular_time",
+                "size": slot_count,
+                "params": {
+                    "epoch": epoch,
+                    "cadence_s": cadence_s,
+                    "mode": "exact",
+                },
+            }
+        },
+    }
+    identity_hash = compute_resolved_index_identity_hash(index)
+    record = ResolvedIndexRecord(
+        recorded_at="2026-08-24T00:00:00Z",
+        recorded_by_run_id="test-run",
+        identity_hash=identity_hash,
+        index=index,
+    )
+    index_dir = cube_dir / ".firecube" / INDEX_DIRNAME
+    index_dir.mkdir(parents=True, exist_ok=True)
+    (index_dir / INDEX_CURRENT_FILENAME).write_bytes(record.to_json_bytes())
+    return record
+
+
+def _seed_irregular_time_record(cube_dir: Path) -> ResolvedIndexRecord:
+    index: dict = {
+        "schema_version": "v1",
+        "name": "test_product",
+        "groups": {
+            "data": {
+                "kind": "irregular_time",
+                "size": 2,
+                "params": {
+                    "coordinate": "time",
+                    "values": ["2024-01-01T00:00:00.000000000Z", "2024-01-02T00:00:00.000000000Z"],
+                },
+            }
+        },
+    }
+    identity_hash = compute_resolved_index_identity_hash(index)
+    record = ResolvedIndexRecord(
+        recorded_at="2026-08-24T00:00:00Z",
+        recorded_by_run_id="test-run",
+        identity_hash=identity_hash,
+        index=index,
+    )
+    index_dir = cube_dir / ".firecube" / INDEX_DIRNAME
+    index_dir.mkdir(parents=True, exist_ok=True)
+    (index_dir / INDEX_CURRENT_FILENAME).write_bytes(record.to_json_bytes())
+    return record
+
+
+def _seed_integer_record(cube_dir: Path) -> ResolvedIndexRecord:
+    index: dict = {
+        "schema_version": "v1",
+        "name": "test_product",
+        "groups": {
+            "data": {
+                "kind": "integer",
+                "size": 4,
+                "params": {},
+            }
+        },
+    }
+    identity_hash = compute_resolved_index_identity_hash(index)
+    record = ResolvedIndexRecord(
+        recorded_at="2026-08-24T00:00:00Z",
+        recorded_by_run_id="test-run",
+        identity_hash=identity_hash,
+        index=index,
+    )
+    index_dir = cube_dir / ".firecube" / INDEX_DIRNAME
+    index_dir.mkdir(parents=True, exist_ok=True)
+    (index_dir / INDEX_CURRENT_FILENAME).write_bytes(record.to_json_bytes())
+    return record
+
+
+def _seed_regular_time_record_missing_epoch(cube_dir: Path) -> ResolvedIndexRecord:
+    index: dict = {
+        "schema_version": "v1",
+        "name": "test_product",
+        "groups": {
+            "data": {
+                "kind": "regular_time",
+                "size": 3,
+                "params": {
+                    "cadence_s": 600,
+                    "mode": "exact",
+                },
+            }
+        },
+    }
+    identity_hash = compute_resolved_index_identity_hash(index)
+    record = ResolvedIndexRecord(
+        recorded_at="2026-08-24T00:00:00Z",
+        recorded_by_run_id="test-run",
+        identity_hash=identity_hash,
+        index=index,
+    )
+    index_dir = cube_dir / ".firecube" / INDEX_DIRNAME
+    index_dir.mkdir(parents=True, exist_ok=True)
+    (index_dir / INDEX_CURRENT_FILENAME).write_bytes(record.to_json_bytes())
+    return record
+
+
+def _show_args(cube_dir: Path, *extras: str) -> list[str]:
+    return [
+        "zarr",
+        "index",
+        "show",
+        "--target",
+        f"file://{cube_dir}",
+        "--product-name",
+        "test_product",
+        *extras,
+    ]
+
+
+def test_show_help_includes_derived_flag() -> None:
+    result = CliRunner().invoke(cli, ["zarr", "index", "show", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--derived" in result.output
+
+
+def test_derived_regular_time_produces_correct_coordinates(tmp_path: Path) -> None:
+    cube = tmp_path / "cube"
+    cube.mkdir()
+    epoch = "2024-01-01T00:00:00Z"
+    cadence_s = 600
+    slot_count = 3
+    _seed_regular_time_record(cube, epoch=epoch, cadence_s=cadence_s, slot_count=slot_count)
+
+    result = CliRunner().invoke(cli, _show_args(cube, "--derived"))
+
+    assert result.exit_code == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    epoch_dt = datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC)
+    delta = datetime.timedelta(seconds=cadence_s)
+    expected = [
+        (epoch_dt + i * delta).isoformat().replace("+00:00", "Z") for i in range(slot_count)
+    ]
+    for coord in expected:
+        assert coord in result.stdout, f"Expected {coord!r} in output"
+    assert "derived_coordinates" in result.stdout
+
+
+def test_derived_does_not_persist_anything(tmp_path: Path) -> None:
+    cube = tmp_path / "cube"
+    cube.mkdir()
+    _seed_regular_time_record(cube)
+
+    snapshot_before = tmp_path / "snapshot_before"
+    shutil.copytree(cube, snapshot_before)
+
+    result = CliRunner().invoke(cli, _show_args(cube, "--derived"))
+    assert result.exit_code == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+    comparison = filecmp.dircmp(str(cube), str(snapshot_before))
+    assert not comparison.left_only, f"New files after --derived: {comparison.left_only}"
+    assert not comparison.right_only, f"Files removed after --derived: {comparison.right_only}"
+    assert not comparison.diff_files, f"Files changed after --derived: {comparison.diff_files}"
+
+
+def test_derived_irregular_time_is_noop_with_note(tmp_path: Path) -> None:
+    cube = tmp_path / "cube"
+    cube.mkdir()
+    _seed_irregular_time_record(cube)
+
+    result = CliRunner().invoke(cli, _show_args(cube, "--derived"))
+
+    assert result.exit_code == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "derived_coordinates" not in result.stdout
+    assert "no-op" in result.stderr or "note" in result.stderr
+
+
+def test_derived_integer_axis_is_noop_with_note(tmp_path: Path) -> None:
+    cube = tmp_path / "cube"
+    cube.mkdir()
+    _seed_integer_record(cube)
+
+    result = CliRunner().invoke(cli, _show_args(cube, "--derived"))
+
+    assert result.exit_code == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "derived_coordinates" not in result.stdout
+    assert "no-op" in result.stderr or "note" in result.stderr
+
+
+def test_derived_missing_epoch_fails_with_actionable_error(tmp_path: Path) -> None:
+    cube = tmp_path / "cube"
+    cube.mkdir()
+    _seed_regular_time_record_missing_epoch(cube)
+
+    result = CliRunner().invoke(cli, _show_args(cube, "--derived"))
+
+    assert result.exit_code != 0, f"Expected failure; stdout={result.stdout!r}"
+    assert "epoch" in result.output or "epoch" in (result.stderr or "")
+
+
+def test_no_derived_flag_output_unchanged(tmp_path: Path) -> None:
+    cube = tmp_path / "cube"
+    cube.mkdir()
+    _seed_regular_time_record(cube)
+
+    result_plain = CliRunner().invoke(cli, _show_args(cube))
+    result_no_derived = CliRunner().invoke(cli, _show_args(cube, "--no-derived"))
+
+    assert result_plain.exit_code == 0
+    assert result_no_derived.exit_code == 0
+    assert result_plain.stdout == result_no_derived.stdout
+    assert "derived_coordinates" not in result_plain.stdout

--- a/tests/integration/test_zarr_preallocate_dry_run.py
+++ b/tests/integration/test_zarr_preallocate_dry_run.py
@@ -1,0 +1,161 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from firecube.cli.main import cli
+from firecube.ingestor.registry import loader as _loader
+
+pytestmark = pytest.mark.integration
+
+PLUGIN_NAME = "irregular_axis_safe"
+PRODUCT_NAME = "irregular_axis_safe"
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_registry() -> Iterator[None]:
+    original_loaded = _loader._LOADED
+    original_registry = dict(_loader.AVAILABLE_INGESTORS)
+    _loader._LOADED = False
+    _loader.AVAILABLE_INGESTORS.clear()
+    importlib.reload(importlib.import_module("irregular_axis_test_plugin"))
+    yield
+    _loader._LOADED = original_loaded
+    _loader.AVAILABLE_INGESTORS.clear()
+    _loader.AVAILABLE_INGESTORS.update(original_registry)
+
+
+def _dry_run_args(target_dir: Path) -> list[str]:
+    return [
+        "zarr",
+        "preallocate",
+        PLUGIN_NAME,
+        "--target",
+        f"file://{target_dir}",
+        "--product-name",
+        PRODUCT_NAME,
+        "--storage-type",
+        "local",
+        "--storage-driver",
+        "fsspec",
+        "--write-mode",
+        "staged",
+        "--dry-run",
+    ]
+
+
+def _real_preallocate_args(target_dir: Path) -> list[str]:
+    return [
+        "zarr",
+        "preallocate",
+        PLUGIN_NAME,
+        "--target",
+        f"file://{target_dir}",
+        "--product-name",
+        PRODUCT_NAME,
+        "--storage-type",
+        "local",
+        "--storage-driver",
+        "fsspec",
+        "--write-mode",
+        "staged",
+    ]
+
+
+def _index_show_args(target_dir: Path) -> list[str]:
+    return [
+        "zarr",
+        "index",
+        "show",
+        "--target",
+        f"file://{target_dir}",
+        "--product-name",
+        PRODUCT_NAME,
+        "--json",
+    ]
+
+
+def test_dry_run_help_shows_flag() -> None:
+    result = CliRunner().invoke(cli, ["zarr", "preallocate", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "--dry-run" in result.output
+
+
+def test_dry_run_exits_zero(tmp_path: Path) -> None:
+    target_dir = tmp_path / "out.zarr"
+    result = CliRunner().invoke(cli, _dry_run_args(target_dir))
+    assert result.exit_code == 0, result.output
+
+
+def test_dry_run_output_is_valid_json_with_required_keys(tmp_path: Path) -> None:
+    target_dir = tmp_path / "out.zarr"
+    result = CliRunner().invoke(cli, _dry_run_args(target_dir))
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert "identity_hash" in parsed
+    assert "index" in parsed
+    assert len(parsed["identity_hash"]) == 64
+
+
+def test_dry_run_makes_no_filesystem_mutations(tmp_path: Path) -> None:
+    target_dir = tmp_path / "out.zarr"
+    before = set(tmp_path.rglob("*"))
+    result = CliRunner().invoke(cli, _dry_run_args(target_dir))
+    assert result.exit_code == 0, result.output
+    after = set(tmp_path.rglob("*"))
+    new_files = after - before
+    assert new_files == set(), (
+        f"dry-run created unexpected filesystem entries: {sorted(str(p) for p in new_files)}"
+    )
+
+
+def test_dry_run_output_is_deterministic(tmp_path: Path) -> None:
+    target_dir = tmp_path / "out.zarr"
+    r1 = CliRunner().invoke(cli, _dry_run_args(target_dir))
+    r2 = CliRunner().invoke(cli, _dry_run_args(target_dir))
+    assert r1.exit_code == 0, r1.output
+    assert r2.exit_code == 0, r2.output
+    assert r1.stdout == r2.stdout
+    payload = json.loads(r1.output)
+    assert payload["recorded_at"] == "dry-run"
+    assert len(payload["identity_hash"]) == 64
+
+
+def test_dry_run_identity_hash_equals_real_preallocate(tmp_path: Path) -> None:
+    """Safety contract 7: dry-run identity_hash must equal the real preallocate identity_hash."""
+    target_dir = tmp_path / "out.zarr"
+
+    dry_result = CliRunner().invoke(cli, _dry_run_args(target_dir))
+    assert dry_result.exit_code == 0, dry_result.output
+    dry_hash = json.loads(dry_result.output)["identity_hash"]
+
+    real_result = CliRunner().invoke(cli, _real_preallocate_args(target_dir))
+    assert real_result.exit_code == 0, real_result.output
+
+    show_result = CliRunner().invoke(cli, _index_show_args(target_dir))
+    assert show_result.exit_code == 0, show_result.output
+    real_hash = json.loads(show_result.output)["identity_hash"]
+
+    assert dry_hash == real_hash, (
+        f"dry-run identity_hash {dry_hash[:16]}... != "
+        f"real preallocate identity_hash {real_hash[:16]}..."
+    )

--- a/tests/sdk/test_api_docs_coverage.py
+++ b/tests/sdk/test_api_docs_coverage.py
@@ -54,6 +54,11 @@ PUBLIC_MODULES = (
 # a reason; remove the entry when the name gains a reference page.
 INTENTIONALLY_UNDOCUMENTED: dict[str, dict[str, str]] = {
     "firecube.ingestor.api": {
+        # Content-addressed manifest types: public re-exports used by the engine
+        # for IrregularTimeAxis AUTO planning. Plugin authors do not construct
+        # these directly; they are engine-internal planning data.
+        "ItemManifestEntry": "engine-internal planning type; plugin authors do not construct this",
+        "validate_manifest_entries": "engine-internal manifest validation helper",
         # Engine write-strategy implementations, not an authoring surface.
         "AppendStrategy": "engine write strategy",
         "AppendWriteStrategy": "engine write strategy",
@@ -89,6 +94,11 @@ INTENTIONALLY_UNDOCUMENTED: dict[str, dict[str, str]] = {
         "warn_if_misaligned": "engine-internal; not part of the plugin-authoring surface",
     },
     "firecube.core.api": {
+        # Content-addressed manifest types: public re-exports used by the engine
+        # for IrregularTimeAxis AUTO planning. Plugin authors do not construct
+        # these directly; they are engine-internal planning data.
+        "ItemManifestEntry": "engine-internal planning type; plugin authors do not construct this",
+        "validate_manifest_entries": "engine-internal manifest validation helper",
         # Control-plane, archive, and host-integration helpers.
         "CatalogGroupInfo": "host integration type",
         "RegionZarrWriterProtocol": "engine writer protocol",

--- a/tests/unit/test_controlplane_types.py
+++ b/tests/unit/test_controlplane_types.py
@@ -1,0 +1,293 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for content-addressed item manifest schema on ResolvedIndexRecord.
+
+Covers:
+
+- Byte parity: RegularTimeAxis / IntegerAxis records unchanged pre and post
+  the schema addition (asymmetric items handling).
+- Freeze detection: manifest items fold into identity_hash so adding or
+  removing an item mutates the recorded value.
+- Validation: ``validate_manifest_entries`` rejects duplicate identity_hashes,
+  duplicate coordinate_values, and empty source_ref.
+- Wire round-trip: with-manifest records survive to_json_bytes /
+  from_json_bytes preserving item content.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from firecube.core.controlplane.types import (
+    ItemManifestEntry,
+    ResolvedIndexRecord,
+    canonical_index_bytes,
+    compute_resolved_index_identity_hash,
+    validate_manifest_entries,
+)
+from firecube.core.errors import ManifestError
+
+
+def _regular_index() -> dict[str, object]:
+    return {
+        "schema_version": "v1",
+        "name": "resolved_index",
+        "groups": {
+            "data": {
+                "kind": "regular_time",
+                "size": 10,
+                "params": {
+                    "epoch": "2024-01-01T00:00:00Z",
+                    "cadence_s": 600,
+                    "mode": "exact",
+                },
+            },
+        },
+    }
+
+
+def _integer_index() -> dict[str, object]:
+    return {
+        "schema_version": "v1",
+        "name": "resolved_index",
+        "groups": {
+            "data": {"kind": "integer", "size": 5, "params": {}},
+        },
+    }
+
+
+def _make_record(
+    *,
+    index: dict[str, object],
+    items: tuple[ItemManifestEntry, ...] | None = None,
+    recorded_at: str = "2026-01-01T00:00:00Z",
+    recorded_by_run_id: str = "run-abc",
+) -> ResolvedIndexRecord:
+    identity_hash = compute_resolved_index_identity_hash(index, items)
+    return ResolvedIndexRecord(
+        schema_version="v1",
+        recorded_at=recorded_at,
+        recorded_by_run_id=recorded_by_run_id,
+        identity_hash=identity_hash,
+        index=index,
+        items=items,
+    )
+
+
+def _sample_items() -> tuple[ItemManifestEntry, ...]:
+    return (
+        ItemManifestEntry(
+            identity_hash="a" * 64,
+            coordinate_value="2024-01-01T00:00:00Z",
+            source_ref="s3://bucket/one.nc",
+            source_ref_kind="uri",
+        ),
+        ItemManifestEntry(
+            identity_hash="b" * 64,
+            coordinate_value="2024-01-01T00:10:00Z",
+            source_ref="s3://bucket/two.nc",
+            source_ref_kind="uri",
+        ),
+    )
+
+
+def _coordinate_order_items() -> tuple[ItemManifestEntry, ...]:
+    return (
+        ItemManifestEntry(
+            identity_hash="z" * 64,
+            coordinate_value="2024-01-01T00:10:00Z",
+            source_ref="s3://bucket/later.nc",
+            source_ref_kind="uri",
+        ),
+        ItemManifestEntry(
+            identity_hash="a" * 64,
+            coordinate_value="2024-01-01T00:00:00Z",
+            source_ref="s3://bucket/earlier.nc",
+            source_ref_kind="uri",
+        ),
+    )
+
+
+def test_regular_axis_identity_hash_unchanged_after_schema() -> None:
+    index = _regular_index()
+    pre_manifest_hash = hashlib.sha256(canonical_index_bytes(index)).hexdigest()
+    record = _make_record(index=index)
+    assert record.items is None
+    assert record.identity_hash == pre_manifest_hash
+
+
+def test_integer_axis_identity_hash_unchanged_after_schema() -> None:
+    index = _integer_index()
+    pre_manifest_hash = hashlib.sha256(canonical_index_bytes(index)).hexdigest()
+    record = _make_record(index=index)
+    assert record.items is None
+    assert record.identity_hash == pre_manifest_hash
+
+
+def test_to_json_bytes_omits_items_key_when_none() -> None:
+    record = _make_record(index=_regular_index())
+    payload = json.loads(record.to_json_bytes())
+    assert "items" not in payload
+
+
+def test_manifest_items_affect_identity_hash() -> None:
+    index = _regular_index()
+    record_no_items = _make_record(index=index)
+    record_with_items = _make_record(index=index, items=_sample_items())
+    assert record_no_items.identity_hash != record_with_items.identity_hash
+
+
+def test_manifest_item_content_changes_identity_hash() -> None:
+    index = _regular_index()
+    items_a = _sample_items()
+    items_b = (
+        items_a[0],
+        ItemManifestEntry(
+            identity_hash="c" * 64,
+            coordinate_value="2024-01-01T00:20:00Z",
+            source_ref="s3://bucket/three.nc",
+            source_ref_kind="uri",
+        ),
+    )
+    assert (
+        _make_record(index=index, items=items_a).identity_hash
+        != _make_record(index=index, items=items_b).identity_hash
+    )
+
+
+def test_manifest_item_order_does_not_affect_identity_hash() -> None:
+    index = _regular_index()
+    items = _sample_items()
+    forward = _make_record(index=index, items=items)
+    reversed_ = _make_record(index=index, items=items[::-1])
+    assert forward.identity_hash == reversed_.identity_hash
+
+
+def test_to_json_bytes_sorts_items_by_coordinate_value() -> None:
+    record = _make_record(index=_regular_index(), items=_coordinate_order_items())
+    payload = json.loads(record.to_json_bytes())
+
+    assert [item["coordinate_value"] for item in payload["items"]] == [
+        "2024-01-01T00:00:00Z",
+        "2024-01-01T00:10:00Z",
+    ]
+
+
+def test_validate_manifest_entries_accepts_valid_entries() -> None:
+    validate_manifest_entries(list(_sample_items()))
+
+
+def test_validate_manifest_entries_rejects_duplicate_identity_hashes() -> None:
+    entries = [
+        ItemManifestEntry(
+            identity_hash="same" + "0" * 60,
+            coordinate_value="2024-01-01T00:00:00Z",
+            source_ref="s3://bucket/a.nc",
+            source_ref_kind="uri",
+        ),
+        ItemManifestEntry(
+            identity_hash="same" + "0" * 60,
+            coordinate_value="2024-01-01T00:10:00Z",
+            source_ref="s3://bucket/b.nc",
+            source_ref_kind="uri",
+        ),
+    ]
+    with pytest.raises(ValueError, match="duplicate identity_hash"):
+        validate_manifest_entries(entries)
+
+
+def test_validate_manifest_entries_rejects_duplicate_coordinate_values() -> None:
+    entries = [
+        ItemManifestEntry(
+            identity_hash="a" * 64,
+            coordinate_value="2024-01-01T00:00:00Z",
+            source_ref="s3://bucket/a.nc",
+            source_ref_kind="uri",
+        ),
+        ItemManifestEntry(
+            identity_hash="b" * 64,
+            coordinate_value="2024-01-01T00:00:00Z",
+            source_ref="s3://bucket/b.nc",
+            source_ref_kind="uri",
+        ),
+    ]
+    with pytest.raises(ValueError, match="duplicate coordinate_value"):
+        validate_manifest_entries(entries)
+
+
+def test_validate_manifest_entries_rejects_empty_source_ref() -> None:
+    entries = [
+        ItemManifestEntry(
+            identity_hash="a" * 64,
+            coordinate_value="2024-01-01T00:00:00Z",
+            source_ref="",
+            source_ref_kind="uri",
+        ),
+    ]
+    with pytest.raises(ValueError, match="source_ref must be non-empty"):
+        validate_manifest_entries(entries)
+
+
+def test_round_trip_preserves_manifest() -> None:
+    record = _make_record(index=_regular_index(), items=_sample_items())
+    recovered = ResolvedIndexRecord.from_json_bytes(record.to_json_bytes())
+    assert recovered.identity_hash == record.identity_hash
+    assert recovered.items is not None
+    assert len(recovered.items) == len(_sample_items())
+    recovered_hashes = {entry.identity_hash for entry in recovered.items}
+    expected_hashes = {entry.identity_hash for entry in _sample_items()}
+    assert recovered_hashes == expected_hashes
+
+
+def test_round_trip_preserves_absence_of_manifest() -> None:
+    record = _make_record(index=_regular_index())
+    recovered = ResolvedIndexRecord.from_json_bytes(record.to_json_bytes())
+    assert recovered.items is None
+
+
+def test_from_json_bytes_rejects_tampered_manifest() -> None:
+    record = _make_record(index=_regular_index(), items=_sample_items())
+    payload = json.loads(record.to_json_bytes())
+    assert isinstance(payload["items"], list) and payload["items"]
+    payload["items"][0]["identity_hash"] = "d" * 64
+    with pytest.raises(ManifestError, match="identity-hash mismatch"):
+        ResolvedIndexRecord.from_json_bytes(json.dumps(payload).encode("utf-8"))
+
+
+def test_from_json_bytes_rejects_invalid_source_ref_kind() -> None:
+    record = _make_record(index=_regular_index(), items=_sample_items())
+    payload = json.loads(record.to_json_bytes())
+    payload["items"][0]["source_ref_kind"] = "bogus"
+    with pytest.raises(ManifestError, match="source_ref_kind"):
+        ResolvedIndexRecord.from_json_bytes(json.dumps(payload).encode("utf-8"))
+
+
+def test_item_manifest_entry_is_reexported_from_public_apis() -> None:
+    from firecube.core.api import ItemManifestEntry as CoreEntry
+    from firecube.ingestor.api import ItemManifestEntry as IngestorEntry
+
+    assert CoreEntry is ItemManifestEntry
+    assert IngestorEntry is ItemManifestEntry
+
+
+def test_validate_manifest_entries_is_reexported_from_public_apis() -> None:
+    from firecube.core.api import validate_manifest_entries as core_fn
+    from firecube.ingestor.api import validate_manifest_entries as ingestor_fn
+
+    assert core_fn is validate_manifest_entries
+    assert ingestor_fn is validate_manifest_entries

--- a/tests/unit/test_index_binding.py
+++ b/tests/unit/test_index_binding.py
@@ -1,0 +1,167 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for planning-time AUTO irregular-axis discovery."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from firecube.core.errors import (
+    DuplicateIrregularCoordinateError,
+    MissingIrregularCoordinateError,
+    NoDiscoveredItemsError,
+)
+from firecube.core.index_spec import AUTO, IndexSpec, IntegerAxis, IrregularTimeAxis, ItemInfo
+from firecube.ingestor.runtime.index_binding import resolve_index_spec_for_ingestor
+
+
+class _AutoIngestor:
+    def __init__(self, spec: IndexSpec, coordinates: dict[str, Any], items: list[Any]) -> None:
+        self._spec = spec
+        self._coordinates = coordinates
+        self._items = items
+        self.inspect_calls: list[Any] = []
+
+    def index_spec(self, ctx: Any) -> IndexSpec:
+        return self._spec
+
+    def _resolve_time_dim_name(self) -> str:
+        return "time"
+
+    def discover_source_files(self, ctx: Any) -> list[Any]:
+        return list(self._items)
+
+    def filter_item(self, item: Any, ctx: Any) -> bool:
+        return True
+
+    def inspect_item(self, item: Any, ctx: Any) -> ItemInfo | None:
+        self.inspect_calls.append(item)
+        coordinate = self._coordinates.get(str(item))
+        if coordinate is None:
+            return None
+        return ItemInfo(coordinate=coordinate)
+
+
+def _auto_spec(axis: IrregularTimeAxis | None = None) -> IndexSpec:
+    return IndexSpec(
+        name="auto_irregular_v1",
+        groups={"data": axis or IrregularTimeAxis(coordinate="time", values=AUTO)},
+    )
+
+
+def _ctx(source: object = "source") -> SimpleNamespace:
+    return SimpleNamespace(source=source)
+
+
+def test_resolve_index_spec_for_ingestor_discovers_sorts_and_manifests(tmp_path) -> None:
+    later = tmp_path / "later.txt"
+    earlier = tmp_path / "earlier.txt"
+    later.write_text("later", encoding="utf-8")
+    earlier.write_text("earlier", encoding="utf-8")
+    ingestor = _AutoIngestor(
+        _auto_spec(),
+        {
+            str(later): "2024-01-01T00:10:00Z",
+            str(earlier): "2024-01-01T00:00:00Z",
+        },
+        [later, earlier],
+    )
+
+    binding = resolve_index_spec_for_ingestor(ingestor, _ctx(tmp_path))
+
+    assert binding is not None
+    assert binding.resolved.size("data") == 2
+    assert binding.resolved.coordinate("data", 0) == "2024-01-01T00:00:00Z"
+    assert binding.resolved.coordinate("data", 1) == "2024-01-01T00:10:00Z"
+    assert binding.resolved.items is not None
+    assert [entry.source_ref for entry in binding.resolved.items] == [str(earlier), str(later)]
+    assert [entry.source_ref_kind for entry in binding.resolved.items] == ["path", "path"]
+    assert [entry.coordinate_value for entry in binding.resolved.items] == [
+        "2024-01-01T00:00:00Z",
+        "2024-01-01T00:10:00Z",
+    ]
+
+
+def test_resolve_index_spec_for_ingestor_is_deterministic_for_same_source_state(tmp_path) -> None:
+    one = tmp_path / "one.txt"
+    two = tmp_path / "two.txt"
+    one.write_text("one", encoding="utf-8")
+    two.write_text("two", encoding="utf-8")
+    coordinates = {
+        str(two): "2024-01-01T00:10:00Z",
+        str(one): "2024-01-01T00:00:00Z",
+    }
+
+    first = resolve_index_spec_for_ingestor(
+        _AutoIngestor(_auto_spec(), coordinates, [two, one]), _ctx(tmp_path)
+    )
+    second = resolve_index_spec_for_ingestor(
+        _AutoIngestor(_auto_spec(), coordinates, [two, one]), _ctx(tmp_path)
+    )
+
+    assert first is not None and second is not None
+    assert first.resolved.identity_hash == second.resolved.identity_hash
+    first_record = first.resolved.as_resolved_index_record(
+        run_id="r", recorded_at="2026-08-24T00:00:00Z"
+    )
+    second_record = second.resolved.as_resolved_index_record(
+        run_id="r", recorded_at="2026-08-24T00:00:00Z"
+    )
+    assert first_record.to_json_bytes() == second_record.to_json_bytes()
+
+
+def test_resolve_index_spec_for_ingestor_rejects_duplicate_coordinates(tmp_path) -> None:
+    one = tmp_path / "one.txt"
+    two = tmp_path / "two.txt"
+    one.write_text("one", encoding="utf-8")
+    two.write_text("two", encoding="utf-8")
+    ingestor = _AutoIngestor(
+        _auto_spec(),
+        {str(one): "2024-01-01T00:00:00Z", str(two): "2024-01-01T00:00:00Z"},
+        [one, two],
+    )
+
+    with pytest.raises(DuplicateIrregularCoordinateError, match="coordinates must be unique"):
+        resolve_index_spec_for_ingestor(ingestor, _ctx(tmp_path))
+
+
+def test_resolve_index_spec_for_ingestor_rejects_empty_discovery() -> None:
+    ingestor = _AutoIngestor(_auto_spec(), {}, [])
+
+    with pytest.raises(NoDiscoveredItemsError, match="no items found"):
+        resolve_index_spec_for_ingestor(ingestor, _ctx("empty-source"))
+
+
+def test_resolve_index_spec_for_ingestor_rejects_missing_coordinate(tmp_path) -> None:
+    item = tmp_path / "missing.txt"
+    item.write_text("missing", encoding="utf-8")
+    ingestor = _AutoIngestor(_auto_spec(), {}, [item])
+
+    with pytest.raises(MissingIrregularCoordinateError, match="no resolvable coordinate"):
+        resolve_index_spec_for_ingestor(ingestor, _ctx(tmp_path))
+
+
+def test_resolve_index_spec_for_ingestor_does_not_inspect_non_irregular_auto_axes() -> None:
+    spec = IndexSpec(name="integer_v1", groups={"data": IntegerAxis(slot_count=2)})
+    ingestor = _AutoIngestor(spec, {}, ["a", "b"])
+
+    binding = resolve_index_spec_for_ingestor(ingestor, _ctx())
+
+    assert binding is not None
+    assert binding.resolved.items is None
+    assert ingestor.inspect_calls == []

--- a/tests/unit/test_index_resolve_irregular.py
+++ b/tests/unit/test_index_resolve_irregular.py
@@ -1,0 +1,52 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation tests for irregular index resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from firecube.core.errors import ConfigurationError
+from firecube.core.index_resolve import resolve_index_spec
+from firecube.core.index_spec import IndexSpec, IrregularTimeAxis
+
+
+def _spec(*, coordinate: str) -> IndexSpec:
+    return IndexSpec(
+        name="irregular_v1",
+        groups={
+            "data": IrregularTimeAxis(
+                coordinate=coordinate,
+                values=("2024-01-01T00:00:00Z", "2024-01-01T00:10:00Z"),
+            )
+        },
+    )
+
+
+def test_irregular_time_axis_coordinate_mismatch_raises_configuration_error() -> None:
+    with pytest.raises(
+        ConfigurationError, match=r"IrregularTimeAxis\.coordinate='timestamp'|IrregularTimeAxis"
+    ) as exc_info:
+        resolve_index_spec(_spec(coordinate="timestamp"), time_dim_name="time")
+
+    message = str(exc_info.value)
+    assert "IrregularTimeAxis.coordinate='timestamp'" in message
+    assert "time_dim_name='time'" in message
+
+
+def test_irregular_time_axis_coordinate_match_resolves() -> None:
+    resolved = resolve_index_spec(_spec(coordinate="time"), time_dim_name="time")
+
+    assert resolved.groups == ("data",)

--- a/tests/unit/test_index_spec.py
+++ b/tests/unit/test_index_spec.py
@@ -1,0 +1,54 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from firecube.core.api import AUTO, IrregularTimeAxis
+from firecube.ingestor.api import AUTO as INGESTOR_AUTO
+
+
+def test_irregular_time_axis_accepts_auto() -> None:
+    axis = IrregularTimeAxis(coordinate="time", values=AUTO)
+
+    assert axis.coordinate == "time"
+    assert axis.values is AUTO
+
+
+def test_irregular_time_axis_accepts_concrete_sequence() -> None:
+    axis = IrregularTimeAxis(coordinate="obs_time", values=[1, 2, 3])
+
+    assert axis.coordinate == "obs_time"
+    assert axis.values == (1, 2, 3)
+
+
+def test_irregular_time_axis_rejects_empty_sequence() -> None:
+    try:
+        IrregularTimeAxis(coordinate="time", values=[])
+    except ValueError as exc:
+        assert "non-empty" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("empty sequence was accepted")
+
+
+def test_irregular_time_axis_rejects_duplicate_values() -> None:
+    try:
+        IrregularTimeAxis(coordinate="time", values=[1, 1])
+    except ValueError as exc:
+        assert "duplicates" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("duplicate values were accepted")
+
+
+def test_auto_is_singleton_across_facades() -> None:
+    assert AUTO is INGESTOR_AUTO

--- a/tests/unit/test_schema_drift_error.py
+++ b/tests/unit/test_schema_drift_error.py
@@ -14,7 +14,15 @@
 
 from __future__ import annotations
 
-from firecube.core.errors import FirecubeError, SchemaDriftError
+from firecube.core import api as core_api
+from firecube.core.errors import (
+    ConfigurationError,
+    FirecubeError,
+    MissingIrregularCoordinateError,
+    NoDiscoveredItemsError,
+    SchemaDriftError,
+)
+from firecube.ingestor import api as ingestor_api
 from firecube.ingestor import errors as ingestor_errors
 
 
@@ -24,3 +32,49 @@ def test_schema_drift_error_inherits_firecube_error() -> None:
 
 def test_schema_drift_error_reexported_from_ingestor_errors() -> None:
     assert ingestor_errors.SchemaDriftError is SchemaDriftError
+
+
+def test_missing_irregular_coordinate_error_contract() -> None:
+    error = MissingIrregularCoordinateError("timestamp", 7)
+    missing_item = MissingIrregularCoordinateError("time", None)
+
+    assert issubclass(MissingIrregularCoordinateError, ConfigurationError)
+    assert isinstance(error, ConfigurationError)
+    assert error.coordinate_name == "timestamp"
+    assert error.item_id == 7
+    assert str(error) == (
+        "IrregularTimeAxis discovery: item 7 has no resolvable coordinate for 'timestamp'"
+    )
+    assert missing_item.coordinate_name == "time"
+    assert missing_item.item_id is None
+    assert str(missing_item) == (
+        "IrregularTimeAxis discovery: item None has no resolvable coordinate for 'time'"
+    )
+
+
+def test_missing_irregular_coordinate_error_reexported_from_facades() -> None:
+    assert core_api.MissingIrregularCoordinateError is MissingIrregularCoordinateError
+    assert ingestor_api.MissingIrregularCoordinateError is MissingIrregularCoordinateError
+
+
+def test_no_discovered_items_error_contract() -> None:
+    error = NoDiscoveredItemsError("timestamp", "source.nc")
+    missing_source = NoDiscoveredItemsError("time", None)
+
+    assert issubclass(NoDiscoveredItemsError, ConfigurationError)
+    assert isinstance(error, ConfigurationError)
+    assert error.coordinate_name == "timestamp"
+    assert error.source_ref == "source.nc"
+    assert str(error) == (
+        "IrregularTimeAxis discovery for 'timestamp': no items found in source 'source.nc'"
+    )
+    assert missing_source.coordinate_name == "time"
+    assert missing_source.source_ref is None
+    assert str(missing_source) == (
+        "IrregularTimeAxis discovery for 'time': no items found in source 'None'"
+    )
+
+
+def test_no_discovered_items_error_reexported_from_facades() -> None:
+    assert core_api.NoDiscoveredItemsError is NoDiscoveredItemsError
+    assert ingestor_api.NoDiscoveredItemsError is NoDiscoveredItemsError


### PR DESCRIPTION
## What changed

Adds a new `AxisSpec`, `IrregularTimeAxis(coordinate, values=AUTO)`  for irregular cadence. AUTO triggers planning-time discovery via inspect_item.  Adds `preallocate --dry-run` and `index show --derived` CLI flags, three public exceptions (`MissingIrregularCoordinateError`, `NoDiscoveredItemsError`, `DuplicateIrregularCoordinateError`), and    
an item manifest persisted through the existing ResolvedIndexRecord` path.      

## Why

Extends the `AxisSpec family to irregular slot counts and timestamps that are not known at plugin authoring time. Complements #53 (RegularTimeAxis) and #54 (IntegerAxis + ResolvedIndexRecord)

Together with those, `AxisSpec` now covers regular, integer-indexed, and irregular time axes with either explicit values or **AUTO discovery.** 

Closes #27  (the literal ask is already closed by #53; this completes the axis-type family).  

## Affected behavior

<!-- Which user, operator, plugin, or maintainer behavior changes? -->

- User / CLI: two new flags: `firecube zarr preallocate --dry-run` (prints what would happen without changing), and `firecube zarr index show --derived` (computes RegularTimeAxis coordinates at read time).
- Plugin authors: new `IrregularTimeAxis` importable from `firecube.core.api` and `firecube.ingestor.api`.
- Operators / production: N/A
- Stored formats or control-plane state: 

## Type of changeshort

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (CLI flags, plugin contract, config, or stored format)
- [x] Documentation
- [ ] CI / build / chore

## Checks run

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [ ] `uv run --with bandit bandit -c pyproject.toml -r src scripts -lll`
- [x] `uv run pytest --strict-deps -m "not slow and not s3" -q`
- [x] Docs build (if docs changed): `uv run mkdocs build --strict`

## Follow-up work

Plugin follow-up is out of scope.

## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
