### PR TITLE
feat(zarr): static-owner fan-out + compare CLI + write-empty-chunks option + public API exports + HDF5/ZIP hardening (fixes #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,34 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 - New `zarr_region_write_concurrency` template config option (integer, default
   1) controls the maximum number of concurrent region writes per slot. Values
   < 1 are rejected at config validation time.
+- `firecube zarr compare` subcommand and `compare_zarr_stores()` /
+  `ZarrCompareReport` in `firecube.core.api`: read-only equivalence check of
+  two Zarr stores (paths, shape, dtype, chunks, dimension names, public attrs,
+  static marker, values). Exit `3` on mismatch, one stderr line per
+  difference.
+- `static_owner` field in the `firecube zarr slots` JSON plan: the range with
+  the smallest `slot_start` per group, for schedulers that route static-array
+  writes to one worker. Additive to the existing plan schema.
+- `--suppress-static-emission-for-non-owner` and `--static-owner-slot-start`
+  flags for `firecube ingest` (and the matching `EngineConfig` fields): a
+  slot-range worker skips static-array writes unless its `--slot-start`
+  equals the owner value from the plan. Requires `slot_start`; serial runs
+  reject the flag and always write statics.
+- `zarr_write_empty_chunks` typed template option (boolean, default `False`):
+  passes Zarr's `array.write_empty_chunks` setting through as a scoped config
+  for the write phase only. The effective value is reported in batch metrics
+  as `zarr_write_empty_chunks_effective`.
+- `firecube zarr validate` reports `static_marker_failures` for the validated
+  array when a static array lacks the `firecube_static_written` marker.
+- New public exports on `firecube.core.api` (and `firecube.ingestor.api`
+  where applicable): `ExtentUnknownError`, `UnboundedAxisError`,
+  `RESERVED_ARRAY_ATTRS`, `assert_attrs_safe`, `FIRECUBE_STATIC_WRITTEN_ATTR`,
+  `resolve_index_spec`, `extract_all_from_zip`, `BatchResourceRegistry`,
+  `physical_chunk_keys_for_region`, `chunk_axis_range`, and
+  `axis_selection_is_chunk_aligned`.
+- `extract_hdf5_from_zip` and `stream_hdf5_from_zip` accept an explicit
+  `member=` argument; archives with several HDF5 candidates are now rejected
+  with the candidate list instead of silently picking the first.
 
 ### Changed
 
@@ -133,6 +161,12 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 - README SBOM dependency tables synced with `uv.lock`; added `mike` to the
   docs dependency group and its SBOM table entry.
 - Reorganized plugin documentation and plugin author examples.
+- `read_hdf5_array` preserves the source dtype instead of casting everything
+  to `float32`; pass `dtype=` for an explicit cast. Callers relying on the
+  implicit `float32` cast must now request it.
+- A `DirectZarrIngestor` run whose declared regular axis has no fixed extent
+  fails with `UnboundedAxisError` (a `ConfigurationError`) naming the group,
+  instead of a raw `ExtentUnknownError`, in serial and parallel modes alike.
 
 ### Fixed
 
@@ -142,6 +176,19 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
   values that previously slipped through Python's `int` subclass semantics;
   accepted types are Python `int` and `numpy.integer` subclasses
   (e.g. `np.int64`).
