### PR TITLE
feat(core)!: extract_all_from_zips batch API + extract_workers engine option; pipeline_workers becomes the sole execution-mode switch (removes pipeline_parallel)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ Core design rules for this batch ingestor, including control-plane model and obs
 ## Gotchas / debugging
 
 - If JSON logs are required, disable progress logging (`--option no_progress=true`) to keep stdout machine-readable.
-- If ingestion "hangs" at 0% with parallel execution, try `--option pipeline_parallel=false` or reduce `pipeline_workers` to isolate locking/IO contention (DuckDB, HDF5).
+- If ingestion "hangs" at 0% with parallel execution, set `--option pipeline_workers=1` to isolate locking/IO contention (DuckDB, HDF5).
 
 ## Style guide
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 
 ### Added
 
+- `extract_all_from_zips` extracts a batch of ZIP archives, serially by
+  default or concurrently via `workers=`, returning an `(extracted, failures)`
+  pair in which every input archive appears exactly once; a failed archive is
+  reported instead of aborting the batch and its partial output is removed.
+- New engine option `extract_workers` (default 4): number of parallel
+  archive-extraction workers for plugins that extract source-archive batches.
+  Independent of `pipeline_workers`; set with `--option extract_workers=N`.
 - `IndexedWrite` and `IndexedWriteCompilationError` are now documented in the
   public API reference. `IndexedWrite` appears in `docs/reference/templates.md`
   under Schema And Write Types (both `firecube.ingestor.api` and
@@ -128,7 +135,7 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 - New public exports on `firecube.core.api` (and `firecube.ingestor.api`
   where applicable): `ExtentUnknownError`, `UnboundedAxisError`,
   `RESERVED_ARRAY_ATTRS`, `assert_attrs_safe`, `FIRECUBE_STATIC_WRITTEN_ATTR`,
-  `resolve_index_spec`, `extract_all_from_zip`, `BatchResourceRegistry`,
+  `resolve_index_spec`, `extract_all_from_zips`, `BatchResourceRegistry`,
   `physical_chunk_keys_for_region`, `chunk_axis_range`, and
   `axis_selection_is_chunk_aligned`.
 - `extract_hdf5_from_zip` and `stream_hdf5_from_zip` accept an explicit
@@ -137,6 +144,8 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 
 ### Changed
 
+- `EngineConfig` rejects `pipeline_workers < 1` and `pipeline_batch_size < 1`
+  at construction instead of accepting them silently.
 - `ResolvedIndexConflictError` message now includes a field-level diff (groups symmetric difference, per-group axis changes, top-level name/scalar changes) alongside the two truncated hashes -- no more hash-only conflict messages.
 - `verify_array_spec` now rejects an on-disk sharded array when the declared
   spec has `shards=None`, even at `zarr_region_write_concurrency=1`. Previously
@@ -186,12 +195,19 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 ### Security
 
 - ZIP extraction helpers (`extract_hdf5_from_zip`, `stream_hdf5_from_zip`,
-  `extract_all_from_zip`) reject member names that could escape the
+  `extract_all_from_zips`) reject member names that could escape the
   extraction root (`..` segments, absolute paths, Windows drive prefixes)
   with `ValueError` instead of extracting them.
 
 ### Removed
 
+- Engine option `pipeline_parallel`. Execution mode is now decided solely by
+  `pipeline_workers`: 2 or more runs the parallel pipeline, 1 runs
+  sequentially. Migration: replace `pipeline_parallel=true` with
+  `pipeline_workers=2` (or more) and delete `pipeline_parallel=false`;
+  leftover keys in `--option` flags or config files now fail loudly at
+  option validation. Previously `pipeline_parallel=false` was silently
+  ignored whenever `pipeline_workers` was above 1.
 - Removed unused `ItemInfo.key` and `ItemInfo.group` fields. These were placeholders.
 - `docs/reference/api.md` and `docs/reference/advanced-plugin-api.md`, replaced
   by the per-topic pages; deep links to their headings no longer resolve.

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -105,7 +105,6 @@ driver = "fsspec"
 pushgateway_url = "http://localhost:9091"
 
 [plugins.my_plugin]
-pipeline_parallel = true
 pipeline_workers = 4
 pipeline_batch_size = 40
 custom_option = "value"
@@ -129,7 +128,7 @@ silently ignored.
 
 | Tier | Examples | Applies to |
 |---|---|---|
-| Engine options | `pipeline_parallel`, `pipeline_workers`, `pipeline_batch_size`, `include_patterns`, `resume_existing` | Runtime behavior shared by plugins. |
+| Engine options | `pipeline_workers`, `pipeline_batch_size`, `extract_workers`, `include_patterns`, `resume_existing` | Runtime behavior shared by plugins. |
 | Output options | `zarr_chunk_shape`, `zarr_compression`, `zarr_consolidate` | Zarr template behavior. |
 | Plugin options | `region`, thresholds, filters, product-specific switches | Options declared by the installed plugin. |
 

--- a/docs/concepts/observability/traces.md
+++ b/docs/concepts/observability/traces.md
@@ -41,7 +41,7 @@ Template spans add detail where the engine owns the work. For example,
 `GenericZarrIngestor` emits preparation and Zarr write spans around each batch.
 Plugins can add product-specific spans for work the engine cannot describe.
 
-When `pipeline_parallel=true`, Firecube preserves trace parentage across worker
+When `pipeline_workers` is 2 or more, Firecube preserves trace parentage across worker
 threads. Batch spans still appear under the run trace instead of becoming
 disconnected root spans.
 

