### PR TITLE
fix/zarr-compare-scalar-arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,11 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 
 ### Fixed
 
+- `firecube zarr compare` and `compare_zarr_stores` no longer crash with an
+  IndexError on stores containing a zero-dimensional array (for example a CF
+  grid-mapping scalar such as `spatial_ref`); scalar values are now compared
+  like any other array.
+
 - `include_patterns` is documented as additive to the built-in `.zip`/`.h5`/
   `.nc` selection; the reference previously stated that it replaced them.
 - `SlotAxis.__post_init__` now rejects `bool` and non-integral `cadence_s`

--- a/src/firecube/core/zarr/validation.py
+++ b/src/firecube/core/zarr/validation.py
@@ -175,8 +175,10 @@ def _static_marker(array: Any) -> Any:
 
 
 def _values_equal(left: Any, right: Any) -> bool:
-    left_values = np.asarray(left[:])
-    right_values = np.asarray(right[:])
+    # Ellipsis indexing works for every rank; `[:]` raises on 0-d arrays
+    # (e.g. a CF grid-mapping scalar such as spatial_ref).
+    left_values = np.asarray(left[...])
+    right_values = np.asarray(right[...])
     if left_values.dtype.kind == "f" and right_values.dtype.kind == "f":
         return bool(np.array_equal(left_values, right_values, equal_nan=True))
     return bool(np.array_equal(left_values, right_values))

--- a/tests/unit/test_compare_zarr_stores.py
+++ b/tests/unit/test_compare_zarr_stores.py
@@ -78,6 +78,33 @@ def test_identical_stores_are_equivalent(tmp_path: Path) -> None:
     assert report.mismatches == []
 
 
+def _add_scalar_array(path: Path, value: int) -> None:
+    root = zarr.open_group(store=str(path), mode="r+")
+    scalar = root.require_group("data").create_array(
+        "spatial_ref", shape=(), dtype="int32", chunks=()
+    )
+    scalar[...] = value
+
+
+def test_zero_dimensional_arrays_compare(tmp_path: Path) -> None:
+    # A CF grid-mapping scalar (shape ()) must compare, not crash on indexing.
+    a = _make_store(tmp_path / "a.zarr")
+    b = _make_store(tmp_path / "b.zarr")
+    _add_scalar_array(a, 0)
+    _add_scalar_array(b, 0)
+
+    report = _compare(a, b)
+
+    assert report.equivalent is True
+
+    c = _make_store(tmp_path / "c.zarr")
+    _add_scalar_array(c, 7)
+    report = _compare(a, c)
+
+    assert report.equivalent is False
+    assert any("values differ" in m for m in report.mismatches)
+
+
 def test_shape_mismatch_detected(tmp_path: Path) -> None:
     a = _make_store(tmp_path / "a.zarr", shape=(2, 2), chunks=(1, 2))
     b = _make_store(tmp_path / "b.zarr", shape=(3, 2), chunks=(1, 2))


### PR DESCRIPTION
## What changed

Small fix to `firecube zarr compare` and `compare_zarr_stores`

## Why

`firecube zarr compare` and `compare_zarr_stores` no longer crash with an IndexError on stores containing a zero-dimensional array (for example a CF   grid-mapping scalar such as `spatial_ref`); scalar values are now compared like any other array. 

## Affected behavior

- User / CLI: N/A
- Plugin authors: N/A
- Operators / production: N/A
- Stored formats or control-plane state: N/A

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (CLI flags, plugin contract, config, or stored format)
- [ ] Documentation
- [ ] CI / build / chore

## Checks run

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [ ] `uv run --with bandit bandit -c pyproject.toml -r src scripts -lll`
- [x] `uv run pytest --strict-deps -m "not slow and not s3" -q`
- [ ] Docs build (if docs changed): `uv run mkdocs build --strict`

## Follow-up work

N/A

## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
