### PR TITLE
64 add quickstart plugin to documentation

### DIFF
--- a/docs/guides/plugins/generic-zarr.md
+++ b/docs/guides/plugins/generic-zarr.md
@@ -56,9 +56,9 @@ class MyPlugin(GenericZarrIngestor):
 
 See the [Plugin Templates](../../reference/templates.md#genericzarringestor)
 for the exact hook signature and optional group, path, and writer
-customizations, or the quickstart's
-[example implementation](../../quickstart/plugins.md#implement-the-plugin) for
-a complete, runnable version of this example.
+customizations, or the quickstart plugin's
+[`build_dataset` implementation](https://github.com/eumetsat/firecube-quickstart-plugin/blob/main/src/firecube_quickstart_plugin/ingestor.py)
+for a complete, runnable version of this example.
 
 ## Verify
 

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -1,8 +1,8 @@
 # Quickstart Overview
 
-This quickstart walks you through installing Firecube, creating a small dataset
-plugin, generating NetCDF source files, and writing one Zarr product to local
-storage.
+This quickstart walks you through installing Firecube, installing the example
+`firecube-quickstart-plugin`, generating NetCDF source files, and writing one
+Zarr product to local storage.
 
 Firecube provides the ingestion engine. A plugin provides the dataset-specific
 code that discovers, reads, and converts source files.
@@ -11,22 +11,22 @@ code that discovers, reads, and converts source files.
 
 You need:
 
-- `Python 3.12+` and `uv` installed
+- `Python 3.12+`, `uv`, and `git` installed
 
 The installation step creates a working directory with a `.venv` and installs
-Firecube from PyPI. Keep the virtual environment active and run the remaining
-commands from that directory.
+Firecube from PyPI. Keep the virtual environment active for the rest of the
+quickstart.
 
 ## Quickstart Path
 
 1. **[Installation](installation.md)**: Create `.venv`, install Firecube from
    PyPI, and verify the CLI.
-2. **[Create and Install the Example Plugin](plugins.md)**: Create the local
-   `weather_netcdf` plugin, implement its dataset conversion, and install it.
-3. **[Prepare Source Data](source-data.md)**: Create four deterministic NetCDF
-   files for the example ingestion.
-4. **[Run Ingestion](ingestion.md)**: Write one local Zarr product and inspect
-   its ChunkManager record.
+2. **[Install the Example Plugin](plugins.md)**: Clone and install the
+   `firecube-quickstart-plugin` example.
+3. **[Prepare Source Data](source-data.md)**: Generate four deterministic
+   NetCDF files for the example ingestion.
+4. **[Run Ingestion](ingestion.md)**: Write one local Zarr product and open it
+   with `xarray`.
 
 ## Next Steps
 

--- a/docs/quickstart/ingestion.md
+++ b/docs/quickstart/ingestion.md
@@ -1,49 +1,39 @@
 # Run Ingestion
 
-Run the installed plugin once to write a local Zarr product and record the run
-in the product's `.firecube/` control plane.
+Run the installed plugin once to write a local Zarr product, then open it to
+confirm the data cube looks the way you expect.
 
 ## Prerequisites
 
 - The quickstart virtual environment is active.
-- The `weather_netcdf` plugin from
-  [Create and Install the Example Plugin](plugins.md) is installed.
-- The four files from [Prepare Source Data](source-data.md) exist.
+- The `quickstart_plugin` plugin from
+  [Install the Example Plugin](plugins.md) is installed.
+- The four files from [Prepare Source Data](source-data.md) exist under
+  `sample_data/`.
+- Commands run from the `firecube-quickstart-plugin/` directory.
 
-## Inspect The Plugin
-
-Confirm the plugin name and options before writing data:
-
-```bash
-firecube plugins describe weather_netcdf
-firecube ingest weather_netcdf --show-options
-```
-
-## Run The Local Ingestion
+## Run The Ingestion
 
 ```bash
-mkdir -p quickstart-output
-
-firecube ingest weather_netcdf \
-  --input-data quickstart-data/weather-netcdf \
-  --target "file://${PWD}/quickstart-output/weather.zarr" \
-  --product-name quickstart_weather \
+firecube ingest quickstart_plugin \
+  --input-data sample_data \
+  --target "file://${PWD}/sample_data/quickstart_plugin_out.zarr" \
+  --product-name quickstart_plugin \
   --storage-type local \
   --storage-driver fsspec \
   --output-format zarr \
-  --write-mode direct
+  --write-mode staged
 ```
 
-The final summary should identify the selected plugin, the
-`quickstart_weather` product, four processed files, and the local `stored_at`
-path.
+The final summary should identify the selected plugin, the `quickstart_plugin`
+product, four processed files, and the local `stored_at` path.
 
 ## Verify The Run
 
 Confirm that the Zarr directory exists:
 
 ```bash
-test -d quickstart-output/weather.zarr && echo "Zarr product created"
+test -d sample_data/quickstart_plugin_out.zarr && echo "Zarr product created"
 ```
 
 Expected output:
@@ -56,19 +46,55 @@ Inspect the product's control-plane records using the full product URI:
 
 ```bash
 firecube chunks list \
-  --product-name "file://${PWD}/quickstart-output/weather.zarr"
+  --product-name "file://${PWD}/sample_data/quickstart_plugin_out.zarr"
 ```
 
 The result should contain at least one `span` record for the completed run.
 These are logical Firecube records, not physical Zarr array chunks.
 
+## Open And Inspect The Cube
+
+Firecube writes the plugin's data into a `default` group inside the Zarr
+store:
+
+```bash
+python - <<'PY'
+import xarray as xr
+
+ds = xr.open_zarr(
+    "sample_data/quickstart_plugin_out.zarr",
+    group="default",
+    consolidated=False,
+)
+print(ds)
+print(ds["temperature_c"].isel(latitude=0, longitude=0).values.tolist())
+PY
+```
+
+Expected output includes:
+
+```text
+Dimensions:  (timestamp: 4, latitude: 2, longitude: 3)
+[19.4, 22.8, 27.3, 24.1]
+```
+
+The `timestamp` dimension has length 4, `latitude` has length 2, and
+`longitude` has length 3. The four temperature values keep the timestamp order
+defined in the source files. The result also contains `humidity_pct` and
+Firecube's timestamp-state array.
+
+This completes the quickstart: you installed Firecube, installed a plugin,
+staged source data, and produced a Zarr cube you can open with `xarray`.
+
 ## Next Steps
 
-- **[Configure S3 Access](../operations/s3-access.md)**: repeat the workflow
+- **[Configure S3 Access](../operations/s3-access.md)**: repeat this workflow
   against S3 or an S3-compatible service.
-- **[Create an Intake Catalog](../operations/intake-catalog.md)**: make an
-  existing Zarr or Parquet product discoverable through Intake.
-- **[NetCDF To Zarr tutorial](../tutorials/weather-netcdf.md)**: inspect how the
-  quickstart plugin transforms the source files and verify the stored values.
-- **[Operations](../operations/index.md)**: inspect, recover, archive, or manage
-  completed products.
+- **[Storage Drivers](../reference/storage-drivers.md)**: choose a different
+  storage backend for the product.
+- **[Create an Intake Catalog](../operations/intake-catalog.md)**: make this
+  product discoverable through Intake.
+- **[Plugin Development](../guides/plugins/index.md)**: build a plugin for
+  your own dataset.
+- **[Operations](../operations/index.md)**: inspect, recover, archive, or
+  manage completed products.

--- a/docs/quickstart/installation.md
+++ b/docs/quickstart/installation.md
@@ -45,7 +45,7 @@ To change Firecube itself, use the source setup in
 
 ## Next Steps
 
-Continue to **[Create and Install the Example Plugin](plugins.md)**. Firecube
-provides the ingestion engine, but it does not know how to read every dataset
-by itself. The next page creates the dataset-specific Python package used by
-the rest of this quickstart.
+Continue to **[Install the Example Plugin](plugins.md)**. Firecube provides
+the ingestion engine, but it does not know how to read every dataset by
+itself. The next page installs the dataset-specific Python package used by the
+rest of this quickstart.

--- a/docs/quickstart/plugins.md
+++ b/docs/quickstart/plugins.md
@@ -1,4 +1,4 @@
-# Create and Install the Example Plugin
+# Install the Example Plugin
 
 ## When To Use This
 
@@ -6,110 +6,75 @@ A Firecube plugin is a separately installed Python package that tells Firecube
 how to discover, read, and convert a particular dataset. Firecube runs the
 ingestion workflow and manages the output product.
 
-This page creates a local `weather_netcdf` plugin for the quickstart. It reads
-the example NetCDF files and returns one ordered `xarray.Dataset`; Firecube
-writes that dataset to Zarr.
+This page installs the published `firecube-quickstart-plugin` example. It
+already implements dataset conversion for a small set of time-indexed NetCDF
+files, so this quickstart does not require you to write any plugin code.
 
 ## Prerequisites
 
 - Firecube installed in a Python environment.
 - The environment activated with `source .venv/bin/activate`.
-- The current directory is `firecube-quickstart/`.
+- `git` installed.
 
 ## Steps
 
-### Create The Plugin
-
-Create a plugin project from Firecube's Zarr template:
+### Clone The Plugin
 
 ```bash
-mkdir -p plugins_dev
-firecube plugins create weather-netcdf \
-  --template zarr \
-  --target-dir plugins_dev \
-  --non-interactive
+git clone https://github.com/eumetsat/firecube-quickstart-plugin.git
+cd firecube-quickstart-plugin
 ```
 
-Expected output starts with:
-
-```text
-✨ Created plugin project: plugins_dev/firecube-weather-netcdf
-```
-
-The generated package registers the plugin as `weather_netcdf`. Its Zarr
-template handles discovery, batching, and output writes, but its dataset
-conversion deliberately fails until you implement it.
-
-### Implement The Plugin
-
-Open
-`plugins_dev/firecube-weather-netcdf/src/firecube_weather_netcdf/ingestor.py`.
-Replace the generated `build_dataset` method with:
-
-```python
-    def build_dataset(
-        self,
-        group: str,
-        items: list[Any],
-        ctx: PluginContext,
-    ) -> xr.Dataset | None:
-        _ = group
-        if not items:
-            return None
-
-        datasets: list[xr.Dataset] = []
-        for item in items:
-            path = ctx.materialize(item)
-            with xr.open_dataset(path) as source:
-                datasets.append(source.load())
-
-        return xr.concat(datasets, dim="timestamp").sortby("timestamp")
-```
-
-`ctx.materialize(item)` gives `xarray` a local path for each source item.
-`source.load()` keeps the values available after each NetCDF file closes. The
-final line combines the files and orders them by timestamp.
+Stay in this directory for the rest of the quickstart. The virtual environment
+you activated earlier stays active regardless of your current directory.
 
 ### Install The Plugin
 
-Install the generated project into the active environment in editable mode:
+Install the cloned project into the active environment in editable mode:
 
 ```bash
-firecube plugins install --editable plugins_dev/firecube-weather-netcdf
+firecube plugins install --editable .
+```
+
+Expected output ends with:
+
+```text
+Detected plugins: quickstart_plugin
 ```
 
 Editable installation means later changes to the plugin source take effect
 without reinstalling it.
 
-Inspect the registered plugin and its options:
+### Validate The Installation
 
 ```bash
 firecube plugins list
-firecube plugins describe weather_netcdf
-firecube ingest weather_netcdf --show-options
+firecube plugins describe quickstart_plugin
+firecube ingest quickstart_plugin --show-options
 ```
 
-`plugins list` should contain `weather_netcdf`. `plugins describe` should show
-`weather_netcdf` as both the plugin and product name.
+`plugins list` should contain `quickstart_plugin`. `plugins describe` should
+show `quickstart_plugin` as both the plugin and product name, and
+`--show-options` should list the engine, storage, and Zarr options accepted by
+the plugin.
 
 ## Verify
 
-Run the plugin inspection commands above. They should complete without an
-import error, and `--show-options` should list the engine, storage, and Zarr
-options accepted by the plugin.
+Run the three commands above. They should complete without an import error,
+and `plugins describe` should return plugin metadata instead of a "not found"
+error.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Plugin is missing from `plugins list` | The package was installed in a different environment. | Run `source .venv/bin/activate`, then repeat the editable install. |
-| `build_dataset` raises `NotImplementedError` | The generated stub is still present. | Replace the method with the implementation above, then run the command again. |
-| Plugin import fails | The method was pasted outside `WeatherNetcdfIngestor` or has invalid indentation. | Put the method inside the generated class and keep its four-space class indentation. |
-| `uv` cannot find a Python environment | The quickstart environment is not active. | Run `source .venv/bin/activate` from `firecube-quickstart/`. |
+| Plugin is missing from `plugins list` | The package was installed into a different environment. | Run `source .venv/bin/activate`, then repeat the editable install. |
+| `plugins describe quickstart_plugin` reports "not found" | The editable install did not complete, or ran against a different Python. | Repeat `firecube plugins install --editable .` from inside `firecube-quickstart-plugin/` with the quickstart environment active. |
+| `firecube` or `uv` commands fail with no environment found | The quickstart environment is not active. | Run `source .venv/bin/activate` from `firecube-quickstart/`. |
 
 ## Next Steps
 
-- **[Prepare Source Data](source-data.md)**: create the NetCDF files used by the
-  local ingestion example.
-- **[Plugin Development](../guides/plugins/index.md)**: choose a template and
-  develop a plugin for your own dataset after completing the quickstart.
+- **[Prepare Source Data](source-data.md)**: generate the NetCDF files this
+  plugin expects.
+- **[Plugin Development](../guides/plugins/index.md)**: build a plugin for
+  your own dataset instead of the example.

--- a/docs/quickstart/plugins.md
+++ b/docs/quickstart/plugins.md
@@ -33,7 +33,7 @@ you activated earlier stays active regardless of your current directory.
 Install the cloned project into the active environment in editable mode:
 
 ```bash
-firecube plugins install --editable .
+firecube plugins install .
 ```
 
 Expected output ends with:
@@ -42,35 +42,15 @@ Expected output ends with:
 Detected plugins: quickstart_plugin
 ```
 
-Editable installation means later changes to the plugin source take effect
-without reinstalling it.
 
 ### Validate The Installation
 
 ```bash
-firecube plugins list
 firecube plugins describe quickstart_plugin
-firecube ingest quickstart_plugin --show-options
+
 ```
 
-`plugins list` should contain `quickstart_plugin`. `plugins describe` should
-show `quickstart_plugin` as both the plugin and product name, and
-`--show-options` should list the engine, storage, and Zarr options accepted by
-the plugin.
 
-## Verify
-
-Run the three commands above. They should complete without an import error,
-and `plugins describe` should return plugin metadata instead of a "not found"
-error.
-
-## Troubleshooting
-
-| Symptom | Cause | Fix |
-|---|---|---|
-| Plugin is missing from `plugins list` | The package was installed into a different environment. | Run `source .venv/bin/activate`, then repeat the editable install. |
-| `plugins describe quickstart_plugin` reports "not found" | The editable install did not complete, or ran against a different Python. | Repeat `firecube plugins install --editable .` from inside `firecube-quickstart-plugin/` with the quickstart environment active. |
-| `firecube` or `uv` commands fail with no environment found | The quickstart environment is not active. | Run `source .venv/bin/activate` from `firecube-quickstart/`. |
 
 ## Next Steps
 

--- a/docs/quickstart/source-data.md
+++ b/docs/quickstart/source-data.md
@@ -1,82 +1,44 @@
 # Prepare Source Data
 
-Firecube expects you to provide source datasets. In normal use, these files may
-come from a data provider, an existing local sources,
-or object storage. Download or stage the source files before ingestion, then
-pass their directory or storage prefix to `--input-data`.
+Firecube expects you to provide source datasets. In normal use, these files
+may come from a data provider, an existing local source, or object storage.
+You are responsible for staging source files that match what your installed
+plugin accepts, then passing their directory or storage prefix to
+`--input-data`. The installed plugin decides which formats, filenames, and
+dataset structure it accepts; nothing about that is generic.
 
-The installed plugin decides which formats, filenames, and dataset structure it
-accepts. The `weather_netcdf` plugin from the previous page expects
-time-indexed NetCDF files. The example below creates four files it can read.
+The `quickstart_plugin` plugin from the previous page expects time-indexed
+NetCDF files. It ships a script that generates four matching example files, so
+this quickstart does not require you to source real data.
 
 ## Create The Example Files
 
-Run this command from the `firecube-quickstart/` directory with the virtual
-environment active:
+Run this command from the `firecube-quickstart-plugin/` directory, with the
+quickstart virtual environment active:
 
 ```bash
-python - <<'PY'
-from pathlib import Path
-
-import numpy as np
-import xarray as xr
-
-output = Path("quickstart-data/weather-netcdf")
-output.mkdir(parents=True, exist_ok=True)
-
-observations = [
-    ("2024-07-01T00:00:00", 19.4, 68.0),
-    ("2024-07-01T06:00:00", 22.8, 61.0),
-    ("2024-07-01T12:00:00", 27.3, 47.0),
-    ("2024-07-01T18:00:00", 24.1, 55.0),
-]
-
-for index, (timestamp, temperature, humidity) in enumerate(observations, start=1):
-    dataset = xr.Dataset(
-        data_vars={
-            "temperature_c": (
-                ("timestamp", "latitude", "longitude"),
-                np.full((1, 2, 3), temperature, dtype="float64"),
-            ),
-            "humidity_pct": (
-                ("timestamp", "latitude", "longitude"),
-                np.full((1, 2, 3), humidity, dtype="float64"),
-            ),
-        },
-        coords={
-            "timestamp": [np.datetime64(timestamp, "ns")],
-            "latitude": [50.0, 51.0],
-            "longitude": [7.0, 8.0, 9.0],
-        },
-        attrs={"title": "Weather observations"},
-    )
-    dataset.to_netcdf(output / f"weather_{index:02d}.nc")
-PY
+python scripts/generate_sample_data.py
 ```
-
-Firecube's installation includes NumPy, xarray, and NetCDF support used by this
-script.
 
 ## Verify The Source Data
 
 List the generated files:
 
 ```bash
-ls quickstart-data/weather-netcdf
+ls sample_data
 ```
 
 Expected output:
 
 ```text
-weather_01.nc  weather_02.nc  weather_03.nc  weather_04.nc
+sample01.nc  sample02.nc  sample03.nc  sample04.nc
 ```
 
-Each file contains one timestamp on the same 2 by 3 latitude-longitude grid.
-The ingestion command passes their parent directory to the plugin.
+Each file contains one timestamp of `temperature_c` and `humidity_pct` on the
+same 2 by 3 latitude-longitude grid. The ingestion command passes their parent
+directory to the plugin.
 
 ## Next Steps
 
 - **[Run Ingestion](ingestion.md)**: convert the four NetCDF files into one
-  local Zarr product.
-- **[NetCDF To Zarr tutorial](../tutorials/weather-netcdf.md)**: inspect the
-  matching plugin implementation and dataset transformation.
+  local Zarr product and inspect it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,7 @@ nav:
   - Quickstart:
     - Overview: quickstart/index.md
     - Installation: quickstart/installation.md
-    - Create and Install the Example Plugin: quickstart/plugins.md
+    - Install the Example Plugin: quickstart/plugins.md
     - Prepare Source Data: quickstart/source-data.md
     - Run Ingestion: quickstart/ingestion.md
   - Plugin Development:


### PR DESCRIPTION
<!--
Thanks for contributing to Firecube. Please read CONTRIBUTING.md first.
Keep pull requests focused: one logical change per PR.
-->

## What changed

Update to the documentation to include the firecube-quickstart plugin. 

## Why

Closes #64 

## Affected behavior

<!-- Which user, operator, plugin, or maintainer behavior changes? -->

- User / CLI: 
- Plugin authors:
- Operators / production:
- Stored formats or control-plane state:

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (CLI flags, plugin contract, config, or stored format)
- [x] Documentation
- [ ] CI / build / chore

## Checks run

<!-- Tick what you ran; paste anything notable. -->

- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `uv run pyright`
- [ ] `uv run --with bandit bandit -c pyproject.toml -r src scripts -lll`
- [ ] `uv run pytest --strict-deps -m "not slow and not s3" -q`
- [x] Docs build (if docs changed): `uv run mkdocs build --strict`

## Follow-up work

tutorial section needs adaptation after removing the weather-netcdf plugin. 

## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [x] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