--- a/docs/concepts/parallelism.md
+++ b/docs/concepts/parallelism.md
@@ -26,15 +26,30 @@ worker owns a disjoint, chunk-aligned slot range.
 Staged upload parallelism is separate. `upload_workers` controls the upload
 phase after staged pipeline writes have completed.
 
+## Which Worker Option Is Which
+
+Every worker option is an engine option, follows the same `<stage>_workers`
+naming, and controls exactly one pipeline stage:
+
+| Option | Stage it parallelizes | Default |
+|---|---|---|
+| `pipeline_workers` | Whole batches preprocessing concurrently inside one process. 2 or more runs the parallel pipeline; 1 runs sequentially. | 1 |
+| `extract_workers` | Source archives (for example ZIPs) unpacking concurrently inside one batch, before decoding. Independent of `pipeline_workers`; when both are above 1 they multiply. | 4 |
+| `upload_workers` | Staged output files uploading concurrently after the pipeline completes. | 4 |
+
+All three are passed the same way: `--option <name>=N`.
+
 ## Supported Models
 
 **Pipeline workers** run inside one `firecube ingest` process. Use them for
 source parsing, decoding, transformation, and batch preparation.
 
 ```bash
---option pipeline_parallel=true \
 --option pipeline_workers=4
 ```
+
+`pipeline_workers` alone decides the mode: 2 or more runs the parallel
+pipeline, 1 (the default) runs batches sequentially.
 
 **Parquet file parallelism** uses pipeline workers to write independent files.
 This is the simplest parallel write model.

--- a/docs/concepts/performance.md
+++ b/docs/concepts/performance.md
@@ -36,9 +36,11 @@ and shaping batches before the write step.
 Use pipeline workers when this phase dominates:
 
 ```bash
---option pipeline_parallel=true \
 --option pipeline_workers=4
 ```
+
+`pipeline_workers` alone decides the mode: 2 or more runs the parallel
+pipeline, 1 (the default) runs batches sequentially.
 
 Increase workers gradually. If CPU usage is already high, more workers may add
 contention without improving throughput. If memory grows too much, reduce
@@ -142,7 +144,6 @@ For a large gridded Zarr product on S3 with scratch space:
 For CPU-heavy source parsing:
 
 ```bash
---option pipeline_parallel=true \
 --option pipeline_workers=4 \
 --option pipeline_batch_size=40
 ```
@@ -151,7 +152,6 @@ For tabular Parquet output:
 
 ```bash
 --output-format parquet \
---option pipeline_parallel=true \
 --option pipeline_workers=4 \
 --option pipeline_batch_size=50
 ```

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -38,7 +38,6 @@ label_allowlist = ["frp_variant"]
 zarr_chunk_shape = '{"timestamp":1,"ny":550,"nx":475}'
 zarr_compression = false
 zarr_consolidate = false
-pipeline_parallel = true
 pipeline_workers = 2
 pipeline_batch_size = 40
 resume_existing = true

--- a/docs/reference/core-utilities.md
+++ b/docs/reference/core-utilities.md
@@ -27,7 +27,7 @@ Zarr stores and returns `ZarrCompareReport`.
     "rename_time_dim",
     "read_hdf5_array",
     "materialize_hdf5_path",
-    "extract_all_from_zip",
+    "extract_all_from_zips",
     "epoch_s_to_iso",
     "iso_to_epoch_s",
     "coerce_to_epoch_s",
@@ -81,7 +81,7 @@ Zarr stores and returns `ZarrCompareReport`.
 
 ## ZIP Extraction
 
-::: firecube.core.api.extract_all_from_zip
+::: firecube.core.api.extract_all_from_zips
 
 ## Time Conversion
 

--- a/docs/tutorials/sentinel3-frp.md
+++ b/docs/tutorials/sentinel3-frp.md
@@ -203,7 +203,7 @@ Product:     sentinel3_frp
 
 Options Sections:
   [ENGINE]