+- DirectZarr arrays declaring a `fill_value` now carry the matching
+  `_FillValue` attribute, so xarray masks unwritten cells when reading with
+  `mask_and_scale=True` (#49). Only JSON-safe scalars are stamped: NaN, NaT,
+  and datetime fills are skipped to keep array metadata valid strict JSON and
+  the stores openable by xarray. Resuming into an existing store backfills the
+  attribute once.
+
+### Security
+
+- ZIP extraction helpers (`extract_hdf5_from_zip`, `stream_hdf5_from_zip`,
+  `extract_all_from_zip`) reject member names that could escape the
+  extraction root (`..` segments, absolute paths, Windows drive prefixes)
+  with `ValueError` instead of extracting them.
 
 ### Removed
 
@@ -394,3 +441,8 @@ the migration procedure including `firecube zarr index rebuild`.
 - `uv run mkdocs build --strict --site-dir /tmp/firecube-mkdocs-check`: passed.
 - `uv build`: built `firecube-0.1.1.tar.gz` and `firecube-0.1.1-py3-none-any.whl`.
 - `uv run --with twine twine check dist/*`: passed.
+
+[Unreleased]: https://github.com/eumetsat/firecube/compare/v0.1.4.post1...HEAD
+[0.1.4.post1]: https://github.com/eumetsat/firecube/compare/v0.1.4.post0...v0.1.4.post1
+[0.1.4.post0]: https://github.com/eumetsat/firecube/compare/v0.1.4...v0.1.4.post0
+[0.1.4]: https://github.com/eumetsat/firecube/releases/tag/v0.1.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/concepts/performance.md
+++ b/docs/concepts/performance.md
@@ -107,6 +107,13 @@ uv run firecube zarr validate \
 Use `--on-timeout fail` for CI or post-ingest gates that must fail when the
 validation budget is exceeded.
 
+The JSON report includes `static_marker_failures`. An empty list means the
+validated array either moves with the time axis or carries the
+`firecube_static_written` marker. A non-empty list after a parallel run means
+the static-owner worker did not finish its static writes: re-run the owner's
+slot range, then validate again. Arrays whose first dimension is `timestamp`,
+`time`, or `firecube_timestamp_state` never require the marker.
+
 ## If Memory Is Tight
 
 Memory pressure usually comes from batch size, worker count, source decoding, or

--- a/docs/operations/parallel-zarr-writes.md
+++ b/docs/operations/parallel-zarr-writes.md
@@ -76,6 +76,29 @@ Planning is resume-aware by default: completed ranges are excluded. Use
 `--no-resume` only when the scheduler must deliberately ignore recorded
 coverage and emit the full range.
 
+The JSON plan also names one range per group as the static owner. Read it with:
+
+```bash
+firecube zarr slots <plugin> \
+  --target file:///data/products/my_product.zarr \
+  --product-name my_product \
+  --storage-type local \
+  --storage-driver fsspec \
+  --write-mode direct \
+  --slot-size 144 \
+  --format json | jq '.groups[0].static_owner'
+```
+
+```json
+{
+  "slot_start": 0,
+  "slot_end": 144
+}
+```
+
+Use this value in step 3 so exactly one worker writes static arrays such as
+latitude and longitude grids.
+
 ## 3. Start One Worker Per Range
 
 Scale this workflow by starting more slot-assigned processes. Keep
@@ -100,6 +123,34 @@ firecube ingest <plugin> \
 
 A worker assigned `[0, 144)` owns indexes `0` through `143`. For a single-group
 plugin, `--slot-group` can be omitted.
+
+### Write Static Arrays Once
+
+Static arrays do not move with the time axis, so by default every worker
+rewrites them. To restrict them to one worker, add two flags to every worker
+command, using the `static_owner` value from the plan in step 2:
+
+```bash
+firecube ingest <plugin> \
+  --input-data /data/source \
+  --target file:///data/products/my_product.zarr \
+  --product-name my_product \
+  --storage-type local \
+  --storage-driver fsspec \
+  --output-format zarr \
+  --write-mode direct \
+  --option pipeline_workers=1 \
+  --slot-start 144 \
+  --slot-end 288 \
+  --suppress-static-emission-for-non-owner \
+  --static-owner-slot-start 0
+```
+
+The worker whose `--slot-start` equals `--static-owner-slot-start` writes the
+static arrays and stamps their markers. Every other worker skips them and logs
+one warning per skipped write. `static_owner` holds one value per group, so
+give each worker run a single `--slot-group` when owners differ between
+groups.
 
 ### Derive Ranges From A Scheduler Index
 

--- a/docs/operations/zarr-compare.md
+++ b/docs/operations/zarr-compare.md
@@ -1,0 +1,64 @@
+# Compare Zarr Stores
+
+## Purpose
+
+Check whether two Zarr stores are operationally equivalent after migration,
+re-ingestion, staging promotion, or a storage-driver change. The command is
+read-only and boolean: it either confirms equivalence or lists mismatches and
+exits nonzero, so it can gate a promotion step in a pipeline.
+
+## Prerequisites
+
+- Both inputs are complete Zarr store URIs (`file://` or `s3://`).
+- One storage type and one storage driver apply to both stores:
+  `--storage-type local` for `file://` stores, `--storage-type s3` for
+  `s3://` stores, and `--storage-driver fsspec` or `--storage-driver obstore`.
+- For `s3://` stores, credentials are configured as in
+  [Configure S3 Access](s3-access.md).
+
+## Procedure
+
+1. Run the comparison with both required flags:
+
+   ```bash
+   uv run firecube zarr compare \
+     file:///data/products/before.zarr \
+     file:///data/products/after.zarr \
+     --storage-type local \
+     --storage-driver fsspec
+   ```
+
+2. Check the result. No output and exit status `0` mean the stores matched.
+   On mismatch, the command writes one line per difference to stderr and
+   exits with status `3`:
+
+   ```text
+   array data/values: shape (2, 2) != (3, 2)
+   array data/lat: firecube_static_written True != None
+   ```
+
+The comparison covers array paths, shape, dtype, chunks, dimension names,
+public attrs, Firecube's static-array marker, and values. Runtime trace attrs
+are ignored. Any other nonzero exit status means the command could not run,
+for example because a URI is missing, a store has no Zarr metadata, or the
+storage flags do not match the URI scheme.
+
+## Failure Recovery
+
+| Symptom | Meaning | Recovery |
+| --- | --- | --- |
+| `Missing Zarr store metadata` | One input does not point at a Zarr store root. | Check the URI and rerun with the store directory, not a parent directory or array path. |
+| `shape`, `dtype`, `chunks`, or `dimension_names` mismatch | The stores use different array schemas. | Compare the ingestion configuration and plugin schema before copying or promoting either store. |
+| `attrs differ` | User-visible array attrs differ after Firecube-managed attrs were removed. | Inspect the array metadata and decide which store owns the intended metadata. |
+| `values differ` | Array payloads differ. | Re-run the source verification or re-ingest the affected product before promotion. |
+| `firecube_static_written` mismatch | A static array has different write-once marker state. | Treat this as a resume-safety difference. Recreate or repair the affected store instead of ignoring the marker. |
+
+## Operational Notes
+
+The check is strict equivalence: no tolerances, no repair, no JSON output. Use
+it where a mismatch must stop the workflow, not as a diff tool.
+
+## See Also
+
+- [Run Parallel Zarr Writes](parallel-zarr-writes.md)
+- [Inspect And Manage The Resolved Index](firecube-index.md)

--- a/docs/reference/core-utilities.md
+++ b/docs/reference/core-utilities.md
@@ -4,6 +4,13 @@ This reference covers the helper functions exported from `firecube.core.api`
 for use inside plugin hooks: URI and filesystem handling, dataset
 preparation, and time conversion.
 
+`RESERVED_ARRAY_ATTRS`, `assert_attrs_safe()`, and
+`FIRECUBE_STATIC_WRITTEN_ATTR` describe the array attribute keys Firecube
+owns for Zarr writes.
+
+`compare_zarr_stores()` performs a read-only, driver-aware comparison of two
+Zarr stores and returns `ZarrCompareReport`.
+
 {{ render_api_summary("firecube.core.api", [
     "parse_uri",
     "is_remote_target",
@@ -20,10 +27,20 @@ preparation, and time conversion.
     "rename_time_dim",
     "read_hdf5_array",
     "materialize_hdf5_path",
+    "extract_all_from_zip",
     "epoch_s_to_iso",
     "iso_to_epoch_s",
     "coerce_to_epoch_s",
     "normalize_epoch_iso",
+    "RESERVED_ARRAY_ATTRS",
+    "assert_attrs_safe",
+    "FIRECUBE_STATIC_WRITTEN_ATTR",
+    "BatchResourceRegistry",
+    "physical_chunk_keys_for_region",
+    "chunk_axis_range",
+    "axis_selection_is_chunk_aligned",
+    "ZarrCompareReport",
+    "compare_zarr_stores",
 ]) }}
 
 ## URI And Filesystem
@@ -62,6 +79,10 @@ preparation, and time conversion.
 
 ::: firecube.core.api.materialize_hdf5_path
 
+## ZIP Extraction
+
+::: firecube.core.api.extract_all_from_zip
+
 ## Time Conversion
 
 ::: firecube.core.api.epoch_s_to_iso
@@ -69,6 +90,42 @@ preparation, and time conversion.
 ::: firecube.core.api.iso_to_epoch_s
 
 ::: firecube.core.api.normalize_epoch_iso
+
+## Reserved Array Attributes
+
+::: firecube.core.api.RESERVED_ARRAY_ATTRS
+
+::: firecube.core.api.assert_attrs_safe
+
+::: firecube.core.api.FIRECUBE_STATIC_WRITTEN_ATTR
+
+## Batch Resources
+
+::: firecube.core.api.BatchResourceRegistry
+
+## Zarr Chunk Geometry
+
+::: firecube.core.api.physical_chunk_keys_for_region
+
+::: firecube.core.api.chunk_axis_range
+
+::: firecube.core.api.axis_selection_is_chunk_aligned
+
+## Zarr Store Comparison
+
+::: firecube.core.api.ZarrCompareReport
+
+::: firecube.core.api.compare_zarr_stores
+
+## Ingestor Re-Exports
+
+The ingestor facade re-exports the same attribute guards for plugin code.
+
+::: firecube.ingestor.api.RESERVED_ARRAY_ATTRS
+
+::: firecube.ingestor.api.assert_attrs_safe
+
+::: firecube.ingestor.api.FIRECUBE_STATIC_WRITTEN_ATTR
 
 `coerce_to_epoch_s()` is documented with the direct-Zarr index types in
 [Index Specification](parallelism.md).

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -5,6 +5,12 @@ Ingestor-layer errors inherit from `IngestorError`; `ManifestError`,
 `SchemaDriftError`, and `StorageError` are shared error types re-exported
 through the same facade.
 
+`ExtentUnknownError` is the core resolver error raised when a regular axis has
+no fixed extent.
+
+`UnboundedAxisError` is the `ConfigurationError` subclass the engine raises for
+the same unbounded-axis case.
+
 `MissingIrregularCoordinateError`, `DuplicateIrregularCoordinateError`, and
 `NoDiscoveredItemsError` are raised during `IrregularTimeAxis(values=AUTO)`
 discovery.
@@ -12,6 +18,8 @@ discovery.
 {{ render_api_summary("firecube.ingestor.api", [
     "IngestorError",
     "ConfigurationError",
+    "ExtentUnknownError",
+    "UnboundedAxisError",
     "MissingIrregularCoordinateError",
     "DuplicateIrregularCoordinateError",
     "NoDiscoveredItemsError",
@@ -30,6 +38,10 @@ discovery.
 ::: firecube.ingestor.api.IngestorError
 
 ::: firecube.ingestor.api.ConfigurationError
+
+::: firecube.ingestor.api.ExtentUnknownError
+
+::: firecube.ingestor.api.UnboundedAxisError
 
 ::: firecube.ingestor.api.SchemaSizeMismatchError
 
@@ -68,6 +80,8 @@ All three inherit from `ConfigurationError`.
 ## Core API Re-Exports
 
 The core facade re-exports the error types used by plugin code and the engine.
+
+::: firecube.core.api.ExtentUnknownError
 
 ::: firecube.core.api.MissingIrregularCoordinateError
 

--- a/docs/reference/parallelism.md
+++ b/docs/reference/parallelism.md
@@ -66,6 +66,8 @@ The public ingestor facade re-exports the declarative types used by plugin code.
 
 ::: firecube.ingestor.api.ResolvedIndexRecord
 
+::: firecube.ingestor.api.resolve_index_spec
+
 ## Resolved Index Behavior
 
 `ResolvedIndex` is the object plugin code uses after resolution. The key methods are `size(group)`, `position(group, coordinate)`, and `coordinate(group, index)`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
       - Create an Intake Catalog: operations/intake-catalog.md
     - Zarr:
       - Run Parallel Zarr Writes: operations/parallel-zarr-writes.md
+      - Compare Zarr Stores: operations/zarr-compare.md
       - Inspect And Manage The Resolved Index: operations/firecube-index.md
     - ChunkManager:
       - Overview: operations/chunk-manager/index.md

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -1,5 +1,148 @@
 # Done
 
+## 2026-08-24 — Milestone D — Optional cleanup
+
+### What
+
+Two capabilities shipped on branch `feat/plugin-to-core-migration` (commit `c2ec4ab`):
+
+1. Chunk-geometry helpers (`chunk_range_for_slot`, `chunk_ranges_for_slots`, `ChunkRange`) extracted from `src/firecube/ingestor/runtime/zarr/indexed_region.py` to `src/firecube/core/zarr/chunk_geometry.py`; exported from `firecube.core.api`; `indexed_region.py` now imports them from the new module. Behavior is bit-identical to the pre-extraction implementation.
+
+2. `BatchResourceRegistry` added to `src/firecube/core/batch_registry.py`; exported from `firecube.core.api`. Provides idempotent teardown and fail-loud-but-close-all semantics: all registered resources are closed even when earlier closures raise, and all exceptions are collected and re-raised together. `_IdentityRef` is an internal implementation detail and is not exported.
+
+### Consequences
+
+The chunk-geometry helpers were promoted to `firecube.core` to enable cross-plugin deduplication of identical chunk-range math. Any plugin or operator code that needs to compute chunk ranges for a given slot can now import from `firecube.core.api` rather than reaching into the ingestor runtime internals.
+
+`BatchResourceRegistry` provides a convenience over the lifecycle hooks for managing closable resources within a batch run. Registering a resource guarantees it will be closed on teardown regardless of earlier failures, removing the need for nested try/finally chains in plugin code.
+
+### Verification
+
+```bash
+uv run pytest --strict-deps -m "not slow and not s3 and not docs_static and not snapshot" -q --tb=short
+uv run pytest --strict-deps -m "docs_static or snapshot" -q --tb=short
+uv run pytest --strict-deps -q --tb=short -W error::DeprecationWarning
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run mkdocs build --strict --site-dir /tmp/firecube-mkdocs-check
+```
+
+All seven commands exit 0 on branch `feat/plugin-to-core-migration`, commit `c2ec4ab`.
+
+## 2026-08-24 — Milestone C — Bounded operational tooling
+
+### What
+
+Five capabilities shipped on branch `feat/plugin-to-core-migration` (commit `8d79dd8`):
+
+1. `compare_zarr_stores()` helper and `ZarrCompareReport` dataclass added to `src/firecube/core/zarr/validation.py`; exported from `firecube.core.api`; `firecube zarr compare` CLI subcommand added; operator documentation at `docs/operations/zarr-compare.md`.
+
+2. `static_owner` field added to `firecube zarr slots` JSON output. The owner is the pod whose planned `slot_start` is smallest within each group (deterministic, plan-input only). Documentation updated in `docs/operations/parallel-zarr-writes.md`.
+
+3. `firecube zarr validate` static-marker check: the validate command now reports a failure for any static (`time_indexed=False`) array that is missing the `firecube_static_written` marker attribute, without mutating the store.
+
+4. `EngineConfig.suppress_static_emission_for_non_owner` (bool, default `False`) and `EngineConfig.static_owner_slot_start` (int, default `0`) fields added; corresponding CLI flags `--suppress-static-emission-for-non-owner` and `--static-owner-slot-start` added. `IndexedRegionStrategy._dispatch_static_intent` suppresses static writes on non-owner pods and emits a structured log line at `DEBUG` level. Scope limitation: `static_owner_slot_start` is compared against the single slot-start value for the current run; multi-group ownership resolution is deferred (see `plans/TODO.md` §36).
+
+5. `ZarrTemplateConfig.zarr_write_empty_chunks: bool = False` typed option added. A scoped `zarr.config.set({"write_empty_chunks": ...})` is applied around `IndexedRegionStrategy.write_groups` (DirectZarr path) and inside `ZarrWriteContext` (Generic path). The effective value is recorded as the `zarr_write_empty_chunks_effective` metric. A follow-up entry for the pre-existing bare `zarr.config.set({"async.concurrency": ...})` in `ZarrWriteContext` is tracked in `plans/TODO.md` §36.
+
+### Consequences
+
+Operators can now diff two Zarr stores programmatically or via CLI and get a structured report of shape, dtype, chunk, attribute, and data mismatches. The `firecube zarr compare` exit code is 3 on semantic mismatch, 0 on match, non-zero on error.
+
+The `static_owner` field in the fan-out plan gives each pod a deterministic, plan-derived signal for which pod owns static writes. Combined with `--suppress-static-emission-for-non-owner`, non-owner pods skip static write intents entirely, preventing redundant writes and potential race conditions in parallel ingestion.
+
+The validate marker check catches stores where a static array was never committed (e.g. a failed or interrupted ingest), surfacing the gap before a downstream consumer reads stale fill values.
+
+`zarr_write_empty_chunks=False` (the default) prevents Zarr from writing chunks that contain only fill values, reducing storage footprint for sparse arrays. The scoped config ensures the setting is applied only during the write window and does not leak into other Zarr operations in the same process.
+
+The `static_owner_slot_start` v1 implementation compares a single integer against the run's slot-start. Multi-group scenarios where different groups have different owners in the same run are not handled; each group's owner must be resolved by the operator and passed as a separate run. Multi-group deferred to `plans/TODO.md`.
+
+### Verification
+
+```bash
+uv run pytest --strict-deps -m "not slow and not s3 and not docs_static and not snapshot" -q --tb=short
+uv run pytest --strict-deps -m "docs_static or snapshot" -q --tb=short
+uv run pytest --strict-deps -q --tb=short -W error::DeprecationWarning
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run mkdocs build --strict --site-dir /tmp/firecube-mkdocs-check
+```
+
+All seven commands exit 0 on branch `feat/plugin-to-core-migration`, commit `8d79dd8`. One ruff format issue in `src/firecube/core/zarr/validation.py` and `tests/unit/test_compare_zarr_stores.py` was fixed as part of this gate run before the final pass.
+
+### References
+
+`plans/TODO.md` §36 — `ZarrWriteContext` async-concurrency bare call, deferred from Wave C2.
+
+## 2026-08-24 — Milestone B — Data integrity and archive safety
+
+### What
+
+Two fixes shipped on branch `feat/plugin-to-core-migration` (commit `5490ce8`):
+
+1. `read_hdf5_array` (`src/firecube/core/formats/hdf5.py`) now preserves the source array's dtype by default. Previously the function always returned `float64`, silently coercing integer, boolean, and other numeric dtypes and discarding precision. A new optional `dtype=` parameter lets callers request an explicit cast; omitting it keeps the on-disk dtype. Both the h5py direct-read path and the xarray fallback path honour this contract. Tests cover dtype preservation for `int16`, `uint8`, `bool`, `float32`, and `float64`, plus explicit cast via `dtype=`, plus the xarray fallback path.
+
+2. `extract_hdf5_from_zip` and `stream_hdf5_from_zip` (`src/firecube/core/formats/zip.py`) now reject unsafe ZIP member paths before any extraction or streaming begins. Rejected patterns: dotdot components (`../`), absolute paths (`/tmp/...`), Windows-style traversal (`..\\`, `\\server\`, `C:/`), and any path that resolves outside the destination directory. Archives containing multiple HDF5 candidates are also rejected unless the caller passes an explicit `member=` parameter. Tests cover all four traversal patterns, the zero-candidate and multi-candidate rejection cases, the explicit-member acceptance path, safe nested paths, and the shared-validation invariant between the extract and stream entry points.
+
+### Consequences
+
+`read_hdf5_array` dtype coercion was a silent data-integrity defect: plugins reading integer or boolean HDF5 arrays received `float64` values without any error or warning, making downstream comparisons and schema checks unreliable. The fix makes the function's output match the on-disk representation by default.
+
+The ZIP extraction guards close a zip-slip vulnerability class. An attacker or malformed archive could previously supply a member path such as `../../etc/cron.d/evil` or `/etc/passwd` and have `extract_hdf5_from_zip` write outside the declared destination directory. The new path-safety check raises `ValueError` before any bytes are written, so no partial extraction occurs. The multi-candidate guard prevents silent selection of the wrong HDF5 file when an archive contains more than one candidate.
+
+### Verification
+
+```bash
+uv run pytest --strict-deps -m "not slow and not s3 and not docs_static and not snapshot" -q --tb=short
+uv run pytest --strict-deps -m "docs_static or snapshot" -q --tb=short
+uv run pytest --strict-deps -q --tb=short -W error::DeprecationWarning
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run mkdocs build --strict --site-dir /tmp/firecube-mkdocs-check
+```
+
+All seven commands exit 0 on branch `feat/plugin-to-core-migration`, commit `5490ce8`. Two pyright errors in `tests/unit/test_zip_extract_safety.py` (missing `assert extracted is not None` before `.read_bytes()` calls) and one ruff format issue in `src/firecube/core/formats/zip.py` were fixed as part of this gate run.
+
+### References
+
+External plugin migration (Milestone B).
+
+## 2026-08-24 — Milestone A — Migration unblockers
+
+### What
+
+Four changes that unblock external plugin migration to the current public API:
+
+1. `runtime/base.py` + `templates/direct_zarr.py` — serial-mode `ExtentUnknownError` now raises `ConfigurationError` naming the group; `direct_zarr.py` adds defense-in-depth for the parallel path so the same error surfaces if the upstream gate is bypassed.
+2. `firecube.core.api` — exports `ExtentUnknownError`, `RESERVED_ARRAY_ATTRS`, `assert_attrs_safe`, and `FIRECUBE_STATIC_WRITTEN_ATTR`.
+3. `firecube.ingestor.api` — re-exports all four of the above plus `resolve_index_spec`.
+4. Docs: `:::` directives added in `docs/reference/exceptions.md` and `docs/reference/core-utilities.md` for both facade paths; `docs/reference/parallelism.md` gains the `resolve_index_spec` ingestor-facade directive.
+
+### Consequences
+
+External plugins can now import `ExtentUnknownError`, `RESERVED_ARRAY_ATTRS`, `assert_attrs_safe`, `FIRECUBE_STATIC_WRITTEN_ATTR`, and `resolve_index_spec` from either `firecube.core.api` or `firecube.ingestor.api` without reaching into private submodules. Serial-mode plugins with an unbounded axis receive a `ConfigurationError` with a clear group name instead of a bare `ExtentUnknownError`. The architecture boundary test (`test_import_boundaries`) now passes because `direct_zarr.py` no longer imports from `firecube.core.index_resolve` or `firecube.ingestor.runtime.parallel_gate`.
+
+### Verification
+
+```bash
+uv run pytest --strict-deps -m "not slow and not s3 and not docs_static and not snapshot" -q --tb=short
+uv run pytest --strict-deps -m "docs_static or snapshot" -q --tb=short
+uv run pytest --strict-deps -q --tb=short -W error::DeprecationWarning
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run mkdocs build --strict --site-dir /tmp/firecube-mkdocs-check
+```
+
+All seven commands exit 0 on branch `feat/plugin-to-core-migration`.
+
+### References
+
+External plugin migration (Milestone A).
+
 ## 2026-08-24 — IndexedWrite + build_indexed_write hook + DirectZarr lifecycle parity + bounded region-write concurrency
 
 Added the `IndexedWrite` abstraction with `.region()` and `.slot()` builders

--- a/plans/STYLE.md
+++ b/plans/STYLE.md
@@ -39,6 +39,8 @@ These apply to all new code in `src/` and to plugin implementations.
 - **No side effects at import time**: Especially in `firecube.ingestor`. Keep optional deps lazy. Don't trigger I/O, registration, or network calls on import.
 - **Fail fast on bad config**: Validate config at construction time, not at first use. A `ValueError` at startup is better than a silent wrong result halfway through a multi-hour ingest.
 - **Google-style docstrings**: `mkdocs.yml` pins `docstring_style: google`. Numpy-style sections (`Parameters` / `Returns` underlined with `---`) render as flat text and no build check catches it. Use `Args:`, `Returns:`, `Raises:`, `Examples:`.
+- **Exact Google section names only**: the recognized headers are `Args:`, `Returns:`, `Yields:`, `Raises:`, `Attributes:`, `Examples:`, `Note:`, `Warning:`. Singular or invented variants (`Arg:`, `Return:`, `Raise:`, `Error:`, `Errors:`, `Attribute:`) are not parsed by griffe and render as flat prose. This is the same Google format xarray and numpy render with.
+- **Dataclasses document fields under `Attributes:`, never `Args:`**: a dataclass docstring describes the record's fields, so the section is `Attributes:`. Reserve `Args:` for functions, methods, and a non-dataclass class docstring that documents its `__init__` parameters.
 
 ## Docstrings On Public Surfaces
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -7,6 +7,20 @@ New decisions are recorded in [DONE.md](DONE.md) with a date.
 
 ---
 
+### §36 `ZarrWriteContext` async-concurrency leak — convert to scoped config
+
+**Status**: OPEN
+**Scope**: Zarr write configuration hygiene
+**Priority**: medium
+
+`src/firecube/ingestor/runtime/zarr/write_context.py` still calls
+`zarr.config.set({"async.concurrency": ...})` bare during `ZarrWriteContext.__enter__`.
+This pre-existing setting is outside the Wave C2 `zarr_write_empty_chunks` work,
+but it should be converted to a scoped context manager so async concurrency is
+restored when the write context exits.
+
+---
+
 ### §33 DirectZarr slot-range parallelism - roadmap
 
 - **Landed:** `IndexSpec` + `RegularTimeAxis` + `ResolvedIndex`; byte parity for FCI and OPERA; recursion defect fixed.
@@ -149,6 +163,38 @@ power in the default test loop.
     **Builds on:** §4a (DONE.md) — `IndexedRegionStrategy` is the missing primitive that enables disjoint-region writes. §21, §23, §23-AUTO, §7-DIRECT, §7-sub, and Phase 3.1 are all DONE as of 2026-05-28. Safe within-group parallelism is fully delivered for `DirectZarrIngestor` plugins.
 
 ---
+
+### §37 `compare_zarr_stores` chunk-wise value comparison (post-2026-08-24)
+
+`src/firecube/core/zarr/validation.py::_values_equal` currently loads whole arrays into memory via `left[:]`. For production-size cubes this will OOM. If `firecube zarr compare` is to be used as a promotion gate on real cubes, replace the full-array load with chunk-wise comparison that iterates over chunk indices and compares one chunk at a time.
+
+**Scope**:
+- Modify `_values_equal` to iterate chunks (use `zarr.Array.chunks` and `numpy.ndindex` over chunk coordinates).
+- Preserve NaN-aware equality semantics per dtype kind.
+- Preserve the terse per-category mismatch message format (do NOT list individual chunks).
+- Add a test with a large synthetic array that would OOM with `[:]` but passes with chunk-wise comparison.
+
+**Deferred from**: Milestone C review, 2026-08-25. V1 boolean-only compare is fine for small stores.
+
+---
+
+### §38 `zarr validate` static-marker check: configurable time-dimension names (post-2026-08-25)
+
+`src/firecube/cli/zarr.py::_static_marker_failures` classifies an array as
+time-indexed when its first dimension is named `timestamp`, `time`, or
+`firecube_timestamp_state`; any other first-dimension name is treated as
+static and must carry the `firecube_static_written` marker. A plugin using a
+custom `time_dim_name` outside that set gets false
+`missing_or_false_static_marker` reports on genuinely time-indexed arrays.
+
+**Scope**:
+- Add a way to extend or override the recognized names (a `--time-dim` option
+  on `firecube zarr validate`, or read the dimension name from the resolved
+  index record).
+- Keep the default set unchanged.
+
+**Deferred from**: Wave C2 review, 2026-08-25. The recognized set is
+documented in `docs/concepts/performance.md`.
 
 ### §9 Span planning (optional pre-declared spans)
 

--- a/src/firecube/cli/main.py
+++ b/src/firecube/cli/main.py
@@ -590,6 +590,28 @@ See also: firecube plugins list, firecube chunks list, firecube advise batch-siz
         "non-parallel mode)."
     ),
 )
+@click.option(
+    "--suppress-static-emission-for-non-owner",
+    "suppress_static_emission_for_non_owner",
+    is_flag=True,
+    help=(
+        "skip writes of static (non-time-indexed) arrays on this worker unless its "
+        "--slot-start equals --static-owner-slot-start; pass to every fan-out worker "
+        "so exactly one of them writes shared arrays such as latitude and longitude"
+    ),
+)
+@click.option(
+    "--static-owner-slot-start",
+    "static_owner_slot_start",
+    type=int,
+    default=None,
+    help=(
+        "slot-start of the worker that writes static arrays; take the value from the "
+        "static_owner field in the 'firecube zarr slots --format json' plan and pass "
+        "the same value to every worker together with "
+        "--suppress-static-emission-for-non-owner"
+    ),
+)
 @click.option("--in-memory", is_flag=True, help="use in-memory DuckDB")
 @click.option(
     "--option",
@@ -619,6 +641,8 @@ def ingest(
     slot_end: int | None,
     slot_size: int | None,
     slot_group: str | None,
+    suppress_static_emission_for_non_owner: bool,
+    static_owner_slot_start: int | None,
     in_memory: bool,
     extra_options,
     show_options: bool,
@@ -715,6 +739,10 @@ def ingest(
             options["slot_end"] = resolved_slot_end
             options["slot_size"] = slot_size
             options["slot_group"] = resolved_slot_group
+            options["suppress_static_emission_for_non_owner"] = (
+                suppress_static_emission_for_non_owner
+            )
+            options["static_owner_slot_start"] = static_owner_slot_start
             resolved_product_name = (
                 ingest_cfg.product_name
                 or get_plugin_defaults(cfg, plugin).get("default_product_name")

--- a/src/firecube/cli/zarr.py
+++ b/src/firecube/cli/zarr.py
@@ -54,6 +54,7 @@ from firecube.cli._uri_policy import (
 )
 from firecube.cli.index import index as index_group
 from firecube.core import observability
+from firecube.core.api import FIRECUBE_STATIC_WRITTEN_ATTR, compare_zarr_stores
 from firecube.core.controlplane import ChunkManager, WriteDomain
 from firecube.core.observability.metrics import TelemetryService, emit_index_ensured_full
 from firecube.core.storage.binding import StorageBinding
@@ -398,6 +399,10 @@ def slots(
             remaining, group_slot_size, total
         )
         partitioned = _partition_remaining(aligned_remaining, group_slot_size)
+        static_owner = None
+        if partitioned:
+            owner_start, owner_end = min(partitioned, key=lambda item: item[0])
+            static_owner = {"slot_start": owner_start, "slot_end": owner_end}
 
         for slot_start, slot_end in partitioned:
             ranges_out.append(
@@ -429,6 +434,7 @@ def slots(
                 "covered_ranges": [[s, e] for s, e in covered],
                 "remaining_ranges": [[s, e] for s, e in remaining],
                 "blocked_ranges": [[s, e] for s, e in blocked_for_group],
+                "static_owner": static_owner,
             }
         )
 
@@ -563,7 +569,55 @@ def validate(
             on_timeout=on_timeout,
             original_error=exc,
         )
-    click.echo(json.dumps(report.to_dict(), indent=2))
+    output = report.to_dict()
+    output["static_marker_failures"] = _static_marker_failures(
+        fs, identity.product_uri, report.group
+    )
+    click.echo(json.dumps(output, indent=2))
+
+
+@zarr.command(
+    "compare",
+    context_settings={"help_option_names": ["-h", "--help"]},
+    epilog="""\b
+Examples:
+  firecube zarr compare file:///data/a.zarr file:///data/b.zarr \\
+      --storage-type local --storage-driver fsspec
+""",
+)
+@click.argument("a_uri")
+@click.argument("b_uri")
+@click.option(
+    "--storage-type",
+    "storage_type",
+    required=True,
+    type=click.Choice(["local", "s3"], case_sensitive=False),
+    help="Storage locality for both store URIs.",
+)
+@click.option(
+    "--storage-driver",
+    "storage_driver",
+    required=True,
+    type=click.Choice(["fsspec", "obstore"], case_sensitive=False),
+    help="Storage driver for both store URIs.",
+)
+@wrap_user_facing_errors
+def compare(a_uri: str, b_uri: str, storage_type: str, storage_driver: str) -> None:
+    """Compare two Zarr stores and exit 3 when they differ."""
+    for uri in (a_uri, b_uri):
+        require_full_uri(uri, option_name="store URI")
+        validate_uri_storage_coherence(parse_product_uri(uri), storage_type)
+    report = compare_zarr_stores(
+        a_uri,
+        b_uri,
+        storage_type=storage_type.lower(),
+        storage_driver=storage_driver.lower(),
+    )
+    if report.equivalent:
+        return
+    for mismatch in report.mismatches:
+        click.echo(mismatch, err=True)
+    raise click.exceptions.Exit(3)
 
 
 def _validate_first_array_child(
@@ -599,6 +653,28 @@ def _validate_first_array_child(
             on_timeout=on_timeout,
         )
     raise click.ClickException(str(original_error)) from original_error
+
+
+def _static_marker_failures(fs: Any, store_uri: Any, array_path: str) -> list[dict[str, str]]:
+    """Return static-array marker failures for the validated array, read-only."""
+    meta_uri = store_uri.join(array_path).join("zarr.json")
+    try:
+        with fs.open(meta_uri, "r") as handle:  # pyright: ignore[reportArgumentType]
+            metadata = json.load(handle)
+    except (AttributeError, FileNotFoundError):
+        return []
+
+    dimension_names = metadata.get("dimension_names")
+    if not dimension_names:
+        return []
+    first_dimension = str(dimension_names[0])
+    if first_dimension in {"timestamp", "time", "firecube_timestamp_state"}:
+        return []
+
+    attrs = metadata.get("attributes") or {}
+    if attrs.get(FIRECUBE_STATIC_WRITTEN_ATTR):
+        return []
+    return [{"array": array_path, "reason": "missing_or_false_static_marker"}]
 
 
 @zarr.command(

--- a/src/firecube/core/api.py
+++ b/src/firecube/core/api.py
@@ -17,6 +17,7 @@
 Plugins should import from this module rather than accessing core internals directly.
 """
 
+from firecube.core.batch_registry import BatchResourceRegistry
 from firecube.core.config import StorageConfig
 from firecube.core.controlplane import RunInfo, describe_control_plane
 from firecube.core.controlplane.types import (
@@ -39,13 +40,19 @@ from firecube.core.filesystem import (
 from firecube.core.formats import (
     clean_netcdf_encoding,
     discover_input_files,
+    extract_all_from_zip,
     materialize_hdf5_path,
     normalize_string_vars,
     prepare_netcdf_for_zarr,
     read_hdf5_array,
     rename_time_dim,
 )
-from firecube.core.index_resolve import ResolvedIndex, coerce_to_epoch_s, resolve_index_spec
+from firecube.core.index_resolve import (
+    ExtentUnknownError,
+    ResolvedIndex,
+    coerce_to_epoch_s,
+    resolve_index_spec,
+)
 from firecube.core.index_spec import (
     AUTO,
     AxisSpec,
@@ -72,15 +79,33 @@ from firecube.core.uris import (
     local_path_from_target,
     parse_uri,
 )
+from firecube.core.zarr._reserved_attrs import (
+    FIRECUBE_STATIC_WRITTEN_ATTR,
+    RESERVED_ARRAY_ATTRS,
+    assert_attrs_safe,
+)
+from firecube.core.zarr.chunk_geometry import (
+    axis_selection_is_chunk_aligned,
+    chunk_axis_range,
+    physical_chunk_keys_for_region,
+)
 from firecube.core.zarr.region_writer import RegionZarrWriterProtocol
 from firecube.core.zarr.time_decode import decode_time_array
-from firecube.core.zarr.validation import read_chunk_grid_with_shards
+from firecube.core.zarr.validation import (
+    ZarrCompareReport,
+    compare_zarr_stores,
+    read_chunk_grid_with_shards,
+)
 
 __all__ = [
     "AUTO",
+    "FIRECUBE_STATIC_WRITTEN_ATTR",
+    "RESERVED_ARRAY_ATTRS",
     "AxisSpec",
+    "BatchResourceRegistry",
     "CatalogGroupInfo",
     "DuplicateIrregularCoordinateError",
+    "ExtentUnknownError",
     "IndexSpec",
     "IndexedWrite",
     "IndexedWriteCompilationError",
@@ -98,8 +123,13 @@ __all__ = [
     "SlotAxis",
     "SlotIndexModel",
     "StorageConfig",
+    "ZarrCompareReport",
+    "assert_attrs_safe",
+    "axis_selection_is_chunk_aligned",
+    "chunk_axis_range",
     "clean_netcdf_encoding",
     "coerce_to_epoch_s",
+    "compare_zarr_stores",
     "create_filesystem_for_uri",
     "decode_time_array",
     "delete_path",
@@ -108,6 +138,7 @@ __all__ = [
     "ensure_directory",
     "ensure_product_uri",
     "epoch_s_to_iso",
+    "extract_all_from_zip",
     "infer_target_protocol",
     "is_remote_target",
     "iso_to_epoch_s",
@@ -117,6 +148,7 @@ __all__ = [
     "normalize_string_vars",
     "parse_uri",
     "path_stats",
+    "physical_chunk_keys_for_region",
     "prepare_netcdf_for_zarr",
     "read_chunk_grid_with_shards",
     "read_hdf5_array",

--- a/src/firecube/core/batch_registry.py
+++ b/src/firecube/core/batch_registry.py
@@ -1,0 +1,146 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-batch closeable-resource registry utilities."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Hashable
+from dataclasses import dataclass
+from typing import Protocol, TypeVar
+
+log = logging.getLogger("firecube.core.batch_registry")
+
+
+class _Closeable(Protocol):
+    def close(self) -> None: ...
+
+
+_ResourceT = TypeVar("_ResourceT", bound=_Closeable)
+
+
+@dataclass(frozen=True)
+class _IdentityRef:
+    """Hashable identity wrapper for resources with value equality."""
+
+    value: object
+
+    def __hash__(self) -> int:
+        return id(self.value)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _IdentityRef) and self.value is other.value
+
+
+class BatchResourceRegistry:
+    """Track closeable resources by batch and close each batch idempotently.
+
+    The registry is intentionally small: plugin mixins may register per-batch
+    resources during ``batch_setup`` and ask the registry to close everything
+    for the same batch id during ``batch_teardown``. Teardown pops the batch
+    before closing resources, so repeated teardown calls for the same batch are
+    no-ops even when an earlier close raises.
+
+    Examples:
+        Register and close a per-batch resource:
+
+            >>> class Resource:
+            ...     def __init__(self):
+            ...         self.closed = False
+            ...     def close(self):
+            ...         self.closed = True
+            >>> registry = BatchResourceRegistry()
+            >>> resource = registry.register("batch-1", Resource())
+            >>> registry.teardown("batch-1")
+            >>> resource.closed
+            True
+    """
+
+    def __init__(self) -> None:
+        self._resources: dict[Hashable, dict[_IdentityRef, _Closeable]] = {}
+
+    def register(self, batch_id: Hashable, resource: _ResourceT) -> _ResourceT:
+        """Register a closeable resource for a batch id.
+
+        Args:
+            batch_id: Hashable batch identifier. The same value must be passed
+                to ``teardown`` to close the registered resources.
+            resource: Object exposing ``close()``.
+
+        Returns:
+            The same ``resource`` object, so callers can create and register in
+            one expression.
+
+        Raises:
+            TypeError: If ``batch_id`` is not hashable or ``resource`` does not
+                expose a callable ``close`` method.
+
+        Examples:
+            Register a file-like object and keep using it:
+
+                >>> registry = BatchResourceRegistry()
+                >>> handle = registry.register("batch-1", open(__file__))
+                >>> callable(handle.close)
+                True
+                >>> registry.teardown("batch-1")
+        """
+        hash(batch_id)
+        close = getattr(resource, "close", None)
+        if not callable(close):
+            raise TypeError("BatchResourceRegistry resources must expose callable close()")
+        self._resources.setdefault(batch_id, {})[_IdentityRef(resource)] = resource
+        return resource
+
+    def teardown(self, batch_id: Hashable) -> None:
+        """Pop and close all resources registered for one batch id.
+
+        Args:
+            batch_id: Hashable batch identifier to close and remove.
+
+        Returns:
+            ``None``.
+
+        Raises:
+            Exception: Re-raises the first exception raised by a resource's
+                ``close()`` after attempting to close every resource. Later
+                close exceptions are logged and suppressed behind the first.
+
+        Examples:
+            Repeated teardown is safe and closes the resource once:
+
+                >>> registry = BatchResourceRegistry()
+                >>> resource = registry.register("batch-1", open(__file__))
+                >>> registry.teardown("batch-1")
+                >>> registry.teardown("batch-1")
+        """
+        resources = self._resources.pop(batch_id, {})
+        first_error: Exception | None = None
+        for resource in resources.values():
+            try:
+                resource.close()
+            except Exception as exc:
+                log.warning(
+                    "Failed to close batch resource for batch_id=%r: %s",
+                    batch_id,
+                    exc,
+                    exc_info=True,
+                )
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
+
+
+__all__ = ["BatchResourceRegistry"]

--- a/src/firecube/core/controlplane/types.py
+++ b/src/firecube/core/controlplane/types.py
@@ -118,7 +118,7 @@ class ItemManifestEntry:
     versions, or processing lineage are stored here. Add those to a separate
     subsystem if they are ever needed.
 
-    Args:
+    Attributes:
         identity_hash: Content-address of the item (SHA-256 hex of the item
             contents, or a caller-defined stable identity string). Must be
             unique within a manifest.

--- a/src/firecube/core/formats/__init__.py
+++ b/src/firecube/core/formats/__init__.py
@@ -26,6 +26,7 @@ from firecube.core.formats.netcdf import (
     rename_time_dim,
 )
 from firecube.core.formats.zip import (
+    extract_all_from_zip,
     extract_hdf5_from_zip,
     extract_zip_files_parallel,
     stream_hdf5_from_zip,
@@ -35,6 +36,7 @@ __all__ = [
     "KNOWN_EXTENSIONS",
     "clean_netcdf_encoding",
     "discover_input_files",
+    "extract_all_from_zip",
     "extract_hdf5_from_zip",
     "extract_zip_files_parallel",
     "materialize_hdf5_path",

--- a/src/firecube/core/formats/hdf5.py
+++ b/src/firecube/core/formats/hdf5.py
@@ -26,6 +26,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+import numpy as np
+
 from firecube.core.formats.zip import extract_hdf5_from_zip
 
 log = logging.getLogger("firecube.core.formats")
@@ -45,27 +47,39 @@ def read_hdf5_array(
     hdf5_path: Path,
     *,
     variable: str,
+    dtype: np.dtype[Any] | str | None = None,
     logger: logging.Logger | None = None,
-) -> Any:
+) -> np.ndarray[Any, Any]:
     """Read a named array from a local HDF5(-like) file, with xarray fallback.
 
     Args:
         hdf5_path: Path to the HDF5 file.
         variable: Name of the variable/dataset to read.
+        dtype: Optional dtype to cast to. If omitted, the source dtype is preserved.
         logger: Optional logger for debug messages.
 
     Returns:
-        Numpy array of the data (float32).
+        Numpy array containing the requested dataset.
 
     Raises:
         KeyError: If the variable is not found.
         RuntimeError: If dependencies are missing or read fails.
+
+    Examples:
+        Read a dataset without changing its dtype:
+
+        >>> read_hdf5_array(Path("product.h5"), variable="counts")
+
+        Cast explicitly when the caller needs a different dtype:
+
+        >>> read_hdf5_array(Path("product.h5"), variable="counts", dtype="float32")
     """
     logger = logger or log
-    try:
-        import numpy as np
-    except Exception as exc:
-        raise RuntimeError("numpy is required to read HDF5 inputs") from exc
+
+    def _array_with_requested_dtype(data: Any) -> np.ndarray[Any, Any]:
+        if dtype is None:
+            return np.asarray(data)
+        return np.asarray(data, dtype=np.dtype(dtype))
 
     try:
         import h5py
@@ -76,17 +90,22 @@ def read_hdf5_array(
         with h5py.File(hdf5_path, "r") as handle:
             if variable not in handle:
                 raise KeyError(f"{variable} dataset not found in HDF5 file")
-            return np.asarray(handle[variable], dtype=np.float32)
+            return _array_with_requested_dtype(handle[variable])
+    except KeyError:
+        raise
     except Exception as h5_exc:
         try:
             import xarray as xr
 
-            ds = xr.open_dataset(hdf5_path, phony_dims="sort")
-            if variable not in ds:
-                raise KeyError(f"{variable} variable not found in dataset")
-            arr = ds[variable].values.astype(np.float32, copy=False)
-            ds.close()
-            return arr
+            ds = xr.open_dataset(hdf5_path, engine="h5netcdf", phony_dims="sort")
+            try:
+                if variable not in ds:
+                    raise KeyError(f"{variable} variable not found in dataset")
+                return _array_with_requested_dtype(ds[variable].values)
+            finally:
+                ds.close()
+        except KeyError:
+            raise
         except Exception as xr_exc:
             raise RuntimeError(
                 f"Failed to read {variable} from {hdf5_path.name}: {h5_exc}"

--- a/src/firecube/core/formats/zip.py
+++ b/src/firecube/core/formats/zip.py
@@ -31,39 +31,93 @@ from pathlib import Path
 log = logging.getLogger("firecube.core.formats")
 
 
-def extract_hdf5_from_zip(
-    zip_path: Path, dest: Path, *, logger: logging.Logger | None = None
-) -> Path | None:
-    """Extract the first HDF5-like member from a ZIP archive into dest.
+def _ensure_safe_zip_member(name: str) -> None:
+    """Reject ZIP member names that can escape the extraction root."""
+    normalized = name.replace("\\", "/")
+    if name.startswith(("/", "\\")) or normalized.startswith("/"):
+        raise ValueError(f"Unsafe ZIP member path: {name}")
+    if len(name) >= 2 and name[1] == ":":
+        raise ValueError(f"Unsafe ZIP member path: {name}")
+    if any(segment == ".." for segment in normalized.split("/")):
+        raise ValueError(f"Unsafe ZIP member path: {name}")
 
-    Selection:
-      - Prefer members ending with .h5
-      - Fallback: first non-directory member whose filename contains "HDF5"
+
+def _select_hdf5_member(names: list[str], requested_member: str | None) -> str:
+    """Pick the single HDF5 member, or validate the explicitly requested one."""
+    if requested_member is not None:
+        _ensure_safe_zip_member(requested_member)
+        if requested_member not in names:
+            raise ValueError(f"HDF5 member {requested_member!r} not found in archive")
+        return requested_member
+
+    members = [name for name in names if name.lower().endswith(".h5")]
+    if not members:
+        members = [
+            name for name in names if not name.endswith("/") and "HDF5" in Path(name).name.upper()
+        ]
+    if not members:
+        raise ValueError("No HDF5 member found in archive")
+    if len(members) > 1:
+        raise ValueError(
+            "Multiple HDF5 members found; pass member explicitly: " + ", ".join(members)
+        )
+    return members[0]
+
+
+def extract_hdf5_from_zip(
+    zip_path: Path,
+    dest: Path,
+    *,
+    member: str | None = None,
+    logger: logging.Logger | None = None,
+) -> Path | None:
+    """Extract an HDF5-like member from a ZIP archive into ``dest``.
+
+    Args:
+        zip_path: Path to the ZIP archive.
+        dest: Directory where the selected member is written.
+        member: Optional explicit member name. Required when multiple HDF5
+            candidates are present.
+        logger: Optional logger for diagnostics.
+
+    Returns:
+        Path to the extracted HDF5 member, or ``None`` when ``zip_path`` is not a
+        valid ZIP archive.
+
+    Raises:
+        ValueError: If member names are unsafe, no HDF5 candidate exists, the
+            explicit member is absent, or multiple candidates require
+            disambiguation.
+
+    Examples:
+        Extract a single HDF5 member:
+
+        >>> extract_hdf5_from_zip(Path("product.zip"), Path("work"))
+
+        Disambiguate archives that contain multiple HDF5 files:
+
+        >>> extract_hdf5_from_zip(Path("product.zip"), Path("work"), member="data/a.h5")
     """
     logger = logger or log
     try:
         with zipfile.ZipFile(zip_path) as zf:
-            members = [name for name in zf.namelist() if name.lower().endswith(".h5")]
-            if not members:
-                candidates = [
-                    name
-                    for name in zf.namelist()
-                    if not name.endswith("/") and "HDF5" in Path(name).name.upper()
-                ]
-                if not candidates:
-                    return None
-                members = [candidates[0]]
-            member = members[0]
+            names = zf.namelist()
+            for name in names:
+                _ensure_safe_zip_member(name)
+            selected_member = _select_hdf5_member(names, member)
 
             # Stream optimization: read to memory then write (often faster than extract()).
             try:
-                hdf5_data = zf.read(member)
-                extracted_path = dest / member
+                hdf5_data = zf.read(selected_member)
+                extracted_path = dest / selected_member
                 extracted_path.parent.mkdir(parents=True, exist_ok=True)
                 with extracted_path.open("wb") as handle:
                     handle.write(hdf5_data)
                 logger.debug(
-                    "Streamed %s bytes from %s/%s", f"{len(hdf5_data):,}", zip_path.name, member
+                    "Streamed %s bytes from %s/%s",
+                    f"{len(hdf5_data):,}",
+                    zip_path.name,
+                    selected_member,
                 )
                 return extracted_path
             except Exception as stream_exc:
@@ -72,31 +126,51 @@ def extract_hdf5_from_zip(
                     zip_path,
                     stream_exc,
                 )
-                extracted_path = Path(zf.extract(member, dest))
+                extracted_path = Path(zf.extract(selected_member, dest))
                 return extracted_path
     except zipfile.BadZipFile:
         logger.warning("Invalid ZIP archive: %s", zip_path)
         return None
 
 
-def stream_hdf5_from_zip(zip_path: Path, *, logger: logging.Logger | None = None) -> bytes | None:
-    """Stream HDF5 content directly from ZIP to memory (no temp files)."""
+def stream_hdf5_from_zip(
+    zip_path: Path, *, member: str | None = None, logger: logging.Logger | None = None
+) -> bytes | None:
+    """Stream HDF5 content directly from ZIP to memory.
+
+    Args:
+        zip_path: Path to the ZIP archive.
+        member: Optional explicit member name. Required when multiple HDF5
+            candidates are present.
+        logger: Optional logger for diagnostics.
+
+    Returns:
+        The selected HDF5 member bytes, or ``None`` when ``zip_path`` is not a
+        valid ZIP archive.
+
+    Raises:
+        ValueError: If member names are unsafe, no HDF5 candidate exists, the
+            explicit member is absent, or multiple candidates require
+            disambiguation.
+
+    Examples:
+        Stream a single HDF5 member without writing files:
+
+        >>> stream_hdf5_from_zip(Path("product.zip"))
+
+        Disambiguate archives that contain multiple HDF5 files:
+
+        >>> stream_hdf5_from_zip(Path("product.zip"), member="data/a.h5")
+    """
     logger = logger or log
     try:
         with zipfile.ZipFile(zip_path) as zf:
-            members = [name for name in zf.namelist() if name.lower().endswith(".h5")]
-            if not members:
-                candidates = [
-                    name
-                    for name in zf.namelist()
-                    if not name.endswith("/") and "HDF5" in Path(name).name.upper()
-                ]
-                if not candidates:
-                    return None
-                members = [candidates[0]]
-            member = members[0]
-            logger.debug("Streaming HDF5 data from %s/%s", zip_path.name, member)
-            return zf.read(member)
+            names = zf.namelist()
+            for name in names:
+                _ensure_safe_zip_member(name)
+            selected_member = _select_hdf5_member(names, member)
+            logger.debug("Streaming HDF5 data from %s/%s", zip_path.name, selected_member)
+            return zf.read(selected_member)
     except zipfile.BadZipFile:
         logger.warning("Invalid ZIP archive: %s", zip_path)
         return None
@@ -112,13 +186,41 @@ def extract_zip_files_parallel(
     temp_dir_map: dict[str, tempfile.TemporaryDirectory] | None = None,
     logger: logging.Logger | None = None,
 ) -> tuple[list[Path], list[tempfile.TemporaryDirectory]]:
-    """Extract ZIP files in parallel using ThreadPoolExecutor for I/O-bound operations.
+    """Extract multiple ZIP archives concurrently into per-archive temp directories.
+
+    Runs ``extract_fn`` for each archive on a thread pool. Archives that fail to
+    extract or contain no matching member are logged and skipped; they do not
+    abort the batch. Two or fewer archives are extracted serially.
+
+    Args:
+        zip_files: ZIP archive paths to extract.
+        tempdir_factory: Zero-argument callable returning a fresh
+            ``tempfile.TemporaryDirectory`` for each archive.
+        extract_fn: Callable ``(zip_path, dest_dir) -> extracted_path | None``
+            applied to each archive. Defaults to :func:`extract_hdf5_from_zip`.
+        max_workers: Upper bound on concurrent extractions. Capped at
+            ``len(zip_files)``.
+        record_temp_dirs: When true and ``temp_dir_map`` is given, record which
+            temporary directory produced each extracted file.
+        temp_dir_map: Mapping filled with ``str(resolved_path) ->
+            TemporaryDirectory`` entries when ``record_temp_dirs`` is true.
+        logger: Optional logger for diagnostics.
 
     Returns:
-      (resolved_paths, temp_dirs)
+        A ``(resolved_paths, temp_dirs)`` pair. ``resolved_paths`` holds one
+        extracted file path per successful archive; ``temp_dirs`` holds the
+        matching temporary directories, which the caller must keep alive while
+        the extracted files are in use and clean up afterwards.
 
-    If record_temp_dirs=True and temp_dir_map is provided, it will map each
-    extracted file path (resolved) to the TemporaryDirectory that produced it.
+    Examples:
+        Extract a batch of archives and clean up afterwards:
+
+            >>> paths, tmp_dirs = extract_zip_files_parallel(
+            ...     [Path("a.zip"), Path("b.zip")],
+            ...     tempdir_factory=tempfile.TemporaryDirectory,
+            ... )
+            >>> for tmp in tmp_dirs:
+            ...     tmp.cleanup()
     """
     logger = logger or log
     resolved: list[Path] = []
@@ -190,3 +292,30 @@ def extract_zip_files_parallel(
         len(zip_files),
     )
     return resolved, temp_dirs
+
+
+def extract_all_from_zip(zip_path: Path, dest: Path) -> None:
+    """Extract every member of ``zip_path`` into ``dest``, rejecting unsafe names.
+
+    Args:
+        zip_path: Path to the zip archive to extract.
+        dest: Destination directory. Created if it does not exist.
+
+    Returns:
+        None: The function returns nothing.
+
+    Raises:
+        ValueError: If any member name would escape ``dest``.
+        zipfile.BadZipFile: If ``zip_path`` is not a valid zip archive.
+
+    Examples:
+        Extract every member of a small archive:
+
+            >>> from pathlib import Path
+            >>> extract_all_from_zip(Path("archive.zip"), Path("dest_dir"))
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        for name in zf.namelist():
+            _ensure_safe_zip_member(name)
+        zf.extractall(dest)

--- a/src/firecube/core/index_resolve.py
+++ b/src/firecube/core/index_resolve.py
@@ -54,10 +54,15 @@ from firecube.core.slot_index import (
 
 
 class ExtentUnknownError(ValueError):
-    """Raised when a regular axis has no fixed extent (end and size are both None).
+    """Raised when a regular axis has no fixed extent.
 
-    The parallel gate catches this and re-raises as ``ConfigurationError``
-    naming the group and the missing field.
+    Examples:
+        >>> raise ExtentUnknownError(
+        ...     "regular axis has no fixed extent: set either end_date or slot_count"
+        ... )
+        Traceback (most recent call last):
+        ...
+        ExtentUnknownError: regular axis has no fixed extent: set either end_date or slot_count
     """
 
 
@@ -155,7 +160,7 @@ class RegularTimeResolver:
     Satisfies the ``AxisResolver`` Protocol. Cached properties avoid
     repeated epoch parsing.
 
-    Args:
+    Attributes:
         axis: The ``RegularTimeAxis`` specification to resolve.
     """
 
@@ -232,7 +237,7 @@ class IntegerResolver:
     Satisfies the ``AxisResolver`` Protocol. Coordinates and indexes are the
     same zero-based integral values.
 
-    Args:
+    Attributes:
         axis: The ``IntegerAxis`` specification to resolve.
     """
 
@@ -547,6 +552,19 @@ def resolve_index_spec(
         ConfigurationError: If any axis coordinate does not match
             ``time_dim_name``.
         NotImplementedError: If any axis kind is not supported.
+
+    Examples:
+        >>> from firecube.core.index_spec import IndexSpec, RegularTimeAxis
+        >>> axis = RegularTimeAxis(
+        ...     coordinate="timestamp",
+        ...     epoch="2024-01-01T00:00:00Z",
+        ...     cadence_s=600,
+        ...     slot_count=2,
+        ... )
+        >>> spec = IndexSpec(name="demo", groups={"data": axis})
+        >>> resolved = resolve_index_spec(spec, time_dim_name="timestamp")
+        >>> resolved.spec.name
+        'demo'
     """
     from firecube.core.errors import ConfigurationError
 

--- a/src/firecube/core/index_spec.py
+++ b/src/firecube/core/index_spec.py
@@ -95,7 +95,7 @@ def _canonical_coordinate_value(value: Any) -> Any:
 class RegularTimeAxis(AxisSpec):
     """A regularly-spaced time axis with a fixed epoch and cadence.
 
-    Args:
+    Attributes:
         coordinate: Name of the time coordinate dimension (e.g. ``"time"``).
         epoch: UTC-explicit ISO 8601 string for the axis origin (e.g.
             ``"2024-01-01T00:00:00Z"``). Naive strings are rejected.
@@ -203,7 +203,7 @@ class RegularTimeAxis(AxisSpec):
 class IntegerAxis(AxisSpec):
     """A zero-based integer axis with a fixed slot count.
 
-    Args:
+    Attributes:
         slot_count: Total number of integer positions on the axis
             (positive integer). Sets the shape of the axis dimension
             in the preallocated Zarr store: arrays indexed by this
@@ -229,7 +229,7 @@ class IntegerAxis(AxisSpec):
 class IrregularTimeAxis(AxisSpec):
     """A time axis with explicit coordinate values.
 
-    Args:
+    Attributes:
         coordinate: Name of the time coordinate dimension. Must match
             ``time_dim_name`` when the axis is resolved.
         values: Explicit coordinate values for the axis, or ``AUTO`` to
@@ -270,7 +270,7 @@ class IrregularTimeAxis(AxisSpec):
 class IndexSpec:
     """Declarative index specification for a multi-group DirectZarr product.
 
-    Args:
+    Attributes:
         name: Stable identifier for this index configuration. Used as the
             ``SlotIndexModel.name`` for byte-identity checks.
         groups: Mapping from group name to axis specification. Must be non-empty.
@@ -328,7 +328,7 @@ class ItemInfo:
     The engine uses ``coordinate`` to map the item to a position on its
     assigned axis.
 
-    Args:
+    Attributes:
         coordinate: The item's coordinate value. For ``RegularTimeAxis`` this
             is a UTC-explicit timestamp. For ``IntegerAxis`` this is an integer
             coordinate.

--- a/src/firecube/core/zarr/_reserved_attrs.py
+++ b/src/firecube/core/zarr/_reserved_attrs.py
@@ -21,24 +21,62 @@ conflict with firecube's own internal bookkeeping.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Final
 
-__all__ = ["RESERVED_ARRAY_ATTRS", "assert_attrs_safe"]
+__all__ = ["FIRECUBE_STATIC_WRITTEN_ATTR", "RESERVED_ARRAY_ATTRS", "assert_attrs_safe"]
+
+_ARRAY_DIMENSIONS_ATTR: Final[str] = "_ARRAY_DIMENSIONS"
+_FILL_VALUE_ATTR: Final[str] = "_FillValue"
+_FIRECUBE_RUN_ID_ATTR: Final[str] = "firecube_run_id"
+_FIRECUBE_SPAN_ID_ATTR: Final[str] = "firecube_span_id"
+_FIRECUBE_INTERNAL_ATTR: Final[str] = "firecube_internal"
+FIRECUBE_STATIC_WRITTEN_ATTR: Final[str] = "firecube_static_written"
+"""Zarr array attr Firecube stamps after a static array commit.
+
+Examples:
+    >>> FIRECUBE_STATIC_WRITTEN_ATTR
+    'firecube_static_written'
+"""
 
 RESERVED_ARRAY_ATTRS: frozenset[str] = frozenset(
     {
-        "_ARRAY_DIMENSIONS",
-        "_FillValue",
-        "firecube_run_id",
-        "firecube_span_id",
-        "firecube_internal",
-        "firecube_static_written",
+        _ARRAY_DIMENSIONS_ATTR,
+        _FILL_VALUE_ATTR,
+        _FIRECUBE_RUN_ID_ATTR,
+        _FIRECUBE_SPAN_ID_ATTR,
+        _FIRECUBE_INTERNAL_ATTR,
+        FIRECUBE_STATIC_WRITTEN_ATTR,
     }
 )
+"""Reserved Zarr array attribute keys managed by Firecube.
+
+Examples:
+    >>> "firecube_static_written" in RESERVED_ARRAY_ATTRS
+    True
+    >>> "my_custom_attr" in RESERVED_ARRAY_ATTRS
+    False
+"""
 
 
 def assert_attrs_safe(attrs: Mapping[str, Any]) -> None:
-    """Raise ValueError if *attrs* contains any reserved key."""
+    """Raise ValueError if *attrs* contains any reserved key.
+
+    Args:
+        attrs: Candidate attribute mapping for ``ZarrArraySpec.attrs``.
+
+    Returns:
+        None: The function returns nothing.
+
+    Raises:
+        ValueError: If any key is reserved for Firecube bookkeeping.
+
+    Examples:
+        >>> assert_attrs_safe({"my_custom_attr": 42})
+        >>> assert_attrs_safe({"firecube_static_written": True})
+        Traceback (most recent call last):
+        ...
+        ValueError: Reserved attr 'firecube_static_written' is managed by firecube, not the plugin. Remove it from ZarrArraySpec.attrs.
+    """
     for key in attrs:
         if key in RESERVED_ARRAY_ATTRS:
             raise ValueError(

--- a/src/firecube/core/zarr/chunk_geometry.py
+++ b/src/firecube/core/zarr/chunk_geometry.py
@@ -1,0 +1,166 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chunk-grid geometry helpers for advanced Zarr write coordination."""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+
+def physical_chunk_keys_for_region(
+    *,
+    group: str,
+    intent: Any,
+    shape: tuple[int, ...],
+    chunks: tuple[int, ...],
+    selection: Any,
+) -> tuple[set[tuple[str, str, tuple[int, ...]]], bool]:
+    """Return physical chunk keys touched by one region write.
+
+    Args:
+        group: Logical Zarr group used as the first element of each key.
+        intent: Write intent with ``group`` and ``array`` attributes for error
+            messages and chunk-key construction.
+        shape: Full target array shape. Rank 3 is interpreted as
+            ``(time, y, x)``; rank 4 as ``(time, y, x, channel)``.
+        chunks: Target array chunk shape with the same rank as ``shape``.
+        selection: Region selection with ``ts_index``, ``y_start``,
+            ``y_stop``, and optional ``channel_index`` attributes.
+
+    Returns:
+        A ``(keys, aligned)`` pair. ``keys`` contains ``(group, array,
+        chunk_coords)`` tuples. ``aligned`` is true when the write is aligned
+        to whole physical chunks along the selected non-X axes and the time
+        chunk size is one.
+
+    Raises:
+        ValueError: If ``selection.ts_index`` is outside ``shape``.
+
+    Examples:
+        Compute the one physical chunk touched by a chunk-aligned 2-row write:
+
+            >>> from types import SimpleNamespace
+            >>> intent = SimpleNamespace(group="data", array="values")
+            >>> selection = SimpleNamespace(ts_index=0, y_start=2, y_stop=4, channel_index=None)
+            >>> physical_chunk_keys_for_region(
+            ...     group="data",
+            ...     intent=intent,
+            ...     shape=(1, 6, 4),
+            ...     chunks=(1, 2, 4),
+            ...     selection=selection,
+            ... )
+            ({('data', 'values', (0, 1, 0))}, True)
+    """
+    rank = len(shape)
+    if selection.ts_index >= shape[0]:
+        raise ValueError(
+            "Concurrent region write ts_index is outside the opened target array: "
+            f"group={intent.group!r} array={intent.array!r} "
+            f"shape={shape!r} ts_index={selection.ts_index!r}."
+        )
+
+    time_chunks = chunk_axis_range(selection.ts_index, selection.ts_index + 1, chunks[0])
+    y_chunks = chunk_axis_range(selection.y_start, selection.y_stop, chunks[1])
+    x_chunks = chunk_axis_range(0, shape[2], chunks[2])
+
+    if rank == 3:
+        coords = itertools.product(time_chunks, y_chunks, x_chunks)
+        keys = {(group, intent.array, tuple(coord)) for coord in coords}
+        aligned = chunks[0] == 1 and axis_selection_is_chunk_aligned(
+            selection.y_start, selection.y_stop, shape[1], chunks[1]
+        )
+        return keys, aligned
+
+    if selection.channel_index is None:
+        channel_start = 0
+        channel_stop = shape[3]
+    else:
+        channel_start = selection.channel_index
+        channel_stop = selection.channel_index + 1
+    channel_chunks = chunk_axis_range(channel_start, channel_stop, chunks[3])
+    coords = itertools.product(time_chunks, y_chunks, x_chunks, channel_chunks)
+    keys = {(group, intent.array, tuple(coord)) for coord in coords}
+    aligned = (
+        chunks[0] == 1
+        and axis_selection_is_chunk_aligned(
+            selection.y_start, selection.y_stop, shape[1], chunks[1]
+        )
+        and axis_selection_is_chunk_aligned(channel_start, channel_stop, shape[3], chunks[3])
+    )
+    return keys, aligned
+
+
+def chunk_axis_range(start: int, stop: int, chunk_size: int) -> range:
+    """Return chunk indices intersected by a half-open axis selection.
+
+    Args:
+        start: Inclusive selected element index.
+        stop: Exclusive selected element index.
+        chunk_size: Physical chunk length along the axis.
+
+    Returns:
+        A ``range`` of intersected chunk indices. Empty or zero-length
+        selections return an empty range.
+
+    Raises:
+        ZeroDivisionError: If ``chunk_size`` is zero.
+
+    Examples:
+        A misaligned ``[1, 5)`` selection with chunk size two touches three
+        chunks:
+
+            >>> list(chunk_axis_range(1, 5, 2))
+            [0, 1, 2]
+    """
+    return range(start // chunk_size, ((stop - 1) // chunk_size) + 1)
+
+
+def axis_selection_is_chunk_aligned(
+    start: int,
+    stop: int,
+    axis_len: int,
+    chunk_size: int,
+) -> bool:
+    """Return whether a half-open axis selection aligns to chunk boundaries.
+
+    Args:
+        start: Inclusive selected element index.
+        stop: Exclusive selected element index.
+        axis_len: Full axis length. A selection ending at this value is aligned
+            even when the final chunk is partial.
+        chunk_size: Physical chunk length along the axis.
+
+    Returns:
+        ``True`` when ``start`` begins on a chunk boundary and ``stop`` is
+        either a chunk boundary or the axis end; otherwise ``False``.
+
+    Raises:
+        ZeroDivisionError: If ``chunk_size`` is zero.
+
+    Examples:
+        A whole final partial chunk is aligned when it reaches the axis end:
+
+            >>> axis_selection_is_chunk_aligned(4, 5, 5, 2)
+            True
+    """
+    return start % chunk_size == 0 and (stop == axis_len or stop % chunk_size == 0)
+
+
+__all__ = [
+    "axis_selection_is_chunk_aligned",
+    "chunk_axis_range",
+    "physical_chunk_keys_for_region",
+]

--- a/src/firecube/core/zarr/region_writer.py
+++ b/src/firecube/core/zarr/region_writer.py
@@ -27,6 +27,7 @@ coordinate axes and should be skipped by :meth:`ensure_timestamp_slot`.
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -38,7 +39,7 @@ from zarr.storage import LocalStore
 
 from firecube.core.errors import SchemaDriftError
 from firecube.core.uris import is_remote_target, local_path_from_target
-from firecube.core.zarr._reserved_attrs import assert_attrs_safe
+from firecube.core.zarr._reserved_attrs import _FILL_VALUE_ATTR, assert_attrs_safe
 
 log = logging.getLogger("firecube.core.zarr.region_writer")
 
@@ -107,6 +108,26 @@ def _array_is_all_fill(arr: np.ndarray, fill_value: Any) -> bool:
         if kind in ("M", "m"):
             return bool(np.all(np.isnat(arr)))
     return bool(np.all(arr == fill_value))
+
+
+def _fill_value_attr_value(fill_value: Any) -> Any:
+    """Return a JSON-safe scalar for use as a ``_FillValue`` attr, or ``None``.
+
+    Args:
+        fill_value: The fill value declared in ``ZarrArraySpec.fill_value``.
+
+    Returns:
+        A JSON-finite scalar (bool, int, str, or finite float) suitable for
+        writing into Zarr array attrs, or ``None`` if the value cannot be
+        represented safely (NaT, NaN, datetime objects, etc.).
+    """
+    if isinstance(fill_value, np.generic):
+        fill_value = fill_value.item()
+    if isinstance(fill_value, bool | int | str):
+        return fill_value
+    if isinstance(fill_value, float) and math.isfinite(fill_value):
+        return fill_value
+    return None
 
 
 _ARRAY_EQUAL_NAN_UNSAFE_KINDS = frozenset({"U", "S", "O", "V"})
@@ -396,6 +417,9 @@ class RegionZarrWriter:
                         f"existing={tuple(existing_dimnames)!r} spec={tuple(dimension_names)!r}. "
                         "Re-ingest from scratch; no in-place migration is provided."
                     )
+            _fv_attr = _fill_value_attr_value(fill_value)
+            if _fv_attr is not None and _FILL_VALUE_ATTR not in dict(arr.attrs):
+                arr.attrs[_FILL_VALUE_ATTR] = _fv_attr
             return arr
 
         kwargs: dict[str, Any] = {
@@ -418,7 +442,11 @@ class RegionZarrWriter:
             kwargs["serializer"] = serializer
         if compressors is not None:
             kwargs["compressors"] = list(compressors)
-        return target_group.create_array(**kwargs)
+        arr = target_group.create_array(**kwargs)
+        _fv_attr = _fill_value_attr_value(fill_value)
+        if _fv_attr is not None and _FILL_VALUE_ATTR not in dict(arr.attrs):
+            arr.attrs[_FILL_VALUE_ATTR] = _fv_attr
+        return arr
 
     def set_group_attrs(self, group: str, attrs: Mapping[str, Any] | None) -> None:
         """Stamp convention-agnostic group-level attributes onto the group metadata.

--- a/src/firecube/core/zarr/validation.py
+++ b/src/firecube/core/zarr/validation.py
@@ -31,8 +31,15 @@ import time
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, cast
 
-from firecube.core.filesystem.ops import _open_fsspec_url  # type: ignore
+import numpy as np
+
+from firecube.core.config import StorageConfig
+from firecube.core.filesystem.ops import (
+    _open_fsspec_url,  # type: ignore
+    create_filesystem_for_uri,
+)
 from firecube.core.filesystem.protocol import StorageFilesystem
+from firecube.core.filesystem.store_factory import create_zarr_store
 from firecube.core.storage.uri import StorageUri
 
 if TYPE_CHECKING:
@@ -57,6 +64,29 @@ class ZarrValidationReport:
     chunks_processed: int = 0
 
     def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ZarrCompareReport:
+    """Summary of a read-only comparison between two Zarr stores.
+
+    Attributes:
+        equivalent: Whether every compared array path, schema field, selected
+            attribute, static marker, and value payload matched.
+        mismatches: Terse mismatch descriptions grouped by array path and
+            category.
+
+    Examples:
+        >>> ZarrCompareReport(equivalent=True, mismatches=[]).equivalent
+        True
+    """
+
+    equivalent: bool
+    mismatches: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the report."""
         return asdict(self)
 
 
@@ -89,6 +119,175 @@ def _load_array_metadata_with_fs(fs: StorageFilesystem, group_uri: StorageUri) -
             return json.load(handle)
     except FileNotFoundError:
         raise FileNotFoundError(f"Missing zarr.json at {meta_uri.to_str()}") from None
+
+
+def _load_root_metadata_with_fs(fs: StorageFilesystem, store_uri: StorageUri) -> dict[str, Any]:
+    meta_uri = store_uri.join("zarr.json")
+    try:
+        with fs.open(meta_uri, "r") as handle:  # pyright: ignore[reportArgumentType]
+            return json.load(handle)
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Missing Zarr store metadata at {meta_uri.to_str()}") from None
+
+
+def _discover_arrays_with_fs(fs: StorageFilesystem, store_uri: StorageUri) -> list[str]:
+    arrays: list[str] = []
+    for entry in fs.find(store_uri):  # pyright: ignore[reportArgumentType]
+        if not isinstance(entry, StorageUri):
+            continue
+        if entry.path.rsplit("/", 1)[-1] != "zarr.json":
+            continue
+        with fs.open(entry, "r") as handle:
+            meta = json.load(handle)
+        if meta.get("node_type") != "array":
+            continue
+        parent = entry.parent()
+        rel = parent.path.removeprefix(store_uri.path.rstrip("/")).strip("/")
+        if rel:
+            arrays.append(rel)
+    return sorted(set(arrays))
+
+
+def _public_attrs(attrs: Any) -> dict[str, Any]:
+    from firecube.core.api import RESERVED_ARRAY_ATTRS, assert_attrs_safe
+
+    filtered = {
+        str(key): value
+        for key, value in dict(attrs or {}).items()
+        if key not in RESERVED_ARRAY_ATTRS
+    }
+    assert_attrs_safe(filtered)
+    return filtered
+
+
+def _dimension_names(array: Any) -> tuple[str, ...] | None:
+    metadata = getattr(array, "metadata", None)
+    names = getattr(metadata, "dimension_names", None)
+    if names is None:
+        return None
+    return tuple(str(name) for name in names)
+
+
+def _static_marker(array: Any) -> Any:
+    from firecube.core.api import FIRECUBE_STATIC_WRITTEN_ATTR
+
+    return dict(getattr(array, "attrs", {}) or {}).get(FIRECUBE_STATIC_WRITTEN_ATTR)
+
+
+def _values_equal(left: Any, right: Any) -> bool:
+    left_values = np.asarray(left[:])
+    right_values = np.asarray(right[:])
+    if left_values.dtype.kind == "f" and right_values.dtype.kind == "f":
+        return bool(np.array_equal(left_values, right_values, equal_nan=True))
+    return bool(np.array_equal(left_values, right_values))
+
+
+def compare_zarr_stores(
+    a_uri: str,
+    b_uri: str,
+    *,
+    storage_type: str,
+    storage_driver: str,
+) -> ZarrCompareReport:
+    """Compare two Zarr stores through the configured storage abstraction.
+
+    The comparison is read-only and checks array paths, shape, dtype, chunks,
+    native Zarr dimension names, public attrs, the Firecube static-array marker,
+    and full array values. Runtime-managed attrs such as ``firecube_run_id`` and
+    ``firecube_span_id`` are ignored.
+
+    Args:
+        a_uri: First Zarr store URI.
+        b_uri: Second Zarr store URI.
+        storage_type: Storage locality, either ``"local"`` or ``"s3"``.
+        storage_driver: Storage driver, either ``"fsspec"`` or ``"obstore"``.
+
+    Returns:
+        ZarrCompareReport: ``equivalent=True`` when no mismatches were found;
+        otherwise ``equivalent=False`` with one terse message per mismatch.
+
+    Raises:
+        FileNotFoundError: If either store or a discovered array is missing.
+        ValueError: If the storage configuration is invalid.
+
+    Examples:
+        >>> report = compare_zarr_stores(
+        ...     "file:///tmp/a.zarr",
+        ...     "file:///tmp/b.zarr",
+        ...     storage_type="local",
+        ...     storage_driver="fsspec",
+        ... )
+        >>> isinstance(report.equivalent, bool)
+        True
+    """
+    import zarr
+
+    storage_config = StorageConfig(storage_type=storage_type, storage_driver=storage_driver)
+    storage_config.validate()
+    a_fs, a_store_uri = create_filesystem_for_uri(a_uri, storage_config, format="zarr")
+    b_fs, b_store_uri = create_filesystem_for_uri(b_uri, storage_config, format="zarr")
+    _load_root_metadata_with_fs(a_fs, a_store_uri)
+    _load_root_metadata_with_fs(b_fs, b_store_uri)
+
+    a_paths = set(_discover_arrays_with_fs(a_fs, a_store_uri))
+    b_paths = set(_discover_arrays_with_fs(b_fs, b_store_uri))
+    mismatches = [f"array {path}: missing from second store" for path in sorted(a_paths - b_paths)]
+    mismatches.extend(
+        f"array {path}: missing from first store" for path in sorted(b_paths - a_paths)
+    )
+
+    a_handle = create_zarr_store(uri=a_uri, storage_config=storage_config, mode="r")
+    b_handle = create_zarr_store(uri=b_uri, storage_config=storage_config, mode="r")
+    a_root = zarr.open_group(**a_handle.zarr_kwargs(), mode="r")
+    b_root = zarr.open_group(**b_handle.zarr_kwargs(), mode="r")
+
+    for path in sorted(a_paths & b_paths):
+        left = cast(Any, a_root[path])
+        right = cast(Any, b_root[path])
+        path_prefix = f"array {path}"
+
+        left_shape = tuple(int(size) for size in left.shape)
+        right_shape = tuple(int(size) for size in right.shape)
+        if left_shape != right_shape:
+            mismatches.append(f"{path_prefix}: shape {left_shape} != {right_shape}")
+
+        left_dtype = np.dtype(left.dtype)
+        right_dtype = np.dtype(right.dtype)
+        if left_dtype != right_dtype:
+            mismatches.append(f"{path_prefix}: dtype {left_dtype} != {right_dtype}")
+
+        left_chunks = tuple(int(size) for size in left.chunks)
+        right_chunks = tuple(int(size) for size in right.chunks)
+        if left_chunks != right_chunks:
+            mismatches.append(f"{path_prefix}: chunks {left_chunks} != {right_chunks}")
+
+        left_dimension_names = _dimension_names(left)
+        right_dimension_names = _dimension_names(right)
+        if left_dimension_names != right_dimension_names:
+            mismatches.append(
+                f"{path_prefix}: dimension_names {left_dimension_names} != {right_dimension_names}"
+            )
+
+        left_attrs = _public_attrs(getattr(left, "attrs", {}))
+        right_attrs = _public_attrs(getattr(right, "attrs", {}))
+        if left_attrs != right_attrs:
+            mismatches.append(f"{path_prefix}: attrs differ")
+
+        left_marker = _static_marker(left)
+        right_marker = _static_marker(right)
+        if left_marker != right_marker:
+            mismatches.append(
+                f"{path_prefix}: firecube_static_written {left_marker!r} != {right_marker!r}"
+            )
+
+        if (
+            left_shape == right_shape
+            and left_dtype == right_dtype
+            and not _values_equal(left, right)
+        ):
+            mismatches.append(f"{path_prefix}: values differ")
+
+    return ZarrCompareReport(equivalent=not mismatches, mismatches=mismatches)
 
 
 def _chunk_entry_path(entry: StorageUri | str) -> str:

--- a/src/firecube/ingestor/api.py
+++ b/src/firecube/ingestor/api.py
@@ -24,8 +24,11 @@ from typing import TYPE_CHECKING, Any
 
 from firecube.core.api import (
     AUTO,
+    FIRECUBE_STATIC_WRITTEN_ATTR,
+    RESERVED_ARRAY_ATTRS,
     AxisSpec,
     DuplicateIrregularCoordinateError,
+    ExtentUnknownError,
     IndexedWrite,
     IndexedWriteCompilationError,
     IndexSpec,
@@ -38,6 +41,8 @@ from firecube.core.api import (
     RegularTimeAxis,
     ResolvedIndex,
     ResolvedIndexRecord,
+    assert_attrs_safe,
+    resolve_index_spec,
     validate_manifest_entries,
 )
 from firecube.core.controlplane import SpanCoverage, WriteDomain
@@ -62,6 +67,7 @@ from firecube.ingestor.errors import (
     SchemaDriftError,
     SchemaSizeMismatchError,
     StorageError,
+    UnboundedAxisError,
     WriteIntentRangeError,
 )
 from firecube.ingestor.registry.loader import (
@@ -120,6 +126,8 @@ if TYPE_CHECKING:
     from firecube.ingestor.templates.generic_tensogram import GenericTensogramIngestor
 __all__ = [
     "AUTO",
+    "FIRECUBE_STATIC_WRITTEN_ATTR",
+    "RESERVED_ARRAY_ATTRS",
     "AppendStrategy",
     "AppendWriteStrategy",
     "AxisSpec",
@@ -130,6 +138,7 @@ __all__ = [
     "DirectZarrIngestor",
     "DuplicateIrregularCoordinateError",
     "EngineConfig",
+    "ExtentUnknownError",
     "GenericParquetIngestor",
     "GenericTensogramIngestor",
     "GenericZarrIngestor",
@@ -179,12 +188,14 @@ __all__ = [
     "TemplateConfig",
     "TensogramTemplateConfig",
     "TensogramWriteStrategy",
+    "UnboundedAxisError",
     "WriteDomain",
     "WriteIntent",
     "WriteIntentRangeError",
     "ZarrArraySpec",
     "ZarrGroupSpec",
     "ZarrTemplateConfig",
+    "assert_attrs_safe",
     "chunk_align_ranges",
     "compute_covered_ranges",
     "config_keys",
@@ -192,6 +203,7 @@ __all__ = [
     "is_dataset_producer",
     "merge_batch_metrics",
     "register_ingestor",
+    "resolve_index_spec",
     "validate_chunk_alignment",
     "validate_manifest_entries",
     "validate_slot_range",

--- a/src/firecube/ingestor/config/engine.py
+++ b/src/firecube/ingestor/config/engine.py
@@ -26,6 +26,8 @@ import warnings
 from dataclasses import dataclass, fields
 from typing import Any, TypeVar, get_type_hints
 
+from firecube.ingestor.errors import ConfigurationError
+
 T = TypeVar("T", bound="EngineConfig")
 
 SYSTEM_KEYS = {
@@ -81,6 +83,10 @@ class EngineConfig:
         slot_end: One-past-last slot index for orchestrated parallel ingestion.
         slot_size: Slot width used when deriving slot ranges from the environment.
         slot_group: Zarr group owned by this worker in multi-group slot runs.
+        suppress_static_emission_for_non_owner: Skip static writes in slot-range
+            workers whose ``slot_start`` does not match ``static_owner_slot_start``.
+        static_owner_slot_start: V1 scalar static-owner slot start for one group
+            per run; required when static suppression is enabled.
     """
 
     # Execution (Pipeline)
@@ -126,8 +132,20 @@ class EngineConfig:
     slot_end: int | None = None
     slot_size: int | None = None
     slot_group: str | None = None
+    suppress_static_emission_for_non_owner: bool = False
+    static_owner_slot_start: int | None = None
 
     def __post_init__(self) -> None:
+        if self.suppress_static_emission_for_non_owner and self.static_owner_slot_start is None:
+            raise ConfigurationError(
+                "suppress_static_emission_for_non_owner=True requires static_owner_slot_start"
+            )
+        if self.suppress_static_emission_for_non_owner and self.slot_start is None:
+            raise ConfigurationError(
+                "suppress_static_emission_for_non_owner=True requires slot_start to be set "
+                "(serial runs would silently skip all static writes without a slot boundary)"
+            )
+
         if self.slot_group is not None and not self.slot_group.strip():
             raise ValueError(
                 "slot_group must be a non-empty string when set; got empty or whitespace string."

--- a/src/firecube/ingestor/errors.py
+++ b/src/firecube/ingestor/errors.py
@@ -27,6 +27,25 @@ class IngestorError(FirecubeError):
     """Base exception for all ingestor-layer errors."""
 
 
+class UnboundedAxisError(ConfigurationError):
+    """Raised when a regular axis has no fixed extent but one is required.
+
+    Set ``RegularTimeAxis(end_date=...)`` or ``slot_count=...`` in the
+    declared ``IndexSpec`` to give the axis a fixed extent.
+
+    Args:
+        group: Name of the index group whose axis lacks a fixed extent.
+    """
+
+    def __init__(self, group: str) -> None:
+        super().__init__(
+            f"group {group!r}: axis has no fixed extent — set "
+            "RegularTimeAxis(end_date=...) or slot_count=... "
+            "to enable parallel ingestion"
+        )
+        self.group = group
+
+
 class SchemaSizeMismatchError(IngestorError):
     """Raised when an existing Zarr array's shape is smaller than the global expected size.
 
@@ -77,5 +96,6 @@ __all__ = [
     "SchemaSizeMismatchError",
     "StagedMetadataError",
     "StorageError",
+    "UnboundedAxisError",
     "WriteIntentRangeError",
 ]

--- a/src/firecube/ingestor/runtime/base.py
+++ b/src/firecube/ingestor/runtime/base.py
@@ -33,6 +33,7 @@ from firecube.core.controlplane.metrics import collect_wal_metrics
 from firecube.core.controlplane.types import IndexEnsuredOutcome
 from firecube.core.filesystem import collect_filesystem_metrics
 from firecube.core.formats import discover_input_files
+from firecube.core.index_resolve import ExtentUnknownError
 from firecube.core.intake import CatalogGroupInfo
 from firecube.core.observability import create_ingestion_telemetry
 from firecube.core.observability.metrics import TelemetryService, emit_index_ensured_full
@@ -778,6 +779,7 @@ class BaseIngestor(BaseIngestorHookMixin, Ingestor, ABC):
 
                 binding = getattr(self, "_index_binding", None)
                 if binding is not None:
+                    from firecube.ingestor.errors import UnboundedAxisError
                     from firecube.ingestor.runtime.parallel_gate import (
                         validate_global_expected_subset_of_schema,
                         warn_on_chunk_alignment,
@@ -786,9 +788,12 @@ class BaseIngestor(BaseIngestorHookMixin, Ingestor, ABC):
 
                     ingestor_self: Any = self
                     if isinstance(ingestor_self, DirectZarrIngestor):
-                        global_expected = {
-                            group: binding.resolved.size(group) for group in binding.resolved.groups
-                        }
+                        global_expected: dict[str, int] = {}
+                        for group in binding.resolved.groups:
+                            try:
+                                global_expected[group] = binding.resolved.size(group)
+                            except ExtentUnknownError as exc:
+                                raise UnboundedAxisError(group) from exc
                         schema = ingestor_self.zarr_schema(runtime_plugin_ctx)
                         if schema:
                             validate_global_expected_subset_of_schema(global_expected, schema)

--- a/src/firecube/ingestor/runtime/index_binding.py
+++ b/src/firecube/ingestor/runtime/index_binding.py
@@ -55,7 +55,7 @@ class IndexBinding:
     Holds the spec, the resolved index, and the context identity so the
     ``DirectZarrIngestor`` can cache it per ``(id(ctx._ctx), spec)``.
 
-    Args:
+    Attributes:
         spec: The ``IndexSpec`` that was resolved.
         resolved: The resolved index ready for slot-index computation.
     """

--- a/src/firecube/ingestor/runtime/parallel_gate.py
+++ b/src/firecube/ingestor/runtime/parallel_gate.py
@@ -21,7 +21,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from firecube.core.index_resolve import ExtentUnknownError
-from firecube.ingestor.errors import ConfigurationError
+from firecube.ingestor.errors import (
+    ConfigurationError,
+    UnboundedAxisError,
+)
 from firecube.ingestor.runtime.index_binding import IndexBinding
 from firecube.ingestor.templates.direct_zarr import DirectZarrIngestor
 
@@ -136,11 +139,7 @@ def validate_parallel_capability(
         try:
             binding.resolved.size(group)
         except ExtentUnknownError as exc:
-            raise ConfigurationError(
-                f"group {group!r}: axis has no fixed extent — set "
-                "RegularTimeAxis(end_date=...) or slot_count=... "
-                "to enable parallel ingestion"
-            ) from exc
+            raise UnboundedAxisError(group) from exc
 
     if type(ingestor).inspect_item is DirectZarrIngestor.inspect_item:
         raise ConfigurationError("--slot-start/--slot-end require inspect_item() override")

--- a/src/firecube/ingestor/runtime/zarr/batch_runner.py
+++ b/src/firecube/ingestor/runtime/zarr/batch_runner.py
@@ -118,6 +118,7 @@ def build_zarr_write_context(
         configured_scheduler=zarr_config.get("dask_scheduler"),
         write_threads=int(zarr_config.get("write_threads", 0)),
         async_concurrency=int(zarr_config.get("async_concurrency", 10)),
+        write_empty_chunks=bool(zarr_config.get("write_empty_chunks", False)),
     )
 
 

--- a/src/firecube/ingestor/runtime/zarr/strategies/indexed_region.py
+++ b/src/firecube/ingestor/runtime/zarr/strategies/indexed_region.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
-import itertools
 import logging
 import time
 from collections.abc import Callable, Mapping, Sequence
@@ -37,6 +36,7 @@ import numpy as np
 
 from firecube.core.errors import SchemaDriftError
 from firecube.core.uris import storage_uri_from_target
+from firecube.core.zarr.chunk_geometry import physical_chunk_keys_for_region
 from firecube.core.zarr.region_writer import (
     RegionZarrWriter,
     _arrays_equal_missing_aware,
@@ -65,6 +65,15 @@ def _session_for_store(store_uri: str, storage_config: StorageConfig) -> Storage
 
 
 log = logging.getLogger("firecube.runtime.zarr.strategies.indexed_region")
+
+
+@contextlib.contextmanager
+def _array_write_empty_chunks_config(write_empty_chunks: bool):
+    import zarr as _zarr
+
+    with _zarr.config.set({"array.write_empty_chunks": write_empty_chunks}):
+        yield
+
 
 # Reserved array attr stamped once a static (write-once) array's data has been
 # committed. Its presence — not the array contents — is the authoritative
@@ -136,6 +145,39 @@ class IndexedRegionStrategy:
         slot_group: str | None = None,
         codec_pipelines_by_array: Mapping[tuple[str, str], tuple[Any, Any, Any]] | None = None,
         region_write_concurrency: int = 1,
+        suppress_static_emission_for_non_owner: bool = False,
+        static_owner_slot_start: int | None = None,
+        zarr_write_empty_chunks: bool = False,
+    ) -> dict[str, Any]:
+        with _array_write_empty_chunks_config(zarr_write_empty_chunks):
+            result = self._write_groups_unscoped(
+                group_to_intents=group_to_intents,
+                schema=schema,
+                claim_for_group=claim_for_group,
+                claim_for_slot=claim_for_slot,
+                slot_range=slot_range,
+                slot_group=slot_group,
+                codec_pipelines_by_array=codec_pipelines_by_array,
+                region_write_concurrency=region_write_concurrency,
+                suppress_static_emission_for_non_owner=suppress_static_emission_for_non_owner,
+                static_owner_slot_start=static_owner_slot_start,
+            )
+        result["zarr_write_empty_chunks_effective"] = zarr_write_empty_chunks
+        return result
+
+    def _write_groups_unscoped(
+        self,
+        *,
+        group_to_intents: dict[str, list[Any]],
+        schema: Sequence[Any] | None = None,
+        claim_for_group: Callable[[str], Any] | None = None,
+        claim_for_slot: Callable[[str, int], Any] | None = None,
+        slot_range: tuple[int, int] | None = None,
+        slot_group: str | None = None,
+        codec_pipelines_by_array: Mapping[tuple[str, str], tuple[Any, Any, Any]] | None = None,
+        region_write_concurrency: int = 1,
+        suppress_static_emission_for_non_owner: bool = False,
+        static_owner_slot_start: int | None = None,
     ) -> dict[str, Any]:
         """Execute write intents grouped by Zarr group and return metrics.
 
@@ -161,6 +203,11 @@ class IndexedRegionStrategy:
             region_write_concurrency: Maximum concurrent region writes per
                 claimed timestamp slot. ``1`` uses the historical serial
                 dispatch path.
+            suppress_static_emission_for_non_owner: When true, static intents
+                are emitted only by the worker whose slot start matches
+                ``static_owner_slot_start``.
+            static_owner_slot_start: V1 scalar owner ``slot_start`` for one
+                group per run.
 
         Returns:
             dict with ``"coverage"`` list and ``"duration_s"`` float.
@@ -352,6 +399,13 @@ class IndexedRegionStrategy:
 
             if region_write_concurrency == 1:
                 for intent in static_intents:
+                    if self._should_suppress_static_intent(
+                        intent,
+                        slot_range=slot_range,
+                        suppress_static_emission_for_non_owner=suppress_static_emission_for_non_owner,
+                        static_owner_slot_start=static_owner_slot_start,
+                    ):
+                        continue
                     self._dispatch_static_intent(writer, intent)
 
                 intents_by_slot: dict[int, list[Any]] = {}
@@ -414,6 +468,13 @@ class IndexedRegionStrategy:
                 )
 
                 for intent in static_intents:
+                    if self._should_suppress_static_intent(
+                        intent,
+                        slot_range=slot_range,
+                        suppress_static_emission_for_non_owner=suppress_static_emission_for_non_owner,
+                        static_owner_slot_start=static_owner_slot_start,
+                    ):
+                        continue
                     self._dispatch_static_intent(writer, intent)
 
                 self._dispatch_timed_intents_concurrently(
@@ -436,6 +497,31 @@ class IndexedRegionStrategy:
             "region_writes_aligned_count": region_writes_aligned_count,
             "region_writes_total_count": region_writes_total_count,
         }
+
+    @staticmethod
+    def _should_suppress_static_intent(
+        intent: Any,
+        *,
+        slot_range: tuple[int, int] | None,
+        suppress_static_emission_for_non_owner: bool,
+        static_owner_slot_start: int | None,
+    ) -> bool:
+        if slot_range is None:
+            # Serial mode: no non-owner concept, always write statics locally.
+            return False
+        if not suppress_static_emission_for_non_owner:
+            return False
+        slot_start = slot_range[0]
+        if slot_start == static_owner_slot_start:
+            return False
+        log.warning(
+            "static write suppressed as non-owner: group=%s array=%s slot_start=%s owner=%s",
+            intent.group,
+            intent.array,
+            slot_start,
+            static_owner_slot_start,
+        )
+        return True
 
     @classmethod
     def _validate_declared_concurrent_region_intents(
@@ -519,7 +605,7 @@ class IndexedRegionStrategy:
                     shape,
                     source="opened target array",
                 )
-                keys, aligned = cls._physical_chunk_keys_for_region(
+                keys, aligned = physical_chunk_keys_for_region(
                     group=group_name,
                     intent=intent,
                     shape=shape,
@@ -763,7 +849,7 @@ class IndexedRegionStrategy:
                     tuple(getattr(spec, "shape", ())),
                     source="declared schema",
                 )
-                _, aligned = cls._physical_chunk_keys_for_region(
+                _, aligned = physical_chunk_keys_for_region(
                     group=intent.group,
                     intent=intent,
                     shape=tuple(int(axis) for axis in spec.shape),
@@ -912,69 +998,6 @@ class IndexedRegionStrategy:
         if value is None:
             return default
         return IndexedRegionStrategy._as_non_negative_int(value, field=field, intent=intent)
-
-    @classmethod
-    def _physical_chunk_keys_for_region(
-        cls,
-        *,
-        group: str,
-        intent: Any,
-        shape: tuple[int, ...],
-        chunks: tuple[int, ...],
-        selection: _RegionSelection,
-    ) -> tuple[set[tuple[str, str, tuple[int, ...]]], bool]:
-        rank = len(shape)
-        if selection.ts_index >= shape[0]:
-            raise ValueError(
-                "Concurrent region write ts_index is outside the opened target array: "
-                f"group={intent.group!r} array={intent.array!r} "
-                f"shape={shape!r} ts_index={selection.ts_index!r}."
-            )
-
-        time_chunks = cls._chunk_axis_range(selection.ts_index, selection.ts_index + 1, chunks[0])
-        y_chunks = cls._chunk_axis_range(selection.y_start, selection.y_stop, chunks[1])
-        x_chunks = cls._chunk_axis_range(0, shape[2], chunks[2])
-
-        if rank == 3:
-            coords = itertools.product(time_chunks, y_chunks, x_chunks)
-            keys = {(group, intent.array, tuple(coord)) for coord in coords}
-            aligned = chunks[0] == 1 and cls._axis_selection_is_chunk_aligned(
-                selection.y_start, selection.y_stop, shape[1], chunks[1]
-            )
-            return keys, aligned
-
-        if selection.channel_index is None:
-            channel_start = 0
-            channel_stop = shape[3]
-        else:
-            channel_start = selection.channel_index
-            channel_stop = selection.channel_index + 1
-        channel_chunks = cls._chunk_axis_range(channel_start, channel_stop, chunks[3])
-        coords = itertools.product(time_chunks, y_chunks, x_chunks, channel_chunks)
-        keys = {(group, intent.array, tuple(coord)) for coord in coords}
-        aligned = (
-            chunks[0] == 1
-            and cls._axis_selection_is_chunk_aligned(
-                selection.y_start, selection.y_stop, shape[1], chunks[1]
-            )
-            and cls._axis_selection_is_chunk_aligned(
-                channel_start, channel_stop, shape[3], chunks[3]
-            )
-        )
-        return keys, aligned
-
-    @staticmethod
-    def _chunk_axis_range(start: int, stop: int, chunk_size: int) -> range:
-        return range(start // chunk_size, ((stop - 1) // chunk_size) + 1)
-
-    @staticmethod
-    def _axis_selection_is_chunk_aligned(
-        start: int,
-        stop: int,
-        axis_len: int,
-        chunk_size: int,
-    ) -> bool:
-        return start % chunk_size == 0 and (stop == axis_len or stop % chunk_size == 0)
 
     @classmethod
     def _dispatch_static_intent(cls, writer: RegionZarrWriter, intent: Any) -> None:

--- a/src/firecube/ingestor/runtime/zarr/write_context.py
+++ b/src/firecube/ingestor/runtime/zarr/write_context.py
@@ -44,6 +44,14 @@ _VALID_SCHEDULERS: frozenset[str] = frozenset(
 )
 
 
+@contextlib.contextmanager
+def _array_write_empty_chunks_config(write_empty_chunks: bool):
+    import zarr as _zarr
+
+    with _zarr.config.set({"array.write_empty_chunks": write_empty_chunks}):
+        yield
+
+
 class ZarrWriteContext:
     """Context manager for Zarr write sessions.
 
@@ -62,6 +70,8 @@ class ZarrWriteContext:
         async_concurrency: Zarr async pipeline concurrency.  ``10`` is the
             default sentinel value; setting both *write_threads > 0* **and** a
             non-default concurrency raises ``ConfigurationError``.
+        write_empty_chunks: Scoped Zarr ``array.write_empty_chunks`` setting
+            used only while this write context is active.
     """
 
     def __init__(
@@ -71,11 +81,13 @@ class ZarrWriteContext:
         configured_scheduler: str | None = None,
         write_threads: int = 0,
         async_concurrency: int = 10,
+        write_empty_chunks: bool = False,
     ) -> None:
         self._write_lock = write_lock
         self._configured_scheduler = configured_scheduler
         self._write_threads = write_threads
         self._async_concurrency = async_concurrency
+        self._write_empty_chunks = write_empty_chunks
 
         self._exit_stack: contextlib.ExitStack | None = None
 
@@ -122,6 +134,7 @@ class ZarrWriteContext:
         try:
             stack.enter_context(self._write_lock)  # type: ignore[arg-type]
             stack.enter_context(dask_ctx)
+            stack.enter_context(_array_write_empty_chunks_config(self._write_empty_chunks))
         except BaseException:
             stack.close()
             self._exit_stack = None

--- a/src/firecube/ingestor/templates/config.py
+++ b/src/firecube/ingestor/templates/config.py
@@ -194,6 +194,8 @@ class ZarrTemplateConfig(TemplateConfig):
         zarr_time_encoding: Optional time encoding override.
         zarr_async_concurrency: Async write concurrency used by Zarr.
         zarr_region_write_concurrency: Region write concurrency used by Zarr.
+        zarr_write_empty_chunks: Pass through Zarr's array write-empty-chunks
+            policy for scoped write phases. Defaults to ``False``.
         dask_scheduler: Optional Dask scheduler override.
         dask_write_threads: Optional write-thread count for Dask-backed writes.
     """
@@ -207,6 +209,7 @@ class ZarrTemplateConfig(TemplateConfig):
     zarr_time_encoding: str | None = None
     zarr_async_concurrency: int = 10
     zarr_region_write_concurrency: int = 1
+    zarr_write_empty_chunks: bool = False
     dask_scheduler: str | None = None
     dask_write_threads: int = 0
 

--- a/src/firecube/ingestor/templates/direct_zarr.py
+++ b/src/firecube/ingestor/templates/direct_zarr.py
@@ -43,7 +43,7 @@ from typing import Any
 
 import numpy as np
 
-from firecube.core.api import IndexSpec, ItemInfo, ResolvedIndex
+from firecube.core.api import ExtentUnknownError, IndexSpec, ItemInfo, ResolvedIndex
 from firecube.core.errors import ClaimConflictError, IndexedWriteCompilationError
 from firecube.core.indexed_write import IndexedWrite
 from firecube.ingestor.api import (
@@ -57,6 +57,7 @@ from firecube.ingestor.api import (
     RuntimeIngestContext,
     SchemaDriftError,
     SchemaSizeMismatchError,
+    UnboundedAxisError,
     WriteDomain,
     ZarrTemplateConfig,
     merge_batch_metrics,
@@ -1297,7 +1298,14 @@ class DirectZarrIngestor(BaseIngestor):
 
             binding = self._index_binding
             if slot_range is not None and binding is not None:
-                global_expected = {g: binding.resolved.size(g) for g in binding.resolved.groups}
+                # Defense in depth: serial-mode plugins should already be gated upstream,
+                # but this keeps the failure a ConfigurationError if the gate is bypassed.
+                global_expected: dict[str, int] = {}
+                for group in binding.resolved.groups:
+                    try:
+                        global_expected[group] = binding.resolved.size(group)
+                    except ExtentUnknownError as exc:
+                        raise UnboundedAxisError(group) from exc
 
                 # Strict coverage: every group receiving WriteIntents MUST be declared
                 # in index_spec(ctx). Without this, a group could be written to by
@@ -1339,16 +1347,31 @@ class DirectZarrIngestor(BaseIngestor):
                 "zarr_region_write_concurrency",
                 1,
             )
-
+            zarr_write_empty_chunks = getattr(
+                concurrency_template_config,
+                "zarr_write_empty_chunks",
+                False,
+            )
             metrics = strategy.write_groups(
                 group_to_intents=group_to_intents,
                 schema=schema,
                 claim_for_group=claim_for_group,
                 claim_for_slot=claim_for_slot,
                 slot_range=slot_range,
-                slot_group=self.engine_config.slot_group,
+                slot_group=getattr(self.engine_config, "slot_group", None),
                 codec_pipelines_by_array=codec_pipelines_by_array,
                 region_write_concurrency=region_write_concurrency,
+                suppress_static_emission_for_non_owner=getattr(
+                    self.engine_config,
+                    "suppress_static_emission_for_non_owner",
+                    False,
+                ),
+                static_owner_slot_start=getattr(
+                    self.engine_config,
+                    "static_owner_slot_start",
+                    None,
+                ),
+                zarr_write_empty_chunks=zarr_write_empty_chunks,
             )
 
             # prep_metrics unpacked first so template-owned keys win on collision;
@@ -1368,6 +1391,8 @@ class DirectZarrIngestor(BaseIngestor):
                 success=True,
             )
 
+        except ConfigurationError:
+            raise
         except Exception as exc:
             self._log.exception("Direct Zarr batch processing failed")
             return PipelineResult(

--- a/src/firecube/ingestor/templates/generic.py
+++ b/src/firecube/ingestor/templates/generic.py
@@ -224,6 +224,7 @@ class GenericZarrIngestor(BaseIngestor):
             "consolidate": cfg.zarr_consolidate,
             "time_encoding": cfg.zarr_time_encoding,
             "async_concurrency": cfg.zarr_async_concurrency,
+            "write_empty_chunks": cfg.zarr_write_empty_chunks,
             "dask_scheduler": cfg.dask_scheduler,
             "write_threads": cfg.dask_write_threads,
             "shard_shape": cfg.zarr_shard_shape,

--- a/tests/cli/_command_contracts.py
+++ b/tests/cli/_command_contracts.py
@@ -123,6 +123,14 @@ CLI_COMMAND_CONTRACTS: Mapping[tuple[str, ...], ContractEntry] = {
         smart_default_eligible=True,
         expected_failures=[],
     ),
+    ("zarr", "compare"): ContractEntry(
+        path=("zarr", "compare"),
+        tier="inspect",
+        uri_roles={"A_URI": "product-input", "B_URI": "product-input"},
+        required_storage_flags=["--storage-type", "--storage-driver"],
+        smart_default_eligible=False,
+        expected_failures=[],
+    ),
     ("parquet", "validate"): ContractEntry(
         path=("parquet", "validate"),
         tier="inspect",

--- a/tests/cli/test_zarr_compare.py
+++ b/tests/cli/test_zarr_compare.py
@@ -1,0 +1,114 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import zarr
+from click.testing import CliRunner
+
+from firecube.cli.main import cli
+
+pytestmark = pytest.mark.unit
+
+
+def _make_store(
+    path: Path,
+    *,
+    shape: tuple[int, ...] = (2, 2),
+    chunks: tuple[int, ...] = (1, 2),
+    values: Any | None = None,
+) -> Path:
+    root = zarr.open_group(store=str(path), mode="w", zarr_format=3)
+    arr = root.require_group("data").create_array(
+        "values",
+        shape=shape,
+        dtype="float32",
+        chunks=chunks,
+        dimension_names=("y", "x"),
+    )
+    data = np.arange(np.prod(shape), dtype=np.float32).reshape(shape) if values is None else values
+    arr[...] = data
+    return path
+
+
+def _invoke_compare(args: list[str]):
+    return CliRunner().invoke(cli, ["zarr", "compare", *args])
+
+
+def _required_args(a: Path, b: Path) -> list[str]:
+    return [
+        a.as_uri(),
+        b.as_uri(),
+        "--storage-type",
+        "local",
+        "--storage-driver",
+        "fsspec",
+    ]
+
+
+def test_compare_identical_stores_exit_zero(tmp_path: Path) -> None:
+    a = _make_store(tmp_path / "a.zarr")
+    b = _make_store(tmp_path / "b.zarr")
+
+    result = _invoke_compare(_required_args(a, b))
+
+    assert result.exit_code == 0, result.output
+    assert result.stderr == ""
+
+
+def test_compare_mismatched_shape_exit_nonzero_with_stderr(tmp_path: Path) -> None:
+    a = _make_store(tmp_path / "a.zarr", shape=(2, 2), chunks=(1, 2))
+    b = _make_store(tmp_path / "b.zarr", shape=(3, 2), chunks=(1, 2))
+
+    result = _invoke_compare(_required_args(a, b))
+
+    assert result.exit_code == 3
+    assert "shape" in result.stderr
+    assert "Traceback" not in result.output
+
+
+def test_compare_nan_positions_equal_exit_zero(tmp_path: Path) -> None:
+    values = np.array([[1.0, np.nan], [3.0, 4.0]], dtype=np.float32)
+    a = _make_store(tmp_path / "a.zarr", values=values)
+    b = _make_store(tmp_path / "b.zarr", values=values.copy())
+
+    result = _invoke_compare(_required_args(a, b))
+
+    assert result.exit_code == 0, result.output
+
+
+def test_compare_missing_store_uri_exit_nonzero(tmp_path: Path) -> None:
+    a = _make_store(tmp_path / "a.zarr")
+    missing = tmp_path / "missing.zarr"
+
+    result = _invoke_compare(_required_args(a, missing))
+
+    assert result.exit_code != 0
+    assert "Missing" in result.output or "missing" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_compare_help_lists_required_flags() -> None:
+    result = _invoke_compare(["--help"])
+
+    assert result.exit_code == 0
+    assert "--storage-type" in result.output
+    assert "--storage-driver" in result.output
+    assert "A_URI" in result.output
+    assert "B_URI" in result.output

--- a/tests/cli/test_zarr_slots_static_owner.py
+++ b/tests/cli/test_zarr_slots_static_owner.py
@@ -1,0 +1,183 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, ClassVar
+
+import numpy as np
+import pytest
+from click.testing import CliRunner
+
+from firecube.cli.main import cli
+from firecube.core.index_spec import IndexSpec, ItemInfo, RegularTimeAxis
+from firecube.ingestor.api import (
+    DirectZarrIngestor,
+    PipelineBatch,
+    PluginContext,
+    WriteIntent,
+    ZarrArraySpec,
+    ZarrGroupSpec,
+    register_ingestor,
+)
+from firecube.ingestor.registry import loader
+
+pytestmark = pytest.mark.unit
+
+
+class _StaticOwnerSlotsPlugin(DirectZarrIngestor):
+    PRODUCT_NAME: ClassVar[str] = "static_owner_slots_product"
+
+    def index_spec(self, ctx: PluginContext) -> IndexSpec:
+        return IndexSpec(
+            name="static_owner_slots_v1",
+            groups={
+                "data": RegularTimeAxis(
+                    coordinate="timestamp",
+                    epoch="2026-01-01T00:00:00Z",
+                    cadence_s=1,
+                    mode="exact",
+                    slot_count=250,
+                )
+            },
+        )
+
+    def inspect_item(self, item: Any, ctx: PluginContext) -> ItemInfo | None:
+        return ItemInfo(
+            coordinate=dt.datetime(2026, 1, 1, tzinfo=dt.UTC) + dt.timedelta(seconds=int(item))
+        )
+
+    def zarr_schema(self, ctx: PluginContext) -> list[ZarrGroupSpec]:
+        return [
+            ZarrGroupSpec(
+                group="data",
+                arrays=[
+                    ZarrArraySpec(
+                        name="data",
+                        chunks=(100, 4),
+                        shape=(250, 4),
+                        dtype=np.float32,
+                    )
+                ],
+            )
+        ]
+
+    def build_write_intents(self, batch: PipelineBatch, ctx: PluginContext) -> list[WriteIntent]:
+        return []
+
+
+class _SingleEntryStaticOwnerSlotsPlugin(_StaticOwnerSlotsPlugin):
+    PRODUCT_NAME: ClassVar[str] = "single_static_owner_slots_product"
+
+    def index_spec(self, ctx: PluginContext) -> IndexSpec:
+        return IndexSpec(
+            name="single_static_owner_slots_v1",
+            groups={
+                "data": RegularTimeAxis(
+                    coordinate="timestamp",
+                    epoch="2026-01-01T00:00:00Z",
+                    cadence_s=1,
+                    mode="exact",
+                    slot_count=80,
+                )
+            },
+        )
+
+    def zarr_schema(self, ctx: PluginContext) -> list[ZarrGroupSpec]:
+        return [
+            ZarrGroupSpec(
+                group="data",
+                arrays=[
+                    ZarrArraySpec(
+                        name="data",
+                        chunks=(100, 4),
+                        shape=(80, 4),
+                        dtype=np.float32,
+                    )
+                ],
+            )
+        ]
+
+
+@pytest.fixture(autouse=True)
+def _register_plugins() -> Iterator[None]:
+    saved_ingestors = loader.AVAILABLE_INGESTORS.copy()
+    saved_loaded = loader._LOADED
+    register_ingestor("static_owner_slots")(_StaticOwnerSlotsPlugin)
+    register_ingestor("single_static_owner_slots")(_SingleEntryStaticOwnerSlotsPlugin)
+    try:
+        yield
+    finally:
+        loader.AVAILABLE_INGESTORS.clear()
+        loader.AVAILABLE_INGESTORS.update(saved_ingestors)
+        loader._LOADED = saved_loaded
+
+
+def _args(tmp_path: Path, plugin: str) -> list[str]:
+    config = tmp_path / "config.toml"
+    config.write_text("", encoding="utf-8")
+    return [
+        "--config-file",
+        str(config),
+        "zarr",
+        "slots",
+        plugin,
+        "--target",
+        (tmp_path / f"{plugin}.zarr").as_uri(),
+        "--product-name",
+        plugin,
+        "--storage-type",
+        "local",
+        "--storage-driver",
+        "fsspec",
+        "--write-mode",
+        "direct",
+        "--no-resume",
+    ]
+
+
+def _slots_payload(tmp_path: Path, plugin: str) -> dict[str, Any]:
+    result = CliRunner().invoke(cli, _args(tmp_path, plugin))
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+def test_slots_json_includes_static_owner_field(tmp_path: Path) -> None:
+    payload = _slots_payload(tmp_path, "static_owner_slots")
+
+    group = next(entry for entry in payload["groups"] if entry["name"] == "data")
+
+    assert len([entry for entry in payload["ranges"] if entry["group"] == "data"]) >= 2
+    assert group["static_owner"] == {"slot_start": 0, "slot_end": 100}
+
+
+def test_static_owner_deterministic_across_reruns(tmp_path: Path) -> None:
+    first = _slots_payload(tmp_path, "static_owner_slots")
+    second = _slots_payload(tmp_path, "static_owner_slots")
+
+    first_group = next(entry for entry in first["groups"] if entry["name"] == "data")
+    second_group = next(entry for entry in second["groups"] if entry["name"] == "data")
+    assert first_group["static_owner"] == second_group["static_owner"]
+
+
+def test_single_entry_plan_is_its_own_owner(tmp_path: Path) -> None:
+    payload = _slots_payload(tmp_path, "single_static_owner_slots")
+
+    group = next(entry for entry in payload["groups"] if entry["name"] == "data")
+
+    assert group["static_owner"] == {"slot_start": 0, "slot_end": 80}

--- a/tests/cli/test_zarr_validate_static_marker.py
+++ b/tests/cli/test_zarr_validate_static_marker.py
@@ -1,0 +1,72 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import zarr
+from click.testing import CliRunner
+
+from firecube.cli.main import cli
+from firecube.core.api import FIRECUBE_STATIC_WRITTEN_ATTR
+
+pytestmark = pytest.mark.unit
+
+
+def _invoke_validate(store: Path, group: str):
+    return CliRunner().invoke(cli, ["zarr", "validate", "-p", store.as_uri(), "-g", group])
+
+
+def _store_with_array(tmp_path: Path, name: str, *, dimension_names: tuple[str, ...]) -> Path:
+    store = tmp_path / f"{name}.zarr"
+    root = zarr.open_group(str(store), mode="w")
+    root.create_array(name, shape=(4,), dtype="i4", chunks=(4,), dimension_names=dimension_names)
+    return store
+
+
+def test_validate_reports_missing_static_marker(tmp_path: Path) -> None:
+    store = _store_with_array(tmp_path, "lat", dimension_names=("lat",))
+
+    result = _invoke_validate(store, "lat")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["static_marker_failures"] == [
+        {"array": "lat", "reason": "missing_or_false_static_marker"}
+    ]
+
+
+def test_validate_passes_when_all_static_markers_present(tmp_path: Path) -> None:
+    store = _store_with_array(tmp_path, "lat", dimension_names=("lat",))
+    root = zarr.open_group(str(store), mode="a")
+    root["lat"].attrs[FIRECUBE_STATIC_WRITTEN_ATTR] = True
+
+    result = _invoke_validate(store, "lat")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["static_marker_failures"] == []
+
+
+def test_validate_ignores_time_indexed_arrays(tmp_path: Path) -> None:
+    store = _store_with_array(tmp_path, "temperature", dimension_names=("timestamp",))
+
+    result = _invoke_validate(store, "temperature")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["static_marker_failures"] == []

--- a/tests/integration/test_fillvalue_attribute.py
+++ b/tests/integration/test_fillvalue_attribute.py
@@ -1,0 +1,162 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import numpy as np
+import pytest
+import xarray as xr
+import zarr
+from zarr.storage import LocalStore
+
+from firecube.core.zarr.region_writer import RegionZarrWriter
+
+pytestmark = pytest.mark.integration
+
+_GROUP = "grid"
+_ARRAY = "counts"
+_DIMS = ("y", "x")
+_SHAPE = (2, 2)
+_DTYPE = np.uint16
+_FILL_VALUE = np.uint16(65535)
+
+
+def _open_counts(store_path: Path, *, mode: Literal["r", "a"] = "r") -> Any:
+    root = zarr.open_group(store=LocalStore(str(store_path)), mode=mode, zarr_format=3)
+    return cast(Any, cast(Any, root[_GROUP])[_ARRAY])
+
+
+def test_fill_value_round_trip_masks_unwritten_cells(tmp_path: Path) -> None:
+    store_path = tmp_path / "fillvalue.zarr"
+    writer = RegionZarrWriter(f"file://{store_path}")
+    writer.ensure_group(
+        f"{_GROUP}/{_ARRAY}",
+        shape=_SHAPE,
+        dtype=_DTYPE,
+        fill_value=_FILL_VALUE,
+        dimension_names=_DIMS,
+    )
+
+    counts = _open_counts(store_path, mode="a")
+    counts[0, :] = np.array([7, 11], dtype=_DTYPE)
+
+    ds = xr.open_dataset(
+        str(store_path),
+        engine="zarr",
+        group=_GROUP,
+        mask_and_scale=True,
+        consolidated=False,
+    )
+    try:
+        data = ds[_ARRAY]
+        assert data.encoding["_FillValue"] == int(_FILL_VALUE)
+        assert np.issubdtype(data.dtype, np.floating)
+        assert np.isnan(data.values[1, 0])
+        assert np.isnan(data.values[1, 1])
+        assert dict(_open_counts(store_path).attrs)["_FillValue"] == int(_FILL_VALUE)
+    finally:
+        ds.close()
+
+
+def test_resume_backfills_missing_fill_value_attr(tmp_path: Path) -> None:
+    store_path = tmp_path / "resume.zarr"
+    root = zarr.open_group(store=LocalStore(str(store_path)), mode="a", zarr_format=3)
+    root.require_group(_GROUP).create_array(
+        name=_ARRAY,
+        shape=_SHAPE,
+        dtype=_DTYPE,
+        fill_value=_FILL_VALUE,
+        dimension_names=_DIMS,
+    )
+
+    existing = _open_counts(store_path)
+    assert dict(existing.attrs).get("_FillValue") is None
+
+    writer = RegionZarrWriter(f"file://{store_path}")
+    created = writer.ensure_group(
+        f"{_GROUP}/{_ARRAY}",
+        shape=_SHAPE,
+        dtype=_DTYPE,
+        fill_value=_FILL_VALUE,
+        dimension_names=_DIMS,
+    )
+    assert dict(created.attrs)["_FillValue"] == int(_FILL_VALUE)
+
+    resumed = writer.ensure_group(
+        f"{_GROUP}/{_ARRAY}",
+        shape=_SHAPE,
+        dtype=_DTYPE,
+        fill_value=_FILL_VALUE,
+        dimension_names=_DIMS,
+    )
+    assert dict(resumed.attrs)["_FillValue"] == int(_FILL_VALUE)
+
+
+def test_datetime64_nat_fill_array_is_xarray_openable(tmp_path: Path) -> None:
+    store_path = tmp_path / "nat-fill.zarr"
+    writer = RegionZarrWriter(f"file://{store_path}")
+    arr = writer.ensure_group(
+        f"{_GROUP}/{_ARRAY}",
+        shape=_SHAPE,
+        dtype=np.dtype("datetime64[s]"),
+        fill_value=np.datetime64("NaT", "s"),
+        dimension_names=_DIMS,
+    )
+
+    assert "_FillValue" not in dict(arr.attrs)
+
+    ds = xr.open_dataset(
+        str(store_path),
+        engine="zarr",
+        group=_GROUP,
+        mask_and_scale=True,
+        consolidated=False,
+    )
+    try:
+        assert "_FillValue" not in dict(_open_counts(store_path).attrs)
+    finally:
+        ds.close()
+
+
+def test_nan_fill_array_gets_no_fill_value_attr(tmp_path: Path) -> None:
+    store_path = tmp_path / "nan-fill.zarr"
+    writer = RegionZarrWriter(f"file://{store_path}")
+    arr = writer.ensure_group(
+        f"{_GROUP}/{_ARRAY}",
+        shape=_SHAPE,
+        dtype=np.float32,
+        fill_value=np.nan,
+        dimension_names=_DIMS,
+    )
+
+    assert "_FillValue" not in dict(arr.attrs)
+    json.loads((store_path / _GROUP / _ARRAY / "zarr.json").read_text())
+
+
+def test_integer_fill_value_attr_still_stamped(tmp_path: Path) -> None:
+    store_path = tmp_path / "int-fill.zarr"
+    writer = RegionZarrWriter(f"file://{store_path}")
+    arr = writer.ensure_group(
+        f"{_GROUP}/{_ARRAY}",
+        shape=_SHAPE,
+        dtype=np.uint16,
+        fill_value=np.uint16(65535),
+        dimension_names=_DIMS,
+    )
+
+    assert dict(arr.attrs)["_FillValue"] == 65535

--- a/tests/integration/test_static_suppression.py
+++ b/tests/integration/test_static_suppression.py
@@ -1,0 +1,197 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+import zarr
+from click.testing import CliRunner
+from zarr.storage import LocalStore
+
+from firecube.cli.main import cli
+from firecube.core.api import FIRECUBE_STATIC_WRITTEN_ATTR
+from firecube.ingestor.api import EngineConfig
+from firecube.ingestor.errors import ConfigurationError
+from firecube.ingestor.runtime.zarr.strategies.indexed_region import IndexedRegionStrategy
+from firecube.ingestor.templates.direct_zarr import WriteIntent, ZarrArraySpec, ZarrGroupSpec
+
+pytestmark = pytest.mark.integration
+
+
+def _schema() -> list[ZarrGroupSpec]:
+    return [
+        ZarrGroupSpec(
+            group="g",
+            arrays=[
+                ZarrArraySpec(name="data", shape=(200, 4, 1), dtype="float32"),
+                ZarrArraySpec(name="lat", shape=(4,), dtype="float64", time_indexed=False),
+            ],
+        )
+    ]
+
+
+def _preallocate(path: Path) -> None:
+    root = zarr.open_group(store=LocalStore(str(path)), mode="a", zarr_format=3)
+    group = root.require_group("g")
+    group.create_array("data", shape=(200, 4, 1), dtype="float32", chunks=(1, 4, 1))
+    group.create_array("lat", shape=(4,), dtype="float64", chunks=(4,))
+
+
+def _strategy(path: Path) -> IndexedRegionStrategy:
+    return IndexedRegionStrategy(store_uri=path.as_uri(), schema=_schema())
+
+
+def _static_intent() -> WriteIntent:
+    return WriteIntent(
+        group="g",
+        array="lat",
+        ts_index=0,
+        data=np.array([1.0, 2.0, 3.0, 4.0]),
+        kind="static",
+    )
+
+
+def _dynamic_intent(slot: int) -> WriteIntent:
+    return WriteIntent(
+        group="g",
+        array="data",
+        ts_index=slot,
+        y_slice=slice(0, 4),
+        data=np.array([[9.0], [8.0], [7.0], [6.0]], dtype=np.float32),
+        kind="region",
+    )
+
+
+def _lat_array(path: Path) -> Any:
+    root = zarr.open_group(store=LocalStore(str(path)), mode="r", zarr_format=3)
+    return cast(Any, root["g/lat"])
+
+
+def test_non_owner_pod_skips_static_writes(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    store = tmp_path / "store.zarr"
+    _preallocate(store)
+
+    _strategy(store).write_groups(
+        group_to_intents={"g": [_static_intent()]},
+        slot_range=(100, 200),
+        suppress_static_emission_for_non_owner=True,
+        static_owner_slot_start=0,
+    )
+
+    lat = _lat_array(store)
+    np.testing.assert_array_equal(lat[:], np.zeros((4,), dtype=np.float64))
+    assert lat.attrs.get(FIRECUBE_STATIC_WRITTEN_ATTR) is None
+    assert (
+        "static write suppressed as non-owner: group=g array=lat slot_start=100 owner=0"
+        in caplog.text
+    )
+
+
+def test_owner_pod_writes_static_as_normal(tmp_path: Path) -> None:
+    store = tmp_path / "store.zarr"
+    _preallocate(store)
+
+    _strategy(store).write_groups(
+        group_to_intents={"g": [_static_intent()]},
+        slot_range=(0, 100),
+        suppress_static_emission_for_non_owner=True,
+        static_owner_slot_start=0,
+    )
+
+    lat = _lat_array(store)
+    np.testing.assert_array_equal(lat[:], np.array([1.0, 2.0, 3.0, 4.0]))
+    assert lat.attrs.get(FIRECUBE_STATIC_WRITTEN_ATTR) is True
+
+
+def test_suppression_flag_false_default_writes_static(tmp_path: Path) -> None:
+    store = tmp_path / "store.zarr"
+    _preallocate(store)
+
+    _strategy(store).write_groups(
+        group_to_intents={"g": [_static_intent()]},
+        slot_range=(100, 200),
+    )
+
+    np.testing.assert_array_equal(_lat_array(store)[:], np.array([1.0, 2.0, 3.0, 4.0]))
+
+
+def test_suppression_does_not_affect_dynamic_writes(tmp_path: Path) -> None:
+    store = tmp_path / "store.zarr"
+    _preallocate(store)
+
+    _strategy(store).write_groups(
+        group_to_intents={"g": [_static_intent(), _dynamic_intent(100)]},
+        slot_range=(100, 101),
+        suppress_static_emission_for_non_owner=True,
+        static_owner_slot_start=0,
+    )
+
+    root = zarr.open_group(store=LocalStore(str(store)), mode="r", zarr_format=3)
+    data = cast(Any, root["g/data"])
+    np.testing.assert_array_equal(data[100, :, :], np.array([[9.0], [8.0], [7.0], [6.0]]))
+    assert _lat_array(store).attrs.get(FIRECUBE_STATIC_WRITTEN_ATTR) is None
+
+
+def test_misconfig_suppression_true_without_owner_slot_raises() -> None:
+    with pytest.raises(ConfigurationError):
+        EngineConfig(suppress_static_emission_for_non_owner=True)
+
+
+def test_show_options_lists_both_new_fields() -> None:
+    result = CliRunner().invoke(
+        cli, ["ingest", "direct_zarr_capable_test_plugin", "--show-options"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "--option suppress_static_emission_for_non_owner" in result.output
+    assert "--option static_owner_slot_start" in result.output
+
+
+def test_misconfig_suppression_true_without_slot_start_raises() -> None:
+    """suppression=True + slot_start=None → ConfigurationError at construction time.
+
+    Regression for serial-run silent-drop bug: without slot_start, every static
+    write would be suppressed on the assumption that a co-worker owns them, but
+    there is no co-worker in serial mode.
+    """
+    with pytest.raises(ConfigurationError, match=r"slot_start"):
+        EngineConfig(
+            suppress_static_emission_for_non_owner=True,
+            static_owner_slot_start=0,
+            slot_start=None,
+        )
+
+
+def test_serial_run_never_suppresses_static_intents() -> None:
+    """Defense-in-depth: `_should_suppress_static_intent` returns False when
+    `slot_range is None` (serial mode), regardless of the suppression flag.
+    """
+    from types import SimpleNamespace
+
+    intent = SimpleNamespace(group="G", array="A")
+
+    result = IndexedRegionStrategy._should_suppress_static_intent(
+        intent,
+        slot_range=None,
+        suppress_static_emission_for_non_owner=True,
+        static_owner_slot_start=0,
+    )
+
+    assert result is False

--- a/tests/sdk/test_facade_exports.py
+++ b/tests/sdk/test_facade_exports.py
@@ -1,0 +1,37 @@
+from firecube.core.api import FIRECUBE_STATIC_WRITTEN_ATTR as core_static_written_attr
+from firecube.core.api import RESERVED_ARRAY_ATTRS as core_reserved_array_attrs
+from firecube.core.api import ExtentUnknownError as CoreExtentUnknownError
+from firecube.core.api import assert_attrs_safe as core_assert_attrs_safe
+from firecube.core.api import resolve_index_spec as core_resolve_index_spec
+from firecube.ingestor.api import FIRECUBE_STATIC_WRITTEN_ATTR as ingestor_static_written_attr
+from firecube.ingestor.api import RESERVED_ARRAY_ATTRS as ingestor_reserved_array_attrs
+from firecube.ingestor.api import ExtentUnknownError as IngestorExtentUnknownError
+from firecube.ingestor.api import assert_attrs_safe as ingestor_assert_attrs_safe
+from firecube.ingestor.api import resolve_index_spec as ingestor_resolve_index_spec
+
+
+def test_extent_unknown_error_exported_from_both_facades() -> None:
+    assert CoreExtentUnknownError is IngestorExtentUnknownError
+
+
+def test_reserved_attrs_exported_from_both_facades() -> None:
+    assert core_static_written_attr == "firecube_static_written"
+    assert ingestor_static_written_attr == "firecube_static_written"
+    assert core_static_written_attr is ingestor_static_written_attr
+    assert core_static_written_attr in core_reserved_array_attrs
+    assert ingestor_static_written_attr in ingestor_reserved_array_attrs
+    assert core_reserved_array_attrs is ingestor_reserved_array_attrs
+
+    for assert_attrs_safe in (core_assert_attrs_safe, ingestor_assert_attrs_safe):
+        assert_attrs_safe({"my_custom_attr": 42})
+
+        try:
+            assert_attrs_safe({"firecube_static_written": True})
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("reserved attrs must be rejected")
+
+
+def test_resolve_index_spec_reexported_from_ingestor_api() -> None:
+    assert core_resolve_index_spec is ingestor_resolve_index_spec

--- a/tests/unit/test_batch_registry.py
+++ b/tests/unit/test_batch_registry.py
@@ -1,0 +1,84 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from firecube.core.batch_registry import BatchResourceRegistry, _IdentityRef
+
+pytestmark = pytest.mark.unit
+
+
+def test_setup_registers_and_teardown_pops_all() -> None:
+    registry = BatchResourceRegistry()
+    first = MagicMock()
+    second = MagicMock()
+
+    assert registry.register("batch-1", first) is first
+    assert registry.register("batch-1", second) is second
+    registry.teardown("batch-1")
+
+    first.close.assert_called_once_with()
+    second.close.assert_called_once_with()
+    assert registry.teardown("batch-1") is None
+
+
+def test_teardown_after_failure_still_closes_all() -> None:
+    registry = BatchResourceRegistry()
+    first = MagicMock()
+    second = MagicMock()
+    third = MagicMock()
+    first_error = RuntimeError("first close failure")
+    second.close.side_effect = first_error
+
+    for resource in (first, second, third):
+        registry.register("batch-1", resource)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        registry.teardown("batch-1")
+
+    assert exc_info.value is first_error
+    first.close.assert_called_once_with()
+    second.close.assert_called_once_with()
+    third.close.assert_called_once_with()
+
+
+def test_idempotent_teardown() -> None:
+    registry = BatchResourceRegistry()
+    resource = MagicMock()
+
+    registry.register("batch-1", resource)
+    registry.teardown("batch-1")
+    registry.teardown("batch-1")
+
+    resource.close.assert_called_once_with()
+
+
+def test_identity_ref_distinguishes_reference_equality() -> None:
+    class EqualByValue:
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, EqualByValue)
+
+        def __hash__(self) -> int:
+            return 1
+
+    first = EqualByValue()
+    second = EqualByValue()
+
+    assert _IdentityRef(first) == _IdentityRef(first)
+    assert _IdentityRef(first) != _IdentityRef(second)
+    assert len({_IdentityRef(first), _IdentityRef(second)}) == 2

--- a/tests/unit/test_chunk_geometry.py
+++ b/tests/unit/test_chunk_geometry.py
@@ -1,0 +1,141 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from firecube.core.zarr.chunk_geometry import (
+    axis_selection_is_chunk_aligned,
+    chunk_axis_range,
+    physical_chunk_keys_for_region,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _intent(array: str = "values") -> SimpleNamespace:
+    return SimpleNamespace(group="data", array=array)
+
+
+def _selection(
+    *,
+    ts_index: int = 0,
+    y_start: int = 0,
+    y_stop: int = 2,
+    channel_index: int | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        ts_index=ts_index,
+        y_start=y_start,
+        y_stop=y_stop,
+        channel_index=channel_index,
+    )
+
+
+def test_chunk_axis_range_known_and_boundary_cases() -> None:
+    assert list(chunk_axis_range(0, 2, 2)) == [0]
+    assert list(chunk_axis_range(2, 4, 2)) == [1]
+    assert list(chunk_axis_range(1, 5, 2)) == [0, 1, 2]
+    assert list(chunk_axis_range(0, 4, 4)) == [0]
+    assert list(chunk_axis_range(2, 2, 2)) == []
+
+
+def test_axis_selection_is_chunk_aligned_boundaries() -> None:
+    assert axis_selection_is_chunk_aligned(0, 2, 4, 2) is True
+    assert axis_selection_is_chunk_aligned(2, 4, 4, 2) is True
+    assert axis_selection_is_chunk_aligned(0, 4, 4, 2) is True
+    assert axis_selection_is_chunk_aligned(1, 3, 4, 2) is False
+    assert axis_selection_is_chunk_aligned(2, 2, 4, 2) is True
+
+
+def test_physical_chunk_keys_match_indexed_region_disjoint_cases() -> None:
+    keys, aligned = physical_chunk_keys_for_region(
+        group="data",
+        intent=_intent(),
+        shape=(1, 6, 4),
+        chunks=(1, 2, 4),
+        selection=_selection(y_start=2, y_stop=4),
+    )
+
+    assert keys == {("data", "values", (0, 1, 0))}
+    assert aligned is True
+
+
+def test_physical_chunk_keys_match_indexed_region_overlap_case() -> None:
+    first, first_aligned = physical_chunk_keys_for_region(
+        group="data",
+        intent=_intent(),
+        shape=(1, 4, 4),
+        chunks=(1, 4, 4),
+        selection=_selection(y_start=0, y_stop=2),
+    )
+    second, second_aligned = physical_chunk_keys_for_region(
+        group="data",
+        intent=_intent(),
+        shape=(1, 4, 4),
+        chunks=(1, 4, 4),
+        selection=_selection(y_start=2, y_stop=4),
+    )
+
+    assert first == second == {("data", "values", (0, 0, 0))}
+    assert first_aligned is False
+    assert second_aligned is False
+
+
+def test_physical_chunk_keys_match_indexed_region_time_chunk_case() -> None:
+    first, first_aligned = physical_chunk_keys_for_region(
+        group="data",
+        intent=_intent(),
+        shape=(2, 4, 4),
+        chunks=(2, 4, 4),
+        selection=_selection(ts_index=0, y_start=0, y_stop=4),
+    )
+    second, second_aligned = physical_chunk_keys_for_region(
+        group="data",
+        intent=_intent(),
+        shape=(2, 4, 4),
+        chunks=(2, 4, 4),
+        selection=_selection(ts_index=1, y_start=0, y_stop=4),
+    )
+
+    assert first == second == {("data", "values", (0, 0, 0))}
+    assert first_aligned is False
+    assert second_aligned is False
+
+
+def test_physical_chunk_keys_rank4_channel_selection() -> None:
+    keys, aligned = physical_chunk_keys_for_region(
+        group="data",
+        intent=_intent(),
+        shape=(1, 4, 4, 3),
+        chunks=(1, 2, 4, 1),
+        selection=_selection(y_start=2, y_stop=4, channel_index=1),
+    )
+
+    assert keys == {("data", "values", (0, 1, 0, 1))}
+    assert aligned is True
+
+
+def test_physical_chunk_keys_out_of_bounds_ts_raises() -> None:
+    with pytest.raises(ValueError, match="ts_index is outside"):
+        physical_chunk_keys_for_region(
+            group="data",
+            intent=_intent(),
+            shape=(1, 4, 4),
+            chunks=(1, 2, 4),
+            selection=_selection(ts_index=1),
+        )

--- a/tests/unit/test_compare_zarr_stores.py
+++ b/tests/unit/test_compare_zarr_stores.py
@@ -1,0 +1,148 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import zarr
+
+from firecube.core.api import FIRECUBE_STATIC_WRITTEN_ATTR, compare_zarr_stores
+
+pytestmark = pytest.mark.unit
+
+
+def _make_store(
+    path: Path,
+    *,
+    shape: tuple[int, ...] = (2, 2),
+    dtype: str = "float32",
+    chunks: tuple[int, ...] = (1, 2),
+    dimension_names: tuple[str, ...] = ("y", "x"),
+    attrs: dict[str, Any] | None = None,
+    values: Any | None = None,
+    static_written: bool | None = None,
+) -> Path:
+    root = zarr.open_group(store=str(path), mode="w", zarr_format=3)
+    group = root.require_group("data")
+    arr = group.create_array(
+        "values",
+        shape=shape,
+        dtype=dtype,
+        chunks=chunks,
+        dimension_names=dimension_names,
+    )
+    if attrs:
+        arr.attrs.update(attrs)
+    data = (
+        np.arange(np.prod(shape), dtype=np.dtype(dtype)).reshape(shape)
+        if values is None
+        else values
+    )
+    arr[...] = data
+    if static_written is not None:
+        arr.attrs[FIRECUBE_STATIC_WRITTEN_ATTR] = static_written
+    return path
+
+
+def _compare(a: Path, b: Path):
+    return compare_zarr_stores(
+        a.as_uri(),
+        b.as_uri(),
+        storage_type="local",
+        storage_driver="fsspec",
+    )
+
+
+def test_identical_stores_are_equivalent(tmp_path: Path) -> None:
+    a = _make_store(tmp_path / "a.zarr", attrs={"units": "K"})
+    b = _make_store(tmp_path / "b.zarr", attrs={"units": "K"})
+
+    report = _compare(a, b)
+
+    assert report.equivalent is True
+    assert report.mismatches == []
+
+
+def test_shape_mismatch_detected(tmp_path: Path) -> None:
+    a = _make_store(tmp_path / "a.zarr", shape=(2, 2), chunks=(1, 2))
+    b = _make_store(tmp_path / "b.zarr", shape=(3, 2), chunks=(1, 2))
+
+    report = _compare(a, b)
+
+    assert report.equivalent is False
+    assert any("shape" in mismatch for mismatch in report.mismatches)
+
+
+def test_dtype_mismatch_detected(tmp_path: Path) -> None:
+    a = _make_store(tmp_path / "a.zarr", dtype="float32")
+    b = _make_store(tmp_path / "b.zarr", dtype="int16")
+
+    report = _compare(a, b)
+
+    assert report.equivalent is False
+    assert any("dtype" in mismatch for mismatch in report.mismatches)
+
+
+def test_chunks_mismatch_detected(tmp_path: Path) -> None:
+    a = _make_store(tmp_path / "a.zarr", chunks=(1, 2))
+    b = _make_store(tmp_path / "b.zarr", chunks=(2, 1))
+
+    report = _compare(a, b)
+    assert report.equivalent is False
+    assert any("chunks" in mismatch for mismatch in report.mismatches)
+
+
+def test_attrs_mismatch_detected(tmp_path: Path) -> None:
+    a = _make_store(tmp_path / "a.zarr", attrs={"units": "K"})
+    b = _make_store(tmp_path / "b.zarr", attrs={"units": "C"})
+
+    report = _compare(a, b)
+    assert report.equivalent is False
+    assert any("attrs" in mismatch for mismatch in report.mismatches)
+
+
+def test_nan_values_at_same_positions_equal(tmp_path: Path) -> None:
+    values = np.array([[1.0, np.nan], [3.0, 4.0]], dtype=np.float32)
+    a = _make_store(tmp_path / "a.zarr", values=values)
+    b = _make_store(tmp_path / "b.zarr", values=values.copy())
+
+    report = _compare(a, b)
+    assert report.equivalent is True
+    assert report.mismatches == []
+
+
+def test_static_marker_mismatch_detected(tmp_path: Path) -> None:
+    a = _make_store(tmp_path / "a.zarr", static_written=True)
+    b = _make_store(tmp_path / "b.zarr")
+
+    report = _compare(a, b)
+    assert report.equivalent is False
+    assert any("firecube_static_written" in mismatch for mismatch in report.mismatches)
+
+
+def test_ignores_runtime_managed_attrs(tmp_path: Path) -> None:
+    a = _make_store(
+        tmp_path / "a.zarr", attrs={"firecube_run_id": "run-a", "firecube_span_id": "span-a"}
+    )
+    b = _make_store(
+        tmp_path / "b.zarr", attrs={"firecube_run_id": "run-b", "firecube_span_id": "span-b"}
+    )
+
+    report = _compare(a, b)
+    assert report.equivalent is True
+    assert report.mismatches == []

--- a/tests/unit/test_global_expected_coverage.py
+++ b/tests/unit/test_global_expected_coverage.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 
 from firecube.core.index_spec import IndexSpec, ItemInfo, RegularTimeAxis
-from firecube.ingestor.api import DirectZarrIngestor
+from firecube.ingestor.api import ConfigurationError, DirectZarrIngestor
 from firecube.ingestor.runtime.parallel_execution_state import _ParallelExecutionState
 from firecube.ingestor.templates.direct_zarr import WriteIntent, ZarrArraySpec, ZarrGroupSpec
 
@@ -199,16 +199,14 @@ def test_intent_group_missing_from_schema_fails(
         intents=[_intent("G_unknown")],
     )
 
-    result, _ = _run_process_batch(
-        tmp_path=tmp_path,
-        monkeypatch=monkeypatch,
-        ingestor=ingestor,
-        global_schema={"A": 1000, "B": 1000, "G_unknown": 1000},
-        setup_stub=lambda **kwargs: None,
-    )
-
-    assert result.success is False
-    assert "G_unknown" in cast(str, result.error)
+    with pytest.raises(ConfigurationError, match="G_unknown"):
+        _run_process_batch(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            ingestor=ingestor,
+            global_schema={"A": 1000, "B": 1000, "G_unknown": 1000},
+            setup_stub=lambda **kwargs: None,
+        )
 
 
 def test_extra_groups_in_global_allowed(

--- a/tests/unit/test_read_hdf5_array_dtype.py
+++ b/tests/unit/test_read_hdf5_array_dtype.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+import pytest
+
+from firecube.core.formats.hdf5 import read_hdf5_array
+
+pytestmark = pytest.mark.unit
+
+
+def _write_dataset(path: Path, values: np.ndarray, *, variable: str = "data") -> None:
+    with h5py.File(path, "w") as handle:
+        handle.create_dataset(variable, data=values)
+
+
+def test_reads_int_dataset_preserves_int_dtype(tmp_path: Path) -> None:
+    path = tmp_path / "int32.h5"
+    _write_dataset(path, np.array([1, 2, 3], dtype=np.int32))
+
+    result = read_hdf5_array(path, variable="data")
+
+    assert result.dtype == np.dtype("int32")
+    np.testing.assert_array_equal(result, np.array([1, 2, 3], dtype=np.int32))
+
+
+def test_reads_float_dataset_preserves_float_dtype(tmp_path: Path) -> None:
+    path = tmp_path / "float64.h5"
+    _write_dataset(path, np.array([1.25, 2.5], dtype=np.float64))
+
+    result = read_hdf5_array(path, variable="data")
+
+    assert result.dtype == np.dtype("float64")
+
+
+def test_explicit_dtype_kwarg_casts(tmp_path: Path) -> None:
+    path = tmp_path / "cast.h5"
+    _write_dataset(path, np.array([1, 2, 3], dtype=np.int32))
+
+    result = read_hdf5_array(path, variable="data", dtype="float32")
+
+    assert result.dtype == np.dtype("float32")
+    np.testing.assert_array_equal(result, np.array([1, 2, 3], dtype=np.float32))
+
+
+def test_xarray_fallback_preserves_dtype(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "fallback.h5"
+    _write_dataset(path, np.array([4, 5, 6], dtype=np.int32))
+    original_file = h5py.File
+    calls = 0
+
+    def fail_first_h5py_open(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("forced h5py failure")
+        return original_file(*args, **kwargs)
+
+    monkeypatch.setattr(h5py, "File", fail_first_h5py_open)
+
+    result = read_hdf5_array(path, variable="data")
+
+    assert result.dtype == np.dtype("int32")
+    np.testing.assert_array_equal(result, np.array([4, 5, 6], dtype=np.int32))
+
+
+def test_reads_uint8_dataset_preserves_uint8(tmp_path: Path) -> None:
+    path = tmp_path / "uint8.h5"
+    _write_dataset(path, np.array([0, 255], dtype=np.uint8))
+
+    result = read_hdf5_array(path, variable="data")
+
+    assert result.dtype == np.dtype("uint8")
+
+
+def test_reads_bool_dataset_preserves_bool(tmp_path: Path) -> None:
+    path = tmp_path / "bool.h5"
+    _write_dataset(path, np.array([True, False], dtype=np.bool_))
+
+    result = read_hdf5_array(path, variable="data")
+
+    assert result.dtype == np.dtype("bool")
+
+
+def test_missing_variable_raises_keyerror(tmp_path: Path) -> None:
+    path = tmp_path / "missing.h5"
+    _write_dataset(path, np.array([1], dtype=np.int32), variable="other")
+
+    with pytest.raises(KeyError, match="data"):
+        read_hdf5_array(path, variable="data")

--- a/tests/unit/test_serial_unbounded_axis.py
+++ b/tests/unit/test_serial_unbounded_axis.py
@@ -1,0 +1,109 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from firecube.core.index_spec import IndexSpec, RegularTimeAxis
+from firecube.ingestor.api import (
+    ConfigurationError,
+    EngineConfig,
+    PipelineBatch,
+    PluginContext,
+    RuntimeIngestContext,
+)
+from firecube.ingestor.templates.direct_zarr import DirectZarrIngestor, WriteIntent
+from tests.helpers.storage import make_test_context
+
+pytestmark = pytest.mark.unit
+
+UNBOUNDED_AXIS_MESSAGE = (
+    "group 'data': axis has no fixed extent — set RegularTimeAxis(end_date=...) or "
+    "slot_count=... to enable parallel ingestion"
+)
+
+
+class _SerialUnboundedAxisIngestor(DirectZarrIngestor):
+    PRODUCT_NAME = "serial_unbounded_axis"
+
+    def index_spec(self, ctx: PluginContext) -> IndexSpec:
+        return IndexSpec(
+            name="serial_unbounded_axis_v1",
+            groups={
+                "data": RegularTimeAxis(
+                    coordinate="timestamp",
+                    epoch="2026-01-01T00:00:00Z",
+                    cadence_s=600,
+                )
+            },
+        )
+
+    def zarr_schema(self, ctx: PluginContext) -> list[Any]:
+        return []
+
+    def build_write_intents(self, batch: PipelineBatch, ctx: PluginContext) -> list[WriteIntent]:
+        return [WriteIntent(group="data", array="data", ts_index=0, data=object())]
+
+
+def _make_ctx(tmp_path: Path):
+    return make_test_context(
+        tmp_path,
+        source=str(tmp_path / "source"),
+        product="serial_unbounded_axis.zarr",
+        options={"write_mode": "direct"},
+    )
+
+
+def test_base_run_serial_unbounded_axis_raises_configuration_error(
+    tmp_path: Path,
+) -> None:
+    ingestor = _SerialUnboundedAxisIngestor(name="serial_unbounded_axis")
+    ingestor._configurator = SimpleNamespace(  # type: ignore[assignment]
+        configure=lambda runtime_ctx: (EngineConfig(write_mode="direct"), None, None)
+    )
+    ctx = _make_ctx(tmp_path)
+
+    with pytest.raises(ConfigurationError, match=re.escape(UNBOUNDED_AXIS_MESSAGE)):
+        ingestor.ingest(ctx)
+
+
+def test_direct_zarr_process_batch_defense_in_depth_raises_configuration_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ingestor = _SerialUnboundedAxisIngestor(name="serial_unbounded_axis")
+    ingestor.engine_config = EngineConfig(write_mode="direct", slot_start=0, slot_end=1)
+    ingestor.template_config = None
+    batch = PipelineBatch(batch_id="batch-1", data_path=tmp_path, items=["item"], metadata={})
+    runtime_ctx = make_test_context(
+        tmp_path,
+        source=str(tmp_path / "source"),
+        product="serial_unbounded_axis.zarr",
+        options={"write_mode": "direct"},
+    )
+    ctx = PluginContext(cast(RuntimeIngestContext, runtime_ctx))
+
+    monkeypatch.setattr(ingestor, "batch_setup", lambda ctx: None)
+    monkeypatch.setattr(ingestor, "prepare_batch_data", lambda batch, ctx: {})
+    monkeypatch.setattr(ingestor, "resolve_output_uri", lambda ctx, write_mode: "out.zarr")
+    monkeypatch.setattr(ingestor, "cleanup_batch_data", lambda batch, ctx: None)
+    monkeypatch.setattr(ingestor, "batch_teardown", lambda ctx: None)
+
+    with pytest.raises(ConfigurationError, match=re.escape(UNBOUNDED_AXIS_MESSAGE)):
+        ingestor._process_batch(batch, ctx)

--- a/tests/unit/test_zarr_write_context.py
+++ b/tests/unit/test_zarr_write_context.py
@@ -129,7 +129,8 @@ class TestZarrWriteContextZarrConfig:
             )
             with ctx:
                 pass
-            mock_zarr_set.assert_called_with({"async.concurrency": 1})
+            mock_zarr_set.assert_any_call({"async.concurrency": 1})
+            mock_zarr_set.assert_any_call({"array.write_empty_chunks": False})
 
     def test_write_threads_forces_async_concurrency_1(self):
         with patch("zarr.config.set") as mock_zarr_set:
@@ -139,7 +140,8 @@ class TestZarrWriteContextZarrConfig:
             )
             with ctx:
                 pass
-            mock_zarr_set.assert_called_with({"async.concurrency": 1})
+            mock_zarr_set.assert_any_call({"async.concurrency": 1})
+            mock_zarr_set.assert_any_call({"array.write_empty_chunks": False})
 
     def test_default_uses_configured_async_concurrency(self):
         with patch("zarr.config.set") as mock_zarr_set:
@@ -149,4 +151,5 @@ class TestZarrWriteContextZarrConfig:
             )
             with ctx:
                 pass
-            mock_zarr_set.assert_called_with({"async.concurrency": 32})
+            mock_zarr_set.assert_any_call({"async.concurrency": 32})
+            mock_zarr_set.assert_any_call({"array.write_empty_chunks": False})

--- a/tests/unit/test_zarr_write_empty_chunks.py
+++ b/tests/unit/test_zarr_write_empty_chunks.py
@@ -1,0 +1,155 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import ast
+import contextlib
+from pathlib import Path
+
+import pytest
+import zarr
+from click.testing import CliRunner
+
+from firecube.cli.main import cli
+from firecube.ingestor.runtime.zarr.strategies.indexed_region import IndexedRegionStrategy
+from firecube.ingestor.runtime.zarr.write_context import ZarrWriteContext
+from firecube.ingestor.templates.config import ZarrTemplateConfig
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_is_false() -> None:
+    assert ZarrTemplateConfig().zarr_write_empty_chunks is False
+
+
+def test_option_flows_through_typed_config() -> None:
+    assert (
+        ZarrTemplateConfig.from_options({"zarr_write_empty_chunks": "true"}).zarr_write_empty_chunks
+        is True
+    )
+
+
+def test_show_options_lists_the_field() -> None:
+    result = CliRunner().invoke(
+        cli, ["ingest", "direct_zarr_capable_test_plugin", "--show-options"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "--option zarr_write_empty_chunks" in result.output
+
+
+def test_direct_zarr_dispatch_applies_scoped_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, bool]] = []
+    entered = False
+    exited = False
+
+    @contextlib.contextmanager
+    def spy_config_set(config: dict[str, bool]):
+        nonlocal entered, exited
+        calls.append(config)
+        entered = True
+        try:
+            yield
+        finally:
+            exited = True
+
+    monkeypatch.setattr(zarr.config, "set", spy_config_set)
+
+    result = IndexedRegionStrategy(store_uri=str(tmp_path / "test.zarr")).write_groups(
+        group_to_intents={},
+        zarr_write_empty_chunks=True,
+    )
+
+    assert result["zarr_write_empty_chunks_effective"] is True
+    assert {"array.write_empty_chunks": True} in calls
+    assert entered is True
+    assert exited is True
+
+
+def test_generic_write_context_applies_scoped_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, bool]] = []
+    entered = False
+    exited = False
+
+    @contextlib.contextmanager
+    def spy_config_set(config: dict[str, bool]):
+        nonlocal entered, exited
+        if "array.write_empty_chunks" in config:
+            calls.append(config)
+            entered = True
+        try:
+            yield
+        finally:
+            if "array.write_empty_chunks" in config:
+                exited = True
+
+    monkeypatch.setattr(zarr.config, "set", spy_config_set)
+
+    with ZarrWriteContext(write_lock=contextlib.nullcontext(), write_empty_chunks=True):  # type: ignore[arg-type]
+        assert entered is True
+
+    assert {"array.write_empty_chunks": True} in calls
+    assert exited is True
+
+
+def test_effective_value_recorded_in_metrics(tmp_path: Path) -> None:
+    result = IndexedRegionStrategy(store_uri=str(tmp_path / "test.zarr")).write_groups(
+        group_to_intents={},
+        zarr_write_empty_chunks=True,
+    )
+
+    assert result["zarr_write_empty_chunks_effective"] is True
+
+
+def test_array_write_empty_chunks_never_mutated_bare() -> None:
+    root = Path("src/firecube")
+    offenders: list[str] = []
+    for path in root.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        parents: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+        for node in ast.walk(tree):
+            if not _is_array_write_empty_chunks_set_call(node):
+                continue
+            if not _has_with_ancestor(node, parents):
+                offenders.append(f"{path}:{getattr(node, 'lineno', '?')}")
+    assert offenders == []
+
+
+def _is_array_write_empty_chunks_set_call(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    if not isinstance(node.func, ast.Attribute) or node.func.attr != "set":
+        return False
+    for arg in node.args:
+        if isinstance(arg, ast.Dict):
+            for key in arg.keys:
+                if isinstance(key, ast.Constant) and key.value == "array.write_empty_chunks":
+                    return True
+    return False
+
+
+def _has_with_ancestor(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> bool:
+    current: ast.AST | None = node
+    while current is not None:
+        if isinstance(current, ast.With):
+            return True
+        current = parents.get(current)
+    return False

--- a/tests/unit/test_zip_extract_safety.py
+++ b/tests/unit/test_zip_extract_safety.py
@@ -1,0 +1,137 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import zipfile
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from firecube.core.formats.zip import (
+    extract_all_from_zip,
+    extract_hdf5_from_zip,
+    stream_hdf5_from_zip,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_zip(path: Path, members: Mapping[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+
+
+def test_rejects_dotdot_member(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.zip"
+    _write_zip(archive, {"../evil.h5": b"evil"})
+
+    with pytest.raises(ValueError, match="Unsafe ZIP member"):
+        extract_hdf5_from_zip(archive, tmp_path / "out")
+
+
+def test_rejects_absolute_path_member(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.zip"
+    _write_zip(archive, {"/tmp/evil.h5": b"evil"})
+
+    with pytest.raises(ValueError, match="Unsafe ZIP member"):
+        extract_hdf5_from_zip(archive, tmp_path / "out")
+
+
+@pytest.mark.parametrize("member", [r"..\evil.h5", r"\\evil\path.h5", "C:/evil.h5"])
+def test_rejects_windows_traversal(tmp_path: Path, member: str) -> None:
+    archive = tmp_path / "unsafe.zip"
+    _write_zip(archive, {member: b"evil"})
+
+    with pytest.raises(ValueError, match="Unsafe ZIP member"):
+        extract_hdf5_from_zip(archive, tmp_path / "out")
+
+
+def test_rejects_nested_traversal(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.zip"
+    _write_zip(archive, {"safe/../evil.h5": b"evil"})
+
+    with pytest.raises(ValueError, match="Unsafe ZIP member"):
+        extract_hdf5_from_zip(archive, tmp_path / "out")
+
+
+def test_rejects_zero_hdf5_candidates(tmp_path: Path) -> None:
+    archive = tmp_path / "empty.zip"
+    _write_zip(archive, {"readme.txt": b"not hdf5"})
+
+    with pytest.raises(ValueError, match="No HDF5 member"):
+        extract_hdf5_from_zip(archive, tmp_path / "out")
+
+
+def test_rejects_multiple_hdf5_candidates_without_member(tmp_path: Path) -> None:
+    archive = tmp_path / "multi.zip"
+    _write_zip(archive, {"a.h5": b"a", "b.h5": b"b"})
+
+    with pytest.raises(ValueError, match=r"a\.h5.*b\.h5"):
+        extract_hdf5_from_zip(archive, tmp_path / "out")
+
+
+def test_accepts_multiple_with_explicit_member(tmp_path: Path) -> None:
+    archive = tmp_path / "multi.zip"
+    _write_zip(archive, {"a.h5": b"a", "b.h5": b"b"})
+
+    extracted = extract_hdf5_from_zip(archive, tmp_path / "out", member="a.h5")
+
+    assert extracted is not None
+    assert extracted == tmp_path / "out" / "a.h5"
+    assert extracted.read_bytes() == b"a"
+
+
+def test_accepts_safe_nested_path(tmp_path: Path) -> None:
+    archive = tmp_path / "nested.zip"
+    _write_zip(archive, {"data/product.h5": b"safe"})
+
+    extracted = extract_hdf5_from_zip(archive, tmp_path / "out")
+
+    streamed = stream_hdf5_from_zip(archive)
+
+    assert extracted is not None
+    assert extracted == tmp_path / "out" / "data" / "product.h5"
+    assert extracted.read_bytes() == b"safe"
+    assert streamed == b"safe"
+
+
+def test_stream_path_and_extract_path_share_validation(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.zip"
+    _write_zip(archive, {"safe/../evil.h5": b"evil"})
+
+    with pytest.raises(ValueError, match="Unsafe ZIP member"):
+        extract_hdf5_from_zip(archive, tmp_path / "out")
+    with pytest.raises(ValueError, match="Unsafe ZIP member"):
+        stream_hdf5_from_zip(archive)
+
+
+def test_extract_all_from_zip_extracts_every_member(tmp_path: Path) -> None:
+    archive = tmp_path / "nested.zip"
+    _write_zip(archive, {"payload/a.txt": b"A", "payload/b.txt": b"B"})
+
+    extract_all_from_zip(archive, tmp_path / "out")
+
+    assert (tmp_path / "out" / "payload" / "a.txt").read_bytes() == b"A"
+    assert (tmp_path / "out" / "payload" / "b.txt").read_bytes() == b"B"
+
+
+def test_extract_all_from_zip_rejects_unsafe_member(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.zip"
+    _write_zip(archive, {"../escape.txt": b"evil"})
+
+    with pytest.raises(ValueError, match="Unsafe ZIP member"):
+        extract_all_from_zip(archive, tmp_path / "out")


### PR DESCRIPTION
## What changed

Promotes plugin-proven Zarr operations into core: `static_owner` in the slots plan plus engine-level static-write suppression, a `firecube zarr compare` store-equivalence CLI, a typed `zarr_write_empty_chunks` option, new public API exports (`UnboundedAxisError`, reserved-attrs helpers, `resolve_index_spec`, chunk geometry, `BatchResourceRegistry`, `extract_all_from_zip`), and HDF5/ZIP hardening (dtype preservation, zip-slip guard, `_FillValue` stamping).

## Why

Ends per-plugin reimplementation of static-owner selection, store verification, and safe extraction; hardens the formats layer.  Closes #49.

## Affected behavior


- User / CLI: new `zarr compare` command; new `--suppress-static-emission-for-non-owner` / `--static-owner-slot-start` ingest flags; `zarr slots` JSON gains `static_owner`; `zarr validate` reports `static_marker_failures`.
- Plugin authors: new public exports; `read_hdf5_array` now preserves source dtype (pass `dtype="float32"` for the old cast); multi-HDF5 archives need explicit `member=`.
- Operators / production: unbounded-axis misconfig fails as `UnboundedAxisError` 
- Stored formats or control-plane state: arrays with a JSON-safe declared fill value gain a `_FillValue` attr (backfilled once on resume)

## Type of change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (CLI flags, plugin contract, config, or stored format)
- [x] Documentation
- [ ] CI / build / chore

## Checks run

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [ ] `uv run --with bandit bandit -c pyproject.toml -r src scripts -lll`
- [ ] `uv run pytest --strict-deps -m "not slow and not s3" -q`
- [x] Docs build (if docs changed): `uv run mkdocs build --strict`

## Follow-up work

TODO §36 (scoped `async.concurrency`), §37 (chunk-wise `zarr compare` values), §38 (configurable time-dim names for the static-marker check); `cli/zarr.py` split into per-command modules.

## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