-      pipeline_parallel [boolean] (default: False)
+      pipeline_workers [integer] (default: 1)
       ...
 ```
 

--- a/src/firecube/core/api.py
+++ b/src/firecube/core/api.py
@@ -40,7 +40,7 @@ from firecube.core.filesystem import (
 from firecube.core.formats import (
     clean_netcdf_encoding,
     discover_input_files,
-    extract_all_from_zip,
+    extract_all_from_zips,
     materialize_hdf5_path,
     normalize_string_vars,
     prepare_netcdf_for_zarr,
@@ -138,7 +138,7 @@ __all__ = [
     "ensure_directory",
     "ensure_product_uri",
     "epoch_s_to_iso",
-    "extract_all_from_zip",
+    "extract_all_from_zips",
     "infer_target_protocol",
     "is_remote_target",
     "iso_to_epoch_s",

--- a/src/firecube/core/formats/__init__.py
+++ b/src/firecube/core/formats/__init__.py
@@ -26,9 +26,8 @@ from firecube.core.formats.netcdf import (
     rename_time_dim,
 )
 from firecube.core.formats.zip import (
-    extract_all_from_zip,
+    extract_all_from_zips,
     extract_hdf5_from_zip,
-    extract_zip_files_parallel,
     stream_hdf5_from_zip,
 )
 
@@ -36,9 +35,8 @@ __all__ = [
     "KNOWN_EXTENSIONS",
     "clean_netcdf_encoding",
     "discover_input_files",
-    "extract_all_from_zip",
+    "extract_all_from_zips",
     "extract_hdf5_from_zip",
-    "extract_zip_files_parallel",
     "materialize_hdf5_path",
     "normalize_string_vars",
     "prepare_netcdf_for_zarr",

--- a/src/firecube/core/formats/zip.py
+++ b/src/firecube/core/formats/zip.py
@@ -23,9 +23,9 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
-import tempfile
+import shutil
 import zipfile
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 log = logging.getLogger("firecube.core.formats")
@@ -176,146 +176,95 @@ def stream_hdf5_from_zip(
         return None
 
 
-def extract_zip_files_parallel(
-    zip_files: list[Path],
-    *,
-    tempdir_factory: Callable[[], tempfile.TemporaryDirectory],
-    extract_fn: Callable[[Path, Path], Path | None] = extract_hdf5_from_zip,
-    max_workers: int = 4,
-    record_temp_dirs: bool = False,
-    temp_dir_map: dict[str, tempfile.TemporaryDirectory] | None = None,
-    logger: logging.Logger | None = None,
-) -> tuple[list[Path], list[tempfile.TemporaryDirectory]]:
-    """Extract multiple ZIP archives concurrently into per-archive temp directories.
-
-    Runs ``extract_fn`` for each archive on a thread pool. Archives that fail to
-    extract or contain no matching member are logged and skipped; they do not
-    abort the batch. Two or fewer archives are extracted serially.
-
-    Args:
-        zip_files: ZIP archive paths to extract.
-        tempdir_factory: Zero-argument callable returning a fresh
-            ``tempfile.TemporaryDirectory`` for each archive.
-        extract_fn: Callable ``(zip_path, dest_dir) -> extracted_path | None``
-            applied to each archive. Defaults to :func:`extract_hdf5_from_zip`.
-        max_workers: Upper bound on concurrent extractions. Capped at
-            ``len(zip_files)``.
-        record_temp_dirs: When true and ``temp_dir_map`` is given, record which
-            temporary directory produced each extracted file.
-        temp_dir_map: Mapping filled with ``str(resolved_path) ->
-            TemporaryDirectory`` entries when ``record_temp_dirs`` is true.
-        logger: Optional logger for diagnostics.
-
-    Returns:
-        A ``(resolved_paths, temp_dirs)`` pair. ``resolved_paths`` holds one
-        extracted file path per successful archive; ``temp_dirs`` holds the
-        matching temporary directories, which the caller must keep alive while
-        the extracted files are in use and clean up afterwards.
-
-    Examples:
-        Extract a batch of archives and clean up afterwards:
-
-            >>> paths, tmp_dirs = extract_zip_files_parallel(
-            ...     [Path("a.zip"), Path("b.zip")],
-            ...     tempdir_factory=tempfile.TemporaryDirectory,
-            ... )
-            >>> for tmp in tmp_dirs:
-            ...     tmp.cleanup()
-    """
-    logger = logger or log
-    resolved: list[Path] = []
-    temp_dirs: list[tempfile.TemporaryDirectory] = []
-
-    if not zip_files:
-        return resolved, temp_dirs
-
-    def _maybe_record(path: Path, tmp: tempfile.TemporaryDirectory) -> None:
-        if not record_temp_dirs or temp_dir_map is None:
-            return
-        try:
-            temp_dir_map[str(path.resolve())] = tmp
-        except Exception:
-            temp_dir_map[str(path)] = tmp
-
-    # For small numbers of files, don't bother with parallelism overhead
-    if len(zip_files) <= 2:
-        for zip_path in zip_files:
-            tmp = tempdir_factory()
-            extracted = extract_fn(zip_path, Path(tmp.name))
-            if extracted:
-                _maybe_record(extracted, tmp)
-                temp_dirs.append(tmp)
-                resolved.append(extracted)
-            else:
-                tmp.cleanup()
-                logger.warning("No HDF5 file found inside archive %s", zip_path)
-        return resolved, temp_dirs
-
-    def extract_single_zip(
-        zip_path: Path,
-    ) -> tuple[Path | None, tempfile.TemporaryDirectory | None]:
-        try:
-            tmp = tempdir_factory()
-            extracted = extract_fn(zip_path, Path(tmp.name))
-            if extracted:
-                return extracted, tmp
-            tmp.cleanup()
-            logger.warning("No HDF5 file found inside archive %s", zip_path)
-            return None, None
-        except Exception as exc:
-            logger.error("Failed to extract ZIP file %s: %s", zip_path, exc)
-            return None, None
-
-    actual_workers = min(int(max_workers), len(zip_files))
-    logger.debug(
-        "Extracting %d ZIP files using %d parallel workers", len(zip_files), actual_workers
-    )
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
-        future_to_zip = {
-            executor.submit(extract_single_zip, zip_path): zip_path for zip_path in zip_files
-        }
-        for future in concurrent.futures.as_completed(future_to_zip):
-            zip_path = future_to_zip[future]
-            try:
-                extracted_path, tmp_dir = future.result()
-                if extracted_path and tmp_dir:
-                    _maybe_record(extracted_path, tmp_dir)
-                    resolved.append(extracted_path)
-                    temp_dirs.append(tmp_dir)
-            except Exception as exc:
-                logger.error("ZIP extraction failed for %s: %s", zip_path, exc)
-
-    logger.debug(
-        "Parallel ZIP extraction completed: %d files extracted from %d archives",
-        len(resolved),
-        len(zip_files),
-    )
-    return resolved, temp_dirs
-
-
-def extract_all_from_zip(zip_path: Path, dest: Path) -> None:
-    """Extract every member of ``zip_path`` into ``dest``, rejecting unsafe names.
-
-    Args:
-        zip_path: Path to the zip archive to extract.
-        dest: Destination directory. Created if it does not exist.
-
-    Returns:
-        None: The function returns nothing.
-
-    Raises:
-        ValueError: If any member name would escape ``dest``.
-        zipfile.BadZipFile: If ``zip_path`` is not a valid zip archive.
-
-    Examples:
-        Extract every member of a small archive:
-
-            >>> from pathlib import Path
-            >>> extract_all_from_zip(Path("archive.zip"), Path("dest_dir"))
-    """
+def _extract_one_zip(zip_path: Path, dest: Path) -> None:
+    """Extract every member of ``zip_path`` into ``dest``, rejecting unsafe names."""
     dest.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(zip_path) as zf:
         for name in zf.namelist():
             _ensure_safe_zip_member(name)
         zf.extractall(dest)
+
+
+def extract_all_from_zips(
+    zip_paths: Sequence[Path],
+    dest_dir_for: Callable[[Path], Path],
+    *,
+    workers: int = 1,
+) -> tuple[dict[Path, Path], dict[Path, str]]:
+    """Extract every member of each ZIP archive, optionally in parallel.
+
+    Destination directories are resolved by calling ``dest_dir_for`` once per
+    archive, serially and in input order, before any extraction starts, so the
+    callable needs no locking. Each archive is then fully extracted into its
+    directory; member names that could escape it (``..`` segments, absolute
+    paths, Windows drive prefixes) are rejected before anything is written.
+
+    A failing archive never raises and never aborts the batch: its partially
+    extracted directory is removed and the failure is reported in the result.
+    Callers MUST check the returned failures mapping — an unsafe member name
+    or a corrupt archive is reported there, not as an exception. ``workers=1``
+    extracts serially; higher values extract concurrently with identical
+    failure semantics. Extraction is disk-bound, so ``workers`` composes with,
+    and is independent of, the engine's ``pipeline_workers`` option; a plugin
+    running several pipeline workers multiplies the two, so keep ``workers``
+    modest.
+
+    Args:
+        zip_paths: Archives to extract.
+        dest_dir_for: Callable mapping each archive path to its destination
+            directory. Called once per archive before extraction begins.
+        workers: Upper bound on concurrent extractions, capped at the number
+            of archives. Defaults to serial extraction. Ingestion plugins
+            conventionally pass the engine's ``extract_workers`` option here
+            so operators control it with ``--option extract_workers=N``.
+
+    Returns:
+        An ``(extracted, failures)`` pair: ``extracted`` maps each
+        successfully extracted archive to its destination directory, and
+        ``failures`` maps each failed archive to its error message. Every
+        input path appears in exactly one of the two mappings.
+
+    Raises:
+        ValueError: If ``workers`` is less than 1.
+
+    Examples:
+        Extract a batch of archives next to each archive:
+
+            >>> from pathlib import Path
+            >>> extracted, failures = extract_all_from_zips(
+            ...     [Path("a.zip"), Path("b.zip")],
+            ...     lambda zip_path: zip_path.parent / zip_path.stem,
+            ...     workers=4,
+            ... )
+            >>> if failures:
+            ...     raise RuntimeError(f"failed archives: {failures}")
+    """
+    if workers < 1:
+        raise ValueError(f"workers must be >= 1, got {workers}")
+
+    paths = [Path(p) for p in zip_paths]
+    dests = {path: Path(dest_dir_for(path)) for path in paths}
+    extracted: dict[Path, Path] = {}
+    failures: dict[Path, str] = {}
+
+    def _extract(path: Path) -> None:
+        dest = dests[path]
+        try:
+            _extract_one_zip(path, dest)
+        except Exception as exc:
+            shutil.rmtree(dest, ignore_errors=True)
+            log.warning("ZIP extraction failed for %s: %s", path, exc)
+            failures[path] = str(exc)
+        else:
+            extracted[path] = dest
+
+    pool_size = min(int(workers), len(paths)) if paths else 0
+    if pool_size <= 1:
+        for path in paths:
+            _extract(path)
+        return extracted, failures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=pool_size) as pool:
+        for future in [pool.submit(_extract, path) for path in paths]:
+            future.result()
+    return extracted, failures

--- a/src/firecube/ingestor/config/engine.py
+++ b/src/firecube/ingestor/config/engine.py
@@ -59,9 +59,16 @@ class EngineConfig:
     These options control HOW the ingestion runs, not WHAT product logic is applied.
 
     Attributes:
-        pipeline_parallel: Enable parallel batch preprocessing.
-        pipeline_workers: Number of pipeline worker threads.
-        pipeline_batch_size: Number of source items per batch.
+        pipeline_workers: Number of pipeline worker threads. A value of 2 or
+            more selects parallel pipeline execution; 1 (the default) runs
+            batches sequentially. Must be at least 1.
+        pipeline_batch_size: Number of source items per batch. Must be at
+            least 1.
+        extract_workers: Number of parallel archive-extraction workers used
+            by plugins that extract a batch of source archives (for example
+            ZIPs) to disk before decoding. Extraction is disk-bound and
+            claims no slots, so this is independent of ``pipeline_workers``;
+            when both are above 1 the two multiply. Must be at least 1.
         cleanup_workspace: Delete temporary workspace files after the run.
         workspace: Optional workspace directory override.
         include_patterns: Optional file patterns for source discovery.
@@ -90,9 +97,9 @@ class EngineConfig:
     """
 
     # Execution (Pipeline)
-    pipeline_parallel: bool = False
     pipeline_workers: int = 1
     pipeline_batch_size: int = 10
+    extract_workers: int = 4
 
     # Workspace & Resources
     cleanup_workspace: bool = False
@@ -136,6 +143,12 @@ class EngineConfig:
     static_owner_slot_start: int | None = None
 
     def __post_init__(self) -> None:
+        if self.pipeline_workers < 1:
+            raise ValueError(f"pipeline_workers must be >= 1, got {self.pipeline_workers}")
+        if self.pipeline_batch_size < 1:
+            raise ValueError(f"pipeline_batch_size must be >= 1, got {self.pipeline_batch_size}")
+        if self.extract_workers < 1:
+            raise ValueError(f"extract_workers must be >= 1, got {self.extract_workers}")
         if self.suppress_static_emission_for_non_owner and self.static_owner_slot_start is None:
             raise ConfigurationError(
                 "suppress_static_emission_for_non_owner=True requires static_owner_slot_start"

--- a/src/firecube/ingestor/runtime/base.py
+++ b/src/firecube/ingestor/runtime/base.py
@@ -862,8 +862,8 @@ class BaseIngestor(BaseIngestorHookMixin, Ingestor, ABC):
 
                 # 6. Planning
                 mode = determine_execution_mode(self.engine_config)
-                # Sequential falls back to pipeline with 0/1 workers pattern or distinct loop?
-                # Using BatchPlanner for both ensuring consistency.
+                # pipeline_workers >= 2 selects the threaded pipeline runner;
+                # otherwise the sequential runner. Both plan via BatchPlanner.
 
                 if self._firecube_engine is None:
                     from firecube.ingestor.runtime.engine import PipelineExecutor

--- a/src/firecube/ingestor/runtime/configure.py
+++ b/src/firecube/ingestor/runtime/configure.py
@@ -140,10 +140,13 @@ class TierConfigurator:
 
 
 def determine_execution_mode(engine_config: EngineConfig) -> ExecutionMode:
-    pipeline_requested = (
-        bool(engine_config.pipeline_parallel) or int(engine_config.pipeline_workers) > 1
-    )
-    if pipeline_requested:
+    """Select the execution mode from ``pipeline_workers`` alone.
+
+    ``pipeline_workers >= 2`` selects parallel pipeline execution; 1 runs
+    batches sequentially. ``EngineConfig`` rejects values below 1 at
+    construction, so no other state exists.
+    """
+    if engine_config.pipeline_workers >= 2:
         return ExecutionMode.PIPELINE
     return ExecutionMode.SEQUENTIAL
 

--- a/tests/benchmarks/lazy_writeintent_harness/test_peak_retained_payload.py
+++ b/tests/benchmarks/lazy_writeintent_harness/test_peak_retained_payload.py
@@ -304,8 +304,6 @@ def test_callable_plugin_retained_peak_smoke(
         "direct",
         "--option",
         "no_progress=true",
-        "--option",
-        "pipeline_parallel=false",
     ]
     completed = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
     assert completed.returncode == 0, (

--- a/tests/fixtures/callable_payload_test_plugin/tests/test_safe_ingestor.py
+++ b/tests/fixtures/callable_payload_test_plugin/tests/test_safe_ingestor.py
@@ -70,8 +70,6 @@ def _ingest_args(target_path: Path) -> list[str]:
         "direct",
         "--option",
         "no_progress=true",
-        "--option",
-        "pipeline_parallel=false",
     ]
 
 

--- a/tests/fixtures/callable_payload_test_plugin/tests/test_static_resume_documented_behavior.py
+++ b/tests/fixtures/callable_payload_test_plugin/tests/test_static_resume_documented_behavior.py
@@ -76,8 +76,6 @@ def _ingest_args(target_path: Path, *, force_reingest: bool = False) -> list[str
         "direct",
         "--option",
         "no_progress=true",
-        "--option",
-        "pipeline_parallel=false",
     ]
     if force_reingest:
         args += ["--option", "force_reingest=true"]

--- a/tests/ingestor/test_config_architecture.py
+++ b/tests/ingestor/test_config_architecture.py
@@ -63,8 +63,8 @@ class MockIngestor(BaseIngestor):
 def test_engine_config_strictness():
     """Verify EngineConfig rejects unknown keys."""
     # Valid
-    cfg = EngineConfig.from_options({"pipeline_parallel": True})
-    assert cfg.pipeline_parallel is True
+    cfg = EngineConfig.from_options({"pipeline_workers": 2})
+    assert cfg.pipeline_workers == 2
 
     # Invalid
     with pytest.raises(ValueError, match="Unknown Engine options"):
@@ -77,7 +77,7 @@ def test_option_split_logic():
 
     options = {
         # Engine
-        "pipeline_parallel": "true",
+        "pipeline_workers": "2",
         "cleanup_workspace": "false",
         # Template
         "template_param": "custom_template",
@@ -95,7 +95,7 @@ def test_option_split_logic():
     ingestor.plugin_config = plugin_cfg
 
     # Verify Engine
-    assert ingestor.engine_config.pipeline_parallel is True
+    assert ingestor.engine_config.pipeline_workers == 2
     assert ingestor.engine_config.cleanup_workspace is False
 
     # Verify Template
@@ -112,7 +112,7 @@ def test_union_validator_rejects_typos():
     ingestor = MockIngestor()
 
     options = {
-        "pipeline_parallel": "true",
+        "pipeline_workers": "2",
         "typo_param": "foo",  # Unknown
     }
 
@@ -144,7 +144,7 @@ def test_collision_with_engine():
 
         @dataclass
         class EngineOverridePlugin(PluginConfig):
-            pipeline_parallel: bool = False
+            pipeline_workers: int = 1
 
         class EngineBadIngestor(BaseIngestor):
             PRODUCT_NAME = "engine_bad"
@@ -157,7 +157,7 @@ def test_describe_options_structure():
     desc = MockIngestor.describe_options()
 
     assert "Engine Options" in desc
-    assert "pipeline_parallel" in desc["Engine Options"]
+    assert "pipeline_workers" in desc["Engine Options"]
 
     assert "Template Options" in desc
     assert "template_param" in desc["Template Options"]

--- a/tests/integration/test_architecture_invariants.py
+++ b/tests/integration/test_architecture_invariants.py
@@ -114,7 +114,6 @@ def _prepare_bt3_ingest(
         output_format="zarr",
         options={
             "write_mode": "staged",
-            "pipeline_parallel": False,
             "pipeline_batch_size": 1,
             "no_progress": True,
         },

--- a/tests/integration/test_callable_payload_integration.py
+++ b/tests/integration/test_callable_payload_integration.py
@@ -93,8 +93,6 @@ def _ingest_args(target_path: Path) -> list[str]:
         "direct",
         "--option",
         "no_progress=true",
-        "--option",
-        "pipeline_parallel=false",
     ]
 
 

--- a/tests/integration/test_cf_time_dim_telemetry.py
+++ b/tests/integration/test_cf_time_dim_telemetry.py
@@ -132,7 +132,6 @@ def test_cf_time_dim_plugin_run_summary_reports_year_2000(tmp_path: Path) -> Non
         options={
             "write_mode": "direct",
             "pipeline_batch_size": 1,
-            "pipeline_parallel": False,
             "pipeline_workers": 1,
             "no_progress": True,
             "cleanup_workspace": True,

--- a/tests/integration/test_cf_time_dim_value_dedup.py
+++ b/tests/integration/test_cf_time_dim_value_dedup.py
@@ -63,7 +63,6 @@ def _run_staged_ingest(
             "write_mode": write_mode,
             "resume_existing": resume_existing,
             "pipeline_batch_size": 1,
-            "pipeline_parallel": False,
             "pipeline_workers": 1,
             "no_progress": True,
             "cleanup_workspace": True,

--- a/tests/integration/test_cli_zarr_preallocate_spec_attrs.py
+++ b/tests/integration/test_cli_zarr_preallocate_spec_attrs.py
@@ -87,8 +87,6 @@ def _ingest_args(target_path: Path) -> list[str]:
         "resume_existing=true",
         "--option",
         "no_progress=true",
-        "--option",
-        "pipeline_parallel=false",
     ]
 
 

--- a/tests/integration/test_cli_zarr_preallocate_typed_config.py
+++ b/tests/integration/test_cli_zarr_preallocate_typed_config.py
@@ -87,8 +87,6 @@ def _ingest_args(target_path: Path, *options: str) -> list[str]:
         "direct",
         "--option",
         "no_progress=true",
-        "--option",
-        "pipeline_parallel=false",
     ]
     for option in options:
         args.extend(["--option", option])

--- a/tests/integration/test_engine_failed_batch_wal.py
+++ b/tests/integration/test_engine_failed_batch_wal.py
@@ -80,7 +80,6 @@ def test_mixed_batches_yield_failed_status(tmp_path: Path) -> None:
         target=session.product.product_uri.to_str(),
         output_format="zarr",
         options={
-            "pipeline_parallel": False,
             "pipeline_batch_size": 1,
             "write_mode": "direct",
             "no_progress": True,

--- a/tests/integration/test_indexed_write_pipeline.py
+++ b/tests/integration/test_indexed_write_pipeline.py
@@ -218,8 +218,6 @@ def _ingest_args(plugin: str, product: str, target_path: Path) -> list[str]:
         "direct",
         "--option",
         "no_progress=true",
-        "--option",
-        "pipeline_parallel=false",
     ]
 
 

--- a/tests/integration/test_phase2_behavior_preserved.py
+++ b/tests/integration/test_phase2_behavior_preserved.py
@@ -100,8 +100,6 @@ def _ingest_args(plugin: str, product_name: str, target_path: Path) -> list[str]
         "no_progress=true",
         "--option",
         "pipeline_batch_size=300",
-        "--option",
-        "pipeline_parallel=false",
     ]
 
 

--- a/tests/integration/test_phase3_3_encoded_run_id_lifecycle.py
+++ b/tests/integration/test_phase3_3_encoded_run_id_lifecycle.py
@@ -135,7 +135,7 @@ def _base_args(target_path: Path) -> list[str]:
         "--option",
         "no_progress=true",
         "--option",
-        "pipeline_parallel=true",
+        "pipeline_workers=2",
         "--option",
         "pipeline_batch_size=100",
     ]

--- a/tests/integration/test_phase3_3_phantom_group_e2e.py
+++ b/tests/integration/test_phase3_3_phantom_group_e2e.py
@@ -143,7 +143,7 @@ def _args(target_path: Path) -> list[str]:
         "--option",
         "no_progress=true",
         "--option",
-        "pipeline_parallel=true",
+        "pipeline_workers=2",
         "--option",
         "pipeline_batch_size=10",
     ]

--- a/tests/integration/test_phase3_single_group_preserved.py
+++ b/tests/integration/test_phase3_single_group_preserved.py
@@ -70,7 +70,7 @@ def _base_args(target_path: Path) -> list[str]:
         "--option",
         "pipeline_batch_size=300",
         "--option",
-        "pipeline_parallel=true",
+        "pipeline_workers=2",
     ]
 
 

--- a/tests/integration/test_pipeline_manifest_creation.py
+++ b/tests/integration/test_pipeline_manifest_creation.py
@@ -45,8 +45,8 @@ class PipelineIngestorForTesting(GenericZarrIngestor):
         )
 
 
-@pytest.mark.parametrize("parallel", [True, False])
-def test_pipeline_manifest_creation(tmp_path, parallel):
+@pytest.mark.parametrize("pipeline_workers", [2, 1])
+def test_pipeline_manifest_creation(tmp_path, pipeline_workers):
     """Execution creates WAL immediately and snapshots only on explicit rebuild."""
     source_dir = tmp_path / "source"
     source_dir.mkdir()
@@ -59,8 +59,7 @@ def test_pipeline_manifest_creation(tmp_path, parallel):
         source=str(source_dir),
         product=target_dir.name,
         options={
-            "pipeline_parallel": parallel,
-            "pipeline_workers": 1,
+            "pipeline_workers": pipeline_workers,
             "pipeline_batch_size": 1,
             "include_patterns": ["*.nc"],
             "write_mode": "direct",

--- a/tests/integration/test_slot_index_non_parallel.py
+++ b/tests/integration/test_slot_index_non_parallel.py
@@ -74,8 +74,6 @@ def _ingest_args(
         "no_progress=true",
         "--option",
         "pipeline_batch_size=300",
-        "--option",
-        "pipeline_parallel=false",
     ]
     if resume_existing:
         args.extend(["--option", "resume_existing=true"])

--- a/tests/integration/test_staged_mode_template_parity.py
+++ b/tests/integration/test_staged_mode_template_parity.py
@@ -283,7 +283,6 @@ def _run_staged_ingest(
             "write_mode": write_mode,
             "resume_existing": resume_existing,
             "pipeline_batch_size": 1,
-            "pipeline_parallel": False,
             "pipeline_workers": 1,
             "no_progress": True,
             "cleanup_workspace": True,
@@ -501,7 +500,6 @@ def test_staged_hook_does_not_fire_for_non_zarr_outputs(tmp_path: Path) -> None:
         options={
             "write_mode": "staged",
             "pipeline_batch_size": 1,
-            "pipeline_parallel": False,
             "pipeline_workers": 1,
             "no_progress": True,
             "cleanup_workspace": True,

--- a/tests/integration/test_storage_driver_integration.py
+++ b/tests/integration/test_storage_driver_integration.py
@@ -247,7 +247,6 @@ class TestPipelineWithBothDrivers:
                 )
             ),
             options={
-                "pipeline_parallel": False,
                 "pipeline_workers": 1,
                 "pipeline_batch_size": 1,
                 "include_patterns": ["*.nc"],

--- a/tests/unit/test_execution_mode_selection.py
+++ b/tests/unit/test_execution_mode_selection.py
@@ -1,0 +1,59 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Execution-mode selection is decided by ``pipeline_workers`` alone."""
+
+from __future__ import annotations
+
+import pytest
+
+from firecube.ingestor.config.engine import EngineConfig
+from firecube.ingestor.runtime.configure import ExecutionMode, determine_execution_mode
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_config_runs_sequentially() -> None:
+    assert determine_execution_mode(EngineConfig()) is ExecutionMode.SEQUENTIAL
+
+
+def test_one_worker_runs_sequentially() -> None:
+    config = EngineConfig(pipeline_workers=1)
+    assert determine_execution_mode(config) is ExecutionMode.SEQUENTIAL
+
+
+def test_two_or_more_workers_select_pipeline() -> None:
+    assert determine_execution_mode(EngineConfig(pipeline_workers=2)) is ExecutionMode.PIPELINE
+    assert determine_execution_mode(EngineConfig(pipeline_workers=8)) is ExecutionMode.PIPELINE
+
+
+@pytest.mark.parametrize("workers", [0, -1])
+def test_invalid_pipeline_workers_rejected_at_construction(workers: int) -> None:
+    with pytest.raises(ValueError, match="pipeline_workers must be >= 1"):
+        EngineConfig(pipeline_workers=workers)
+
+
+def test_invalid_pipeline_batch_size_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="pipeline_batch_size must be >= 1"):
+        EngineConfig(pipeline_batch_size=0)
+
+
+def test_invalid_extract_workers_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="extract_workers must be >= 1"):
+        EngineConfig(extract_workers=0)
+
+
+def test_extract_workers_does_not_affect_execution_mode() -> None:
+    config = EngineConfig(extract_workers=8)
+    assert determine_execution_mode(config) is ExecutionMode.SEQUENTIAL

--- a/tests/unit/test_zip_extract_safety.py
+++ b/tests/unit/test_zip_extract_safety.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import pytest
 
 from firecube.core.formats.zip import (
-    extract_all_from_zip,
+    extract_all_from_zips,
     extract_hdf5_from_zip,
     stream_hdf5_from_zip,
 )
@@ -119,19 +119,60 @@ def test_stream_path_and_extract_path_share_validation(tmp_path: Path) -> None:
         stream_hdf5_from_zip(archive)
 
 
-def test_extract_all_from_zip_extracts_every_member(tmp_path: Path) -> None:
+def test_extract_all_from_zips_extracts_every_member(tmp_path: Path) -> None:
     archive = tmp_path / "nested.zip"
     _write_zip(archive, {"payload/a.txt": b"A", "payload/b.txt": b"B"})
 
-    extract_all_from_zip(archive, tmp_path / "out")
+    extracted, failures = extract_all_from_zips([archive], lambda p: tmp_path / "out" / p.stem)
 
-    assert (tmp_path / "out" / "payload" / "a.txt").read_bytes() == b"A"
-    assert (tmp_path / "out" / "payload" / "b.txt").read_bytes() == b"B"
+    assert failures == {}
+    out = extracted[archive]
+    assert (out / "payload" / "a.txt").read_bytes() == b"A"
+    assert (out / "payload" / "b.txt").read_bytes() == b"B"
 
 
-def test_extract_all_from_zip_rejects_unsafe_member(tmp_path: Path) -> None:
+def test_extract_all_from_zips_reports_unsafe_member_as_failure(tmp_path: Path) -> None:
     archive = tmp_path / "unsafe.zip"
     _write_zip(archive, {"../escape.txt": b"evil"})
 
-    with pytest.raises(ValueError, match="Unsafe ZIP member"):
-        extract_all_from_zip(archive, tmp_path / "out")
+    extracted, failures = extract_all_from_zips([archive], lambda p: tmp_path / "out" / p.stem)
+
+    assert extracted == {}
+    assert "Unsafe ZIP member" in failures[archive]
+    assert not (tmp_path / "escape.txt").exists()
+    # Partial output of a failed archive is removed.
+    assert not (tmp_path / "out" / "unsafe").exists()
+
+
+@pytest.mark.parametrize("workers", [1, 4])
+def test_extract_all_from_zips_every_input_lands_in_one_mapping(
+    tmp_path: Path, workers: int
+) -> None:
+    good = []
+    for index in range(3):
+        archive = tmp_path / f"good-{index}.zip"
+        _write_zip(archive, {f"member-{index}.txt": bytes([index]) * 4})
+        good.append(archive)
+    corrupt = tmp_path / "corrupt.zip"
+    corrupt.write_bytes(b"this is not a zip archive")
+    evil = tmp_path / "evil.zip"
+    _write_zip(evil, {"../escape.txt": b"evil"})
+
+    extracted, failures = extract_all_from_zips(
+        [*good, corrupt, evil],
+        lambda p: tmp_path / "out" / p.stem,
+        workers=workers,
+    )
+
+    assert sorted(extracted) == sorted(good)
+    assert set(failures) == {corrupt, evil}
+    dirs = list(extracted.values())
+    assert len(set(dirs)) == len(dirs)
+    for index, archive in enumerate(good):
+        member = extracted[archive] / f"member-{index}.txt"
+        assert member.read_bytes() == bytes([index]) * 4
+
+
+def test_extract_all_from_zips_rejects_invalid_workers(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="workers must be >= 1"):
+        extract_all_from_zips([], lambda p: tmp_path, workers=0)


### PR DESCRIPTION
## What changed

Consolidates the public ZIP surface into a single `extract_all_from_zips` batch API (serial by default, concurrent via `workers=`, `(extracted, failures)` result, zip-slip guard inherited) and deletes the unused `extract_zip_files_parallel`. Adds the `extract_workers` engine option (default 4) so operators control extraction parallelism. Removes the redundant `pipeline_parallel` flag: `pipeline_workers` alone decides the execution mode (2+ parallel, 1 sequential), now validated at construction.

## Why

One ZIP endpoint instead of two plus dead code; `pipeline_parallel=false` was silently ignored whenever `pipeline_workers` was above 1. Parallel batch extraction measured -15.7% ingest wall time at flat memory on a 12-ZIP FCI batch.

## Affected behavior

- User / CLI: `--option pipeline_parallel=...` is rejected as an unknown key (migration: `true` becomes `pipeline_workers=2`+, `false` is deleted); new `--option extract_workers=N`; `pipeline_workers`/`pipeline_batch_size` below 1 now fail fast.
- Plugin authors: `extract_all_from_zips`; docs gain a worker-option table on the parallelism page.
- Operators / production: no behavior change for valid existing configs; stale `pipeline_parallel` keys fail loudly instead of being ignored.
- Stored formats or control-plane state: N/A

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [x] Breaking change (CLI flags, plugin contract, config, or stored format)
- [x] Documentation
- [ ] CI / build / chore

Breaking vs v0.1.4.post1: `pipeline_parallel` removal (CHANGELOG migration note included).

## Checks run

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [ ] `uv run --with bandit bandit -c pyproject.toml -r src scripts -lll`
- [ ] `uv run pytest --strict-deps -m "not slow and not s3" -q`
- [x] Docs build (if docs changed): `uv run mkdocs build --strict`

Full `-m "not slow and not s3"` lane green locally (without `--strict-deps`); run bandit and the strict-deps lane before merge.

## Follow-up work

Plugin migration is out of scope.

## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
