### PR TITLE
perf(controlplane): bound stale-sweep enumeration to O(N + S) via tar geted reads (fixes #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,15 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 
 ### Fixed
 
+- Concurrent multi-process ingests no longer crash at startup with
+  `ControlPlaneCorruptionError` ("Expecting value: line 1 column 1") when one
+  process's resume guard lists runs while a peer is writing its `run.json`:
+  run metadata is now published through a new atomic-replace filesystem
+  primitive (`AtomicWriter.replace_atomic`; temp file + rename locally, a
+  single whole-body PUT on object stores), and the WAL reader skips a
+  zero-byte `run.json` with no segments as an in-flight peer write instead of
+  raising.
+
 - `firecube zarr compare` and `compare_zarr_stores` no longer crash with an
   IndexError on stores containing a zero-dimensional array (for example a CF
   grid-mapping scalar such as `spatial_ref`); scalar values are now compared
@@ -196,6 +205,14 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
   and datetime fills are skipped to keep array metadata valid strict JSON and
   the stores openable by xarray. Resuming into an existing store backfills the
   attribute once.
+
+- Bulk stale-sweep operations (`abandon_stale_runs`, `clear_stale_claims`)
+  no longer re-list the full runs/ or claims/ directory once per stale item.
+  Each mutation-time re-check is now a targeted per-item read. On S3, the
+  cost of a sweep with `S` stale items over a product with `N` total items
+  drops from `O(N × S)` object reads to `O(N + S)`. Behavior is unchanged
+  (race semantics, orphan-handling, and partial-abandon crash recovery are
+  all preserved). Fixes #26.
 
 ### Security
 

--- a/docs/reference/core-utilities.md
+++ b/docs/reference/core-utilities.md
@@ -91,6 +91,9 @@ Zarr stores and returns `ZarrCompareReport`.
 
 ::: firecube.core.api.normalize_epoch_iso
 
+`coerce_to_epoch_s()` is documented with the direct-Zarr index types in
+[Index Specification](parallelism.md).
+
 ## Reserved Array Attributes
 
 ::: firecube.core.api.RESERVED_ARRAY_ATTRS
@@ -116,19 +119,6 @@ Zarr stores and returns `ZarrCompareReport`.
 ::: firecube.core.api.ZarrCompareReport
 
 ::: firecube.core.api.compare_zarr_stores
-
-## Ingestor Re-Exports
-
-The ingestor facade re-exports the same attribute guards for plugin code.
-
-::: firecube.ingestor.api.RESERVED_ARRAY_ATTRS
-
-::: firecube.ingestor.api.assert_attrs_safe
-
-::: firecube.ingestor.api.FIRECUBE_STATIC_WRITTEN_ATTR
-
-`coerce_to_epoch_s()` is documented with the direct-Zarr index types in
-[Index Specification](parallelism.md).
 
 ## See Also
 

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -77,20 +77,6 @@ All three inherit from `ConfigurationError`.
 
 ::: firecube.ingestor.api.IndexedWriteCompilationError
 
-## Core API Re-Exports
-
-The core facade re-exports the error types used by plugin code and the engine.
-
-::: firecube.core.api.ExtentUnknownError
-
-::: firecube.core.api.MissingIrregularCoordinateError
-
-::: firecube.core.api.DuplicateIrregularCoordinateError
-
-::: firecube.core.api.NoDiscoveredItemsError
-
-::: firecube.core.api.IndexedWriteCompilationError
-
 ## See Also
 
 - [Templates](templates.md)

--- a/docs/reference/parallelism.md
+++ b/docs/reference/parallelism.md
@@ -20,33 +20,9 @@ This reference covers the public types used to declare and resolve direct-Zarr i
     "resolve_index_spec",
 ]) }}
 
-## Core API
+## Index Types
 
-::: firecube.core.api.AxisSpec
-
-::: firecube.core.api.IndexSpec
-
-::: firecube.core.api.IntegerAxis
-
-::: firecube.core.api.IrregularTimeAxis
-
-::: firecube.core.api.AUTO
-
-::: firecube.core.api.RegularTimeAxis
-
-::: firecube.core.api.ItemInfo
-
-::: firecube.core.api.ResolvedIndex
-
-::: firecube.core.api.ResolvedIndexRecord
-
-::: firecube.core.api.coerce_to_epoch_s
-
-::: firecube.core.api.resolve_index_spec
-
-## Ingestor Re-Exports
-
-The public ingestor facade re-exports the declarative types used by plugin code.
+Import these from `firecube.ingestor.api`.
 
 ::: firecube.ingestor.api.AxisSpec
 
@@ -67,6 +43,13 @@ The public ingestor facade re-exports the declarative types used by plugin code.
 ::: firecube.ingestor.api.ResolvedIndexRecord
 
 ::: firecube.ingestor.api.resolve_index_spec
+
+## Core API
+
+`coerce_to_epoch_s()` is exported from `firecube.core.api` only; the ingestor
+facade does not re-export it.
+
+::: firecube.core.api.coerce_to_epoch_s
 
 ## Resolved Index Behavior
 

--- a/docs/reference/templates.md
+++ b/docs/reference/templates.md
@@ -138,8 +138,6 @@ For parallel writes across disjoint slot ranges, see
 
 ::: firecube.ingestor.api.IndexedWrite
 
-::: firecube.core.api.IndexedWrite
-
 ## See Also
 
 - [Plugin Development Overview](../guides/plugins/index.md)

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -1,5 +1,60 @@
 # Done
 
+## 2026-08-25 — Stale-sweep fan-out fix (Issue #26)
+
+`abandon_stale_runs` and `clear_stale_claims` each re-enumerated the full runs or claims directory once per candidate found during the sweep. With N candidates and S stale entries, the re-check loop cost O(N × S) directory listings. Under a 4900-run product with 20 stale entries, that meant 20 extra full-directory scans per sweep call. This wave replaces every re-enumeration with a targeted single-file read, reducing the total listing cost to O(N + S).
+
+A secondary fan-out existed in `_get_run_entry`: it called `_list_run_entries` (O(N)) to locate a single run directory. A new `run_dir_for` helper derives the path directly from the run ID, cutting that call to O(1).
+
+`clear_claim` internals also enumerated the claims directory to find the claim file before deleting it. Targeted path derivation via `read_claim_by_domain` eliminates that listing too.
+
+### What
+
+**T1 — pin read_run_entry semantics** (`f422ee2`): Added `tests/unit/test_wal_reader_read_run_entry.py` to characterize `WalReader.read_run_entry` behavior for missing, malformed, and orphan run directories. Establishes the contract the targeted-read helpers depend on.
+
+**T2 — add run_dir_for helper** (`c8e99e5`): Added `run_dir_for(product_uri, run_id)` pure function to `src/firecube/core/controlplane/repo.py`. Derives the run directory path directly from the run ID without listing the parent directory. Used by `_get_run_entry` (T8) and the re-check paths (T9, T10).
+
+**T3 — add read_claim_by_domain** (`1c80955`): Added `ManifestRepository.read_claim_by_domain(domain)` wrapping the existing `_read_claim` helper. Returns the claim record for a single domain without enumerating the claims directory. Used by the `clear_stale_claims` re-check (T10).
+
+**T4 — bound abandon_stale_runs enumeration (RED)** (`b0531be`): Added `CountingFilesystem`-based bound test for `abandon_stale_runs` asserting runs-dir list calls stay at O(N + S). Fails until T9 lands.
+
+**T5 — bound clear_stale_claims enumeration (RED)** (`d7a860b`): Added `CountingFilesystem`-based bound test for `clear_stale_claims` asserting claims-dir list calls stay at O(N + S). Fails until T10 lands.
+
+**T7 — orphan run-directory behavior lock** (`94b6792`): Added `tests/unit/test_bulk_abandon_stale_runs.py` characterization tests for orphan run directories (directory present, `run.json` absent). Confirms sweep behavior is preserved through the targeted-read refactor.
+
+**T8 — _get_run_entry targeted read** (`2ec3e46`): Rewired `ManifestRepository._get_run_entry` to call `run_dir_for` + `read_run_entry` instead of `_list_run_entries`. Eliminates the O(N) scan per single-run lookup.
+
+**T9 — abandon_stale_runs re-check** (`726cc6f`): Replaced the `_list_run_entries` re-enumeration inside `abandon_stale_runs` with a `read_run_entry` call via `run_dir_for`. The re-check now reads one file. Fixes #26 for the runs sweep path. T4 bound test turns green.
+
+**T10 — clear_stale_claims re-check + clear_claim fix** (`ab4b97b`): Replaced the claims-directory re-enumeration inside `clear_stale_claims` with `read_claim_by_domain`. Also replaced the per-claim directory listing inside `clear_claim` with targeted path derivation + `fs.rm`. Fixes #26 for the claims sweep path. T5 bound test turns green.
+
+**T12 — concurrent operators idempotent** (`7edbc8d`): Added `tests/unit/test_bulk_abandon_stale_runs.py` concurrency test confirming two simultaneous `--all-stale` operators produce no errors and leave the store consistent. Heartbeat refresh, terminal transition, and deletion-by-other-operator are all covered.
+
+**T13 — partial-abandon crash recovery** (`08533f0`): Added test confirming that a crash mid-sweep leaves the store in a state where a re-run completes cleanly. No batch semantics were introduced; each record is processed independently.
+
+Note: the snapshot path was excluded from this scope after code inspection confirmed `_snapshot.py` has only one enumeration call, not two. The full remedy for the snapshot cost belongs to the LSM active-run index tracked under IDEAS.md §16.
+
+### Guardrails preserved
+
+- **DESIGN §11** (one container == one run): unchanged.
+- **DESIGN §27** (derived read models): upheld. `_RunEntriesCache` lifetime unchanged; no new persistent state in `.firecube/`.
+- **Public API stability**: no changes to `list_runs`, `list_claims`, `abandon_stale_runs`, `clear_stale_claims`, or `_get_run_entry` signatures. `AbandonSweepResult` and `ClearSweepResult` dataclass fields unchanged.
+- **Race semantics**: heartbeat refresh, terminal transition, and deletion-by-other-operator all still caught (T9/T10 with updated monkeypatch targets, T12).
+- **Orphan run-directory behavior**: preserved (T7 characterization + T8 preservation).
+- **Partial-abandon crash recovery**: preserved. No batch semantics introduced (T13).
+- **Snapshot path untouched**: `git diff --stat src/firecube/core/controlplane/_snapshot.py` shows no changes.
+
+### Verification
+
+- `uv run pytest --strict-deps tests/unit/test_bulk_abandon_stale_runs.py tests/unit/test_bulk_clear_stale_claims.py tests/unit/test_wal_reader_read_run_entry.py tests/unit/test_filesystem_claim_service_read_by_domain.py tests/unit/test_run_dir_for.py -q` — 33 passed.
+- `uv run ruff check .` clean; `uv run ruff format --check .` clean; `uv run pyright` 0 errors on changed files.
+- **Cost reduction**: `CountingFilesystem` bound tests confirm enumeration bounded by O(N + S), down from O(N × S). With N=20, S=10: runs-dir list calls dropped from 21 to at most 2; claims-dir list calls dropped from 21 to at most 2.
+
+### Follow-up
+
+- **IDEAS.md §16** — Wave 2 (LSM active-run marker + completed-slots bitmap) still UNDECIDED. The `_snapshot.py` single-enumeration bullet and `resume_guard.py` bitmap remain OPEN.
+- **IDEAS.md §17** — Wave 3 (terminal run pruning + auto-rebuild) still UNDECIDED, blocked on Wave 2.
+
 ## 2026-08-24 — Milestone D — Optional cleanup
 
 ### What
@@ -1883,3 +1938,4 @@ commit ef771cc). This entry closes the §19 remainder.
   principle). Ref: internal plan `normalize-string-vars-cf-attrs-refinement`.
 
 **Confidence:** HIGH
+

--- a/plans/IDEAS.md
+++ b/plans/IDEAS.md
@@ -230,6 +230,13 @@ File upstream at `https://github.com/ecmwf/tensogram` if Phase 1 implementation 
   - Wave 1 memoization foundation: commit `7847254` (`perf(resume-guard): memoize run-entry scan`).
   - DESIGN.md §27 (derived read-model doctrine).
 
+- **Related work**: Issue #26 Wave 1.5 (DONE.md 2026-08-25) reduced sweep-time
+  enumeration cost in `abandon_stale_runs`, `clear_stale_claims`, and
+  `_get_run_entry` via targeted per-run/per-claim reads. The
+  `_snapshot.py:136` bullet above and the `resume_guard.py:405-410`
+  bitmap remain OPEN — the full remedy for the snapshot cost still
+  belongs to this Wave 2 design.
+
 ### §17 — Wave 3: terminal run pruning + auto-rebuild triggers
 
 - UNDECIDED / DEFERRED (until Wave 2 lands)

--- a/src/firecube/cli/_rename_hints.py
+++ b/src/firecube/cli/_rename_hints.py
@@ -14,7 +14,7 @@
 
 """Click rename-hint layer.
 
-Augments :class:`click.NoSuchOption` errors with a navigation hint when the
+Augments `click.NoSuchOption` errors with a navigation hint when the
 user types a flag that was renamed in the strict-URI refactor.
 
 This is NOT a deprecation alias - the old flag still errors out. It is a UX
@@ -64,7 +64,7 @@ def build_command_path(ctx: click.Context | None) -> tuple[str, ...]:
     """Build a dotted command path from a Click context chain.
 
     Excludes the root context (whose ``info_name`` is the program name -
-    ``"firecube"`` in production, ``"cli"`` under :class:`click.testing.CliRunner`).
+    ``"firecube"`` in production, ``"cli"`` under `click.testing.CliRunner`).
     For ``firecube archive restore`` the returned tuple is ``("archive", "restore")``.
     """
     if ctx is None:
@@ -98,7 +98,7 @@ _INSTALLED_FLAG = "_firecube_rename_hints_installed"
 
 
 def install_rename_hints() -> None:
-    """Monkey-patch :meth:`click.Command.parse_args` once to inject rename hints.
+    """Monkey-patch `click.Command.parse_args` once to inject rename hints.
 
     Subsequent calls are no-ops (idempotent). Safe to call from any module init.
     """

--- a/src/firecube/cli/archive.py
+++ b/src/firecube/cli/archive.py
@@ -16,12 +16,11 @@
 
 Archive subcommands distinguish two URI categories:
 
-* **Source/target Zarr products** are resolved via
-  :class:`firecube.core.product.resolver.ProductResolver` and feed a
-  :class:`firecube.core.storage.session.StorageSession` so that driver,
-  endpoint, and credential resolution happen at the CLI boundary.
+* **Source/target Zarr products** are resolved via `ProductResolver` and feed
+  a `StorageSession` so that driver, endpoint, and credential resolution
+  happen at the CLI boundary.
 * **`.tgm` artifact files** are *not* products. They are external archive
-  files and use raw :class:`firecube.core.storage.uri.StorageUri` only —
+  files and use raw `StorageUri` only —
   product resolvers MUST NOT be used for them. ``info``/``validate``/``list``
   operate on artifacts only and never construct a session.
 """

--- a/src/firecube/core/controlplane/_paths.py
+++ b/src/firecube/core/controlplane/_paths.py
@@ -1,0 +1,53 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure control-plane path derivations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from firecube.core.controlplane.types import RUNS_DIRNAME
+from firecube.core.storage.uri import StorageUri
+
+
+def _validate_run_id(run_id: str) -> str:
+    candidate = str(run_id)
+    if not candidate:
+        raise ValueError("run_id must be non-empty")
+
+    segments = candidate.split("/")
+    if any(segment == "" for segment in segments):
+        raise ValueError("run_id must be a single path segment")
+    if any(segment in {".", ".."} for segment in segments):
+        raise ValueError("run_id must not contain path traversal segments")
+    return candidate
+
+
+def run_dir_for(
+    resolver: Callable[[str], tuple[StorageUri, StorageUri]],
+    product: str,
+    run_id: str,
+) -> tuple[StorageUri, str]:
+    """Return the run directory and run URI for ``product`` and ``run_id``.
+
+    The derivation is pure. It performs no filesystem I/O. ``run_id`` must be a
+    single path segment, so ``/``, ``.`` and ``..`` path components are rejected.
+    """
+
+    control_path, control_uri = resolver(product)
+    safe_run_id = _validate_run_id(run_id)
+    run_dir = control_path.join(RUNS_DIRNAME).join(safe_run_id)
+    run_uri = control_uri.join(RUNS_DIRNAME, safe_run_id).to_str()
+    return run_dir, run_uri

--- a/src/firecube/core/controlplane/_wal_reader.py
+++ b/src/firecube/core/controlplane/_wal_reader.py
@@ -202,11 +202,21 @@ class WalReader:
         segment_paths = self.list_run_segment_paths(run_dir)
 
         if self._fs.exists(meta_uri):
+            raw: str | None = None
             try:
                 with self._fs.open(meta_uri, "r") as handle:
-                    payload = json.load(handle)
+                    raw = str(handle.read())
+                payload = json.loads(raw)
             except Exception:
                 if not segment_paths:
+                    if raw is not None and not raw.strip():
+                        # A zero-byte run.json with no WAL segments is a peer's
+                        # first meta write still in flight (stores written
+                        # before meta writes became atomic), not corruption: an
+                        # instant earlier the file did not exist and this
+                        # reader would have returned None.
+                        self.log.debug("Skipping pending run meta at %s", meta_uri.to_str())
+                        return None
                     raise
                 return self.build_orphan_run_entry(
                     product=product,

--- a/src/firecube/core/controlplane/_wal_writer.py
+++ b/src/firecube/core/controlplane/_wal_writer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""WAL write collaborator for :mod:`firecube.core.controlplane.repo`."""
+"""WAL write collaborator for `ManifestRepository`."""
 
 from __future__ import annotations
 

--- a/src/firecube/core/controlplane/claims.py
+++ b/src/firecube/core/controlplane/claims.py
@@ -217,27 +217,42 @@ class FilesystemClaimService:
         """List stale claims for one product."""
         return [claim for claim in self.list_claims(product=product) if claim.stale]
 
-    def clear_claim(self, *, product: str, domain_id: str, force: bool = False) -> bool:
-        """Delete a claim file; refuses non-stale claims unless force=True."""
+    def read_claim_by_domain(self, *, product: str, domain: str) -> ClaimInfo | None:
+        """Return the claim for a canonical write-domain identifier, if present.
+
+        Uses targeted claim-name derivation to avoid listing the claims directory.
+        Raises ControlPlaneCorruptionError on malformed JSON.
+        """
+        domain_product, category, name = domain.split(":", 2)
+        if domain_product != product:
+            msg = f"claim domain {domain!r} does not belong to product {product!r}"
+            raise ValueError(msg)
         control_path, _control_uri = self._control_root_resolver(product)
         claims_dir = control_path.join(CLAIMS_DIRNAME)
-        try:
-            entries = self._fs.ls(claims_dir, detail=False)  # type: ignore[attr-defined]
-        except Exception:
+        claim_name = WriteDomain(product=domain_product, category=category, name=name).claim_name
+        return self._read_claim(product=product, claim_path=claims_dir.join(claim_name))
+
+    def clear_claim(self, *, product: str, domain_id: str, force: bool = False) -> bool:
+        """Delete a claim file; refuses non-stale claims unless force=True."""
+        domain_product, category, name = domain_id.split(":", 2)
+        if domain_product != product:
+            msg = f"claim domain {domain_id!r} does not belong to product {product!r}"
+            raise ValueError(msg)
+        control_path, _control_uri = self._control_root_resolver(product)
+        claims_dir = control_path.join(CLAIMS_DIRNAME)
+        claim_path = claims_dir.join(
+            WriteDomain(product=domain_product, category=category, name=name).claim_name
+        )
+        info = self._read_claim(product=product, claim_path=claim_path)
+        if info is None:
             return False
-        for entry in entries:
-            claim_path = _entry_to_uri(entry, claims_dir)
-            info = self._read_claim(product=product, claim_path=claim_path)
-            if info is None or info.domain != domain_id:
-                continue
-            if not force and not info.stale:
-                raise ClaimConflictError(
-                    f"Refusing to clear active claim {domain_id}; rerun with --force to override."
-                )
-            with suppress(FileNotFoundError):
-                self._fs.rm(claim_path, recursive=False)
-            return True
-        return False
+        if not force and not info.stale:
+            raise ClaimConflictError(
+                f"Refusing to clear active claim {domain_id}; rerun with --force to override."
+            )
+        with suppress(FileNotFoundError):
+            self._fs.rm(claim_path, recursive=False)
+        return True
 
     def _list_products(self) -> set[str]:
         products: set[str] = set()

--- a/src/firecube/core/controlplane/deletion.py
+++ b/src/firecube/core/controlplane/deletion.py
@@ -440,9 +440,8 @@ class DeletionEngine:
         """Delete Zarr concrete chunks from spans.
 
         ``time_dim_name`` is an explicit operator-supplied time dimension; see
-        :func:`firecube.core.controlplane.time_dim.resolve_span_time_dims` for
-        how it combines with the dim name recorded in span specs and
-        discovered from the timestamp-state array.
+        `resolve_span_time_dims` for how it combines with the dim name
+        recorded in span specs and discovered from the timestamp-state array.
         """
         from firecube.core.zarr.validation import read_chunk_grid
 

--- a/src/firecube/core/controlplane/events.py
+++ b/src/firecube/core/controlplane/events.py
@@ -214,6 +214,9 @@ class RunEventWriter:
         if self._slot_group is not None:
             payload["slot_group"] = self._slot_group
 
-        with self._fs.open(self._run_meta_uri, "w") as handle:
-            json.dump(payload, handle, separators=(",", ":"))
+        # Atomic replace: peer pods list runs (resume guard) while this run is
+        # live, and a plain open("w") exposes a 0-byte run.json between
+        # truncate and json.dump.
+        run_meta_bytes = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self._fs.atomic_writer.replace_atomic(self._run_meta_uri, run_meta_bytes)
         self._last_meta_write = time.time()

--- a/src/firecube/core/controlplane/manager.py
+++ b/src/firecube/core/controlplane/manager.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from firecube.core.config import StorageConfig
+from firecube.core.controlplane._paths import run_dir_for
 from firecube.core.controlplane.deletion import DeletionEngine
 from firecube.core.controlplane.repo import ManifestRepository
 from firecube.core.controlplane.types import (
@@ -547,7 +548,7 @@ class ChunkManager:
         Used by ``ResumeGuard`` for overlap detection and by operators for
         coverage diagnostics.
 
-        Inherits the active-span dedupe from :meth:`list_chunks`: during a
+        Inherits the active-span dedupe from `list_chunks`: during a
         force-reingest in-flight window, only the highest-``run_id`` active
         span per slice contributes to the per-group totals, so coverage is
         not double-counted.
@@ -724,23 +725,25 @@ class ChunkManager:
 
         Between preview (``list_stale_claims``) and mutation (``clear_claim``),
         a live pod could refresh a previously stale claim or another operator
-        could delete it. Each mutation re-reads the current state via
-        ``list_claims`` and only clears domains that remain stale AND present;
-        live claims are never forcibly overridden. Errors are collected
-        per-claim, and the sweep continues past any single-claim race.
+        could delete it. Each mutation re-reads the current domain directly and
+        only clears domains that remain stale AND present; live claims are never
+        forcibly overridden. Errors are collected per-claim, and the sweep
+        continues past any single-claim race.
         """
         result = ClearSweepResult()
         stale = self.list_stale_claims(product=product)
         result.previewed = [claim.domain for claim in stale]
         if dry_run:
             return result
+        if self.repo.claims is None:
+            self.repo._ensure_bound()
+        assert self.repo.claims is not None
         for claim in stale:
-            fresh = self.list_claims(product=product)
-            current = next((c for c in fresh if c.domain == claim.domain), None)
+            current = self.repo.claims.read_claim_by_domain(product=product, domain=claim.domain)
             if current is None:
                 result.skipped_missing.append(claim.domain)
                 continue
-            if not current.stale:
+            if current.last_heartbeat_at != claim.last_heartbeat_at or not current.stale:
                 result.skipped_fresh.append(claim.domain)
                 continue
             try:
@@ -926,8 +929,8 @@ class ChunkManager:
 
         Between preview (``list_stale_runs``) and mutation (``abandon_run``), a
         live pod could refresh the run's heartbeat or the run could reach a
-        terminal status. Each mutation re-reads the current state via
-        ``list_runs`` and only abandons runs that remain stale AND non-terminal.
+        terminal status. Each mutation re-reads the current run entry and only
+        abandons runs that remain stale AND non-terminal.
         Runs already terminal are recorded as ``skipped_already_terminal``;
         runs whose heartbeat refreshed are recorded as ``skipped_fresh``. The
         sweep continues past any single-run race so one live pod cannot block
@@ -938,10 +941,22 @@ class ChunkManager:
         result.previewed = [run.run_id for run in stale]
         if dry_run:
             return result
+        self.repo._ensure_bound()
+        assert self.repo._resolver is not None
+        assert self.repo._wal_reader is not None
         for run in stale:
-            fresh = self.list_runs(product=product)
-            current = next((r for r in fresh if r.run_id == run.run_id), None)
-            if current is None or current.is_terminal:
+            run_dir, run_uri = run_dir_for(self.repo._resolver, product, run.run_id)
+            current_entry = self.repo._wal_reader.read_run_entry(
+                product=product,
+                run_dir=run_dir,
+                run_uri=run_uri,
+                run_id=run.run_id,
+            )
+            if current_entry is None:
+                result.skipped_already_terminal.append(run.run_id)
+                continue
+            current = self.repo._run_info_from_entry(product, current_entry)
+            if current.is_terminal:
                 result.skipped_already_terminal.append(run.run_id)
                 continue
             if not current.stale:
@@ -968,7 +983,7 @@ class ChunkManager:
         Returns ``None`` when the on-disk ``current.json`` is missing. Other
         I/O errors propagate. ``ManifestError`` propagates on corruption (the
         on-disk record's identity-hash cross-check is enforced by
-        :meth:`SlotIndexModelRecord.from_json_bytes`).
+        `SlotIndexModelRecord.from_json_bytes`).
         """
         control_root_uri = self.repo.get_control_root_uri(product)
         _fs, control_root = self.repo._get_fs(control_root_uri)
@@ -992,7 +1007,7 @@ class ChunkManager:
         """Negotiate the slot-index model for ``product``, returning the persisted record.
 
         Acquires the ``slot_index_model:current`` write claim and dispatches into
-        :meth:`_apply_slot_model_precedence`. Loser threads (``ClaimConflictError``)
+        `_apply_slot_model_precedence`. Loser threads (``ClaimConflictError``)
         inspect full convergence: ``current.json`` AND the zarr root identity-hash
         attribute must both match the declared model before the loser emits
         ``EVENT_SLOT_INDEX_MODEL_VERIFIED`` and returns. CP-only match is the race
@@ -1328,7 +1343,7 @@ def check_legacy_index_record(
     carries ``.firecube/slot_index/current.json`` but has not yet produced the
     ``.firecube/index/current.json`` resolved-index record. Called at ``DirectZarrIngestor``
     pod startup and by ``firecube zarr preallocate`` BEFORE any
-    :meth:`ChunkManager.ensure_resolved_index` call so a legacy cube cannot be
+    `ChunkManager.ensure_resolved_index` call so a legacy cube cannot be
     silently overwritten by a fresh resolved-index stamp.
 
     Presence check only: the legacy payload is never trusted for policy. Fresh

--- a/src/firecube/core/controlplane/repo.py
+++ b/src/firecube/core/controlplane/repo.py
@@ -34,6 +34,7 @@ from firecube.core.controlplane._helpers import (
 from firecube.core.controlplane._helpers import (
     open_controlplane_fs_cached as _open_controlplane_fs_cached,
 )
+from firecube.core.controlplane._paths import run_dir_for
 from firecube.core.controlplane._projection import ManifestProjection
 from firecube.core.controlplane._snapshot import (
     read_latest_pointer,
@@ -753,10 +754,15 @@ class ManifestRepository:
         return self._projection._run_info_from_entry(product, payload)
 
     def _get_run_entry(self, *, product: str, run_id: str) -> dict[str, Any]:
-        for entry in self._list_run_entries(product):
-            if str(entry.get("run_id", "")) == run_id:
-                return entry
-        raise ManifestError(f"Run '{run_id}' not found for product '{product}'.")
+        self._ensure_bound()
+        assert self._wal_reader is not None and self._resolver is not None
+        run_dir, run_uri = run_dir_for(self._resolver, product, run_id)
+        entry = self._wal_reader.read_run_entry(
+            product=product, run_dir=run_dir, run_uri=run_uri, run_id=run_id
+        )
+        if entry is None:
+            raise ManifestError(f"Run '{run_id}' not found for product '{product}'.")
+        return entry
 
     def _assert_compaction_allowed(self, product: str) -> None:
         claims = self.list_claims(product=product)

--- a/src/firecube/core/controlplane/types.py
+++ b/src/firecube/core/controlplane/types.py
@@ -126,7 +126,7 @@ class ItemManifestEntry:
             depends on the axis kind (ISO string, integer, etc.). Must be
             JSON-native (``str``, ``int``, ``float``, ``bool``, ``None``);
             non-native values will fail loudly at
-            :func:`canonical_index_bytes` serialisation.
+            `canonical_index_bytes` serialisation.
         source_ref: A stable reference the caller can dereference to load the
             item at write time. Interpretation is fixed by ``source_ref_kind``.
             Must be non-empty.
@@ -225,7 +225,7 @@ def compute_resolved_index_identity_hash(
         items: Optional manifest entries. Accepts either
             ``ItemManifestEntry`` instances (canonicalised via
             ``entry.to_canonical_dict()``) or already-canonicalised dicts
-            (as produced by :meth:`ResolvedIndexRecord.from_json_bytes`).
+            (as produced by `ResolvedIndexRecord.from_json_bytes`).
 
     Returns:
         Lowercase-hex SHA-256 digest (64 characters).
@@ -570,8 +570,8 @@ class ResolvedIndexRecord:
     Optional ``items`` carries a content-addressed manifest for
     ``IrregularTimeAxis`` cubes. It is omitted from the wire format and
     ``identity_hash`` for regular / integer axes so those cubes stay
-    byte-identical to pre-manifest records (see
-    :func:`compute_resolved_index_identity_hash`).
+    byte-identical to pre-manifest records
+    (see `compute_resolved_index_identity_hash`).
     """
 
     schema_version: str = "v1"
@@ -596,7 +596,7 @@ class ResolvedIndexRecord:
         """Serialise to the on-disk wire format (deterministic, UTF-8 JSON).
 
         ASYMMETRIC: the ``items`` key is omitted when
-        :attr:`items` is ``None`` so records for regular / integer axes serialise
+        `items` is ``None`` so records for regular / integer axes serialise
         byte-identically to pre-manifest records.
         """
 
@@ -748,7 +748,7 @@ class SlotIndexModelRecord:
 
         After parsing, this recomputes ``model.identity_hash`` from the embedded
         model payload and asserts it equals the stored ``identity_hash`` field.
-        On mismatch it raises :class:`ManifestError` with a message containing
+        On mismatch it raises `ManifestError` with a message containing
         ``"identity-hash mismatch"`` and both the stored and recomputed values.
 
         The cross-check ensures corrupt or tampered records are rejected before

--- a/src/firecube/core/filesystem/fsspec_backend.py
+++ b/src/firecube/core/filesystem/fsspec_backend.py
@@ -73,11 +73,11 @@ class FsspecAtomicWriter:
       with ``FileExistsError`` if the target already exists, preserving the
       create-if-not-exists contract.
 
-    Per the :class:`~firecube.core.filesystem.protocol.AtomicWriter` contract,
-    backend-specific "already exists" signals are normalized to
-    ``FileExistsError``: local raises ``errno EEXIST``; s3fs wraps the 412 as
+    Per the `AtomicWriter` contract, backend-specific "already exists" signals
+    are normalized to ``FileExistsError``: local raises ``errno EEXIST``;
+    s3fs wraps the 412 as
     ``OSError(EINVAL)`` with a botocore ``ClientError`` cause (matched by
-    :func:`_is_precondition_failed`). Without this translation the control-plane
+    `_is_precondition_failed`). Without this translation the control-plane
     claim layer never observes ``FileExistsError`` on S3, so ``ClaimConflictError``
     is never raised and concurrent pods crash at startup instead of converging
     (see ``ChunkManager.ensure_slot_index_model``).
@@ -100,6 +100,36 @@ class FsspecAtomicWriter:
             if getattr(exc, "errno", None) == errno.EEXIST or _is_precondition_failed(exc):
                 raise FileExistsError(str(uri)) from exc
             raise
+
+    def replace_atomic(self, uri: StorageUri, data: bytes) -> None:
+        """Atomic overwrite-or-create (see `AtomicWriter`).
+
+        - Local filesystem: write a sibling temp file, fsync it, then
+          ``os.replace`` it into place — the rename publishes the fully-written
+          inode over the old one in a single step, so a concurrent reader sees
+          the old or the new content, never a truncated file. A plain
+          ``open(path, "w")`` would truncate in place and expose a 0-byte
+          window (observed as ``ControlPlaneCorruptionError`` "Expecting
+          value: ... char 0" when peer pods list runs during a meta write).
+        - Remote object stores: a buffered ``"wb"`` write emits one whole-body
+          ``PutObject`` on close, which the store publishes atomically.
+        """
+        path = self._to_path(uri)
+        if self._is_local():
+            directory = os.path.dirname(path) or "."
+            fd, tmp = tempfile.mkstemp(dir=directory, prefix=".firecube-atomic-", suffix=".tmp")
+            try:
+                with os.fdopen(fd, "wb") as fh:
+                    fh.write(data)
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                os.replace(tmp, path)
+            finally:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp)
+            return
+        with self._fs.open(path, "wb") as fh:
+            fh.write(data)
 
     def _is_local(self) -> bool:
         proto = getattr(self._fs, "protocol", None)

--- a/src/firecube/core/filesystem/obstore_backend.py
+++ b/src/firecube/core/filesystem/obstore_backend.py
@@ -320,6 +320,16 @@ class ObstoreAtomicWriter:
         except _obstore_compat.AlreadyExistsError as exc:
             raise FileExistsError(uri.to_str()) from exc
 
+    def replace_atomic(self, uri: StorageUri, data: bytes) -> None:
+        """Atomic overwrite-or-create (see `AtomicWriter`).
+
+        Default-mode ``put`` is atomic on every obstore backend: object stores
+        publish a whole-body PUT all-or-nothing, and the local backend stages
+        to a temp file and renames it into place.
+        """
+        rel_path = ObstoreFilesystem._test_resolve_path(uri, self._store_prefix)
+        self._store.put(rel_path, data)
+
 
 def _store_prefix_for(binding: StorageBinding) -> str:
     uri = binding.identity.product_uri

--- a/src/firecube/core/filesystem/protocol.py
+++ b/src/firecube/core/filesystem/protocol.py
@@ -70,6 +70,17 @@ class AtomicWriter(Protocol):
         """
         ...
 
+    def replace_atomic(self, uri: StorageUri, data: bytes) -> None:
+        """Atomic overwrite-or-create. A concurrent reader MUST observe either
+        the previous content or the new content in full — never a truncated,
+        empty, or partially-written object.
+
+        Implementations MUST use backend-native atomicity primitives (e.g. a
+        temp file published via rename locally, a single whole-body PUT on
+        object stores). They MUST NOT truncate the destination in place.
+        """
+        ...
+
 
 @runtime_checkable
 class MultipartUploader(Protocol):

--- a/src/firecube/core/index_resolve.py
+++ b/src/firecube/core/index_resolve.py
@@ -353,8 +353,9 @@ def _resolver_for(axis: AxisSpec) -> AxisResolver:
 class ResolvedIndex:
     """A resolved, immutable index for a multi-group DirectZarr product.
 
-    Built by ``resolve_index_spec``; cached per ``(id(ctx._ctx), spec)``
-    on the ``DirectZarrIngestor`` instance.
+    Built by ``resolve_index_spec`` and cached per run context and spec on
+    the ``DirectZarrIngestor`` instance, so repeated lookups within a run
+    return the same object.
 
     The ``identity_hash`` is content-addressed from the canonical
     resolved-index payload. It intentionally does not track the legacy
@@ -538,7 +539,7 @@ def resolve_index_spec(
     """Resolve an ``IndexSpec`` into a ``ResolvedIndex``.
 
     Validates that each ``RegularTimeAxis.coordinate`` matches
-    ``time_dim_name``. Builds per-group resolvers via ``_resolver_for``.
+    ``time_dim_name``, then builds one resolver per group.
 
     Args:
         spec: The index specification to resolve.
@@ -554,7 +555,7 @@ def resolve_index_spec(
         NotImplementedError: If any axis kind is not supported.
 
     Examples:
-        >>> from firecube.core.index_spec import IndexSpec, RegularTimeAxis
+        >>> from firecube.core.api import IndexSpec, RegularTimeAxis
         >>> axis = RegularTimeAxis(
         ...     coordinate="timestamp",
         ...     epoch="2024-01-01T00:00:00Z",

--- a/src/firecube/core/indexed_write.py
+++ b/src/firecube/core/indexed_write.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Coordinate-keyed indexed write intent for :class:`DirectZarrIngestor`.
+"""Coordinate-keyed indexed write intent for `DirectZarrIngestor`.
 
-Defines :class:`IndexedWrite`, a frozen dataclass produced by
-``DirectZarrIngestor.build_indexed_write()``. Lives in ``firecube.core``
+Defines `IndexedWrite`, a frozen dataclass produced by
+``DirectZarrIngestor.build_indexed_write()``.  Lives in ``firecube.core``
 so both the ``firecube.core.api`` and ``firecube.ingestor.api`` façades
 can re-export it without violating the core-below-ingestor layering rule
 enforced by ``tests/architecture/test_core_independence.py``.
 
-The compile step from :class:`IndexedWrite` to :class:`WriteIntent` is
+The compile step from `IndexedWrite` to `WriteIntent` is
 ingestor-owned and stays in ``firecube.ingestor.templates.direct_zarr``.
 """
 
@@ -44,8 +44,8 @@ class IndexedWrite:
     time against the plugin's declared ``IndexSpec``, then materializes an
     equivalent ``WriteIntent``.
 
-    Use the :meth:`region` classmethod for 2-D spatial region writes and
-    :meth:`slot` for 1-D per-slot writes. These are the only two builders by
+    Use the `region` classmethod for 2-D spatial region writes and
+    `slot` for 1-D per-slot writes. These are the only two builders by
     design — there is intentionally no ``.static()`` or ``.coordinate()``
     factory:
 
@@ -81,15 +81,15 @@ class IndexedWrite:
     """
 
     y_slice: slice | None = None
-    """Row slice within the array; required for :meth:`region`, ``None`` for :meth:`slot`."""
+    """Row slice within the array; required for `region`, ``None`` for `slot`."""
 
     channel_index: int | None = None
-    """Channel dimension index for :meth:`region` writes, ``None`` otherwise."""
+    """Channel dimension index for `region` writes, ``None`` otherwise."""
 
     _kind: str = "region"
     """Private discriminator selecting region vs slot compile behavior.
 
-    Set by the :meth:`region` / :meth:`slot` classmethods. Not part of the
+    Set by the `region` / `slot` classmethods. Not part of the
     public constructor contract — pass builders, not raw kwargs.
     """
 
@@ -130,7 +130,7 @@ class IndexedWrite:
                 non-channel arrays.
 
         Returns:
-            An :class:`IndexedWrite` with ``_kind="region"``.
+            An `IndexedWrite` describing a 2-D spatial region write.
 
         Examples:
             >>> import numpy as np
@@ -178,7 +178,7 @@ class IndexedWrite:
             data: 1-D array payload, or a zero-arg callable that returns it.
 
         Returns:
-            An :class:`IndexedWrite` with ``_kind="slot"``.
+            An `IndexedWrite` describing a 1-D per-slot write.
 
         Examples:
             >>> import numpy as np

--- a/src/firecube/core/observability/logging.py
+++ b/src/firecube/core/observability/logging.py
@@ -22,7 +22,7 @@ from opentelemetry import trace
 
 
 class JsonFormatter(logging.Formatter):
-    """Emit log records as a single JSON line via :func:`json.dumps`.
+    """Emit log records as a single JSON line via `json.dumps`.
 
     Replaces the previous hand-formatted JSON template which interpolated
     record fields directly into a format string and therefore failed to

--- a/src/firecube/core/observability/metrics.py
+++ b/src/firecube/core/observability/metrics.py
@@ -251,7 +251,7 @@ class TelemetryService:
     ) -> None:
         """Emit the ``index_ensured`` telemetry event.
 
-        Fires once per :meth:`ChunkManager.ensure_resolved_index` call from
+        Fires once per `ChunkManager.ensure_resolved_index` call from
         DirectZarr startup or ``firecube zarr index rebuild``. The counter value is
         always 1; the interesting content is the ``meta`` payload. Multi-value
         ``axis_kinds`` and ``groups`` are joined with commas so Prometheus labels

--- a/src/firecube/core/slot_index.py
+++ b/src/firecube/core/slot_index.py
@@ -27,7 +27,7 @@ Stability rules:
   is always serialised as ``"time_unit":null``.
  ``identity_hash`` is never embedded inside the hashed payload.
  Epoch normalisation is the explicit responsibility of
-  :func:`normalize_epoch_iso`; ``canonical_bytes()`` does NOT silently mutate
+  `normalize_epoch_iso`; ``canonical_bytes()`` does NOT silently mutate
   the stored epoch string. ``"Z"`` and ``"+00:00"`` therefore deliberately
   produce different hashes -- callers that want them to converge must
   normalise the epoch before constructing the model.
@@ -83,7 +83,7 @@ class SlotIndexModel:
         name: Human-readable identifier for the model (e.g. ``"opera_v1"``).
         epoch: ISO-8601 UTC anchor (e.g. ``"2026-01-01T00:00:00Z"``); used as
             the origin from which slot indices are counted.
-        groups: Per-group :class:`SlotAxis` mapping; at least one entry.
+        groups: Per-group `SlotAxis` mapping; at least one entry.
         time_unit: Optional storage-precision hint
             (e.g. ``"seconds"``, ``"milliseconds"``); ``None`` is permitted
             and is serialised as JSON ``null``.
@@ -114,7 +114,7 @@ class SlotIndexModel:
         * ``json.dumps(..., sort_keys=True, separators=(",", ":"))`` is used so
           that whitespace and key order are stable across runs and platforms.
         * ``time_unit=None`` is serialised as JSON ``null``.
-        * The output does NOT contain :attr:`identity_hash` -- the hash is
+        * The output does NOT contain `identity_hash` -- the hash is
           computed over the canonical bytes, not stored inside them.
         """
 
@@ -134,9 +134,9 @@ class SlotIndexModel:
 
     @property
     def identity_hash(self) -> str:
-        """SHA-256 hex digest of :meth:`canonical_bytes`.
+        """SHA-256 hex digest of `canonical_bytes`.
 
-        Two :class:`SlotIndexModel` instances are considered equivalent
+        Two `SlotIndexModel` instances are considered equivalent
         partitioning schemes iff their ``identity_hash`` values match.
         """
 
@@ -148,7 +148,7 @@ def iso_to_epoch_s(iso: str) -> int:
 
     Only UTC inputs are accepted. The trailing ``"Z"`` or the explicit
     ``"+00:00"`` offset are both honoured; any other offset raises
-    :class:`ValueError`. Numpy is imported lazily so that ``slot_index`` stays
+    `ValueError`. Numpy is imported lazily so that ``slot_index`` stays
     cheap to import for code paths that never touch the epoch helpers.
     """
 
@@ -195,7 +195,7 @@ def normalize_epoch_iso(iso: str) -> str:
     """Round-trip an ISO-8601 UTC string through ``epoch_s`` and back to ``"...Z"``.
 
     Equivalent to ``epoch_s_to_iso(iso_to_epoch_s(iso))``; raises
-    :class:`ValueError` for non-UTC inputs via :func:`iso_to_epoch_s`.
+    `ValueError` for non-UTC inputs via `iso_to_epoch_s`.
     """
 
     return epoch_s_to_iso(iso_to_epoch_s(iso))

--- a/src/firecube/core/zarr/region_writer.py
+++ b/src/firecube/core/zarr/region_writer.py
@@ -21,7 +21,7 @@ or the auto-computation in ``IndexedRegionStrategy``.
 
 Extracted from the MTG FCI plugin's ``ZarrStoreWriter``; all sensor-specific
 logic has been removed.  Use ``coord_names`` to specify which array names are
-coordinate axes and should be skipped by :meth:`ensure_timestamp_slot`.
+coordinate axes and should be skipped by `ensure_timestamp_slot`.
 """
 
 from __future__ import annotations
@@ -90,7 +90,7 @@ def _array_is_all_fill(arr: np.ndarray, fill_value: Any) -> bool:
     """Return True iff every element of *arr* equals *fill_value* under
     missing-aware equality.
 
-    Mirrors :func:`_fill_value_is_missing` semantics:
+    Mirrors `_fill_value_is_missing` semantics:
       - float / complex NaN fill: every element must be NaN
       - datetime64 / timedelta64 NaT fill: every element must be NaT
       - all other dtypes (int, bool, bytes/string): plain element-wise equality
@@ -238,9 +238,57 @@ class RegionZarrWriterProtocol(Protocol):
         filters: Sequence[Any] | None = None,
         serializer: Any | None = None,
         compressors: Sequence[Any] | None = None,
-    ) -> Any: ...
+    ) -> Any:
+        """Ensure a group or array path exists, creating it when absent.
 
-    def ensure_timestamp_slot(self, group: str, ts_index: int) -> None: ...
+        A single-segment *group* with no *shape* resolves to a group. Any
+        other path resolves to an array, and *shape* and *dtype* are then
+        required. Existing arrays are returned as-is unless *allow_grow* is
+        set, in which case they are resized up to *shape*.
+
+        Args:
+            group: Group path or array path (e.g. ``data_1km/counts``).
+            shape: Array shape when creating array paths.
+            dtype: Array dtype when creating array paths.
+            fill_value: Fill value for newly created arrays.
+            chunks: Chunk shape for newly created arrays.
+            allow_grow: If ``True``, grow an existing array to at least
+                *shape* instead of leaving it undersized.
+            shards: Optional Zarr v3 shard shape for newly created arrays.
+            attrs: Optional user attributes written at array creation.
+                Reserved keys (see `RESERVED_ARRAY_ATTRS`) are rejected.
+                This is creation-only: attribute drift on existing arrays is
+                reported by `verify_array_spec`, not here.
+            dimension_names: Optional Zarr v3 ``dimension_names`` for newly
+                created arrays.
+            filters: Optional Zarr v3 filter chain for newly created arrays.
+            serializer: Optional Zarr v3 serializer for newly created arrays.
+            compressors: Optional Zarr v3 compressor chain for newly created
+                arrays.
+
+        Returns:
+            The existing or newly created group or array.
+
+        Raises:
+            ValueError: If array creation is requested without *shape* and
+                *dtype*, or if *attrs* contains reserved keys.
+            SchemaDriftError: If *dimension_names* differs from an existing
+                array's ``dimension_names`` on resume. Firecube performs no
+                in-place dimension renames.
+        """
+        ...
+
+    def ensure_timestamp_slot(self, group: str, ts_index: int) -> None:
+        """Ensure every timestamped array in *group* can hold *ts_index*.
+
+        Coordinate arrays and scalar arrays are skipped; only arrays carrying
+        a leading time axis are checked or grown.
+
+        Args:
+            group: Data group path (e.g. ``data_1km``).
+            ts_index: Zero-based timestamp index that must be addressable.
+        """
+        ...
 
     def write_region(
         self,
@@ -251,7 +299,22 @@ class RegionZarrWriterProtocol(Protocol):
         data: np.ndarray,
         *,
         channel_index: int | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Write one spatial region into one timestamp slot.
+
+        Args:
+            group: Data group path.
+            array_name: Target array name inside *group*.
+            ts_index: Timestamp slot index to write into.
+            y_slice: Spatial y-range covered by *data*.
+            data: Region payload; its shape must match the addressed window.
+            channel_index: Channel index for 4-D arrays; ``None`` for 3-D.
+
+        Raises:
+            ValueError: If the target array rank is unsupported or *data*
+                does not match the addressed window.
+        """
+        ...
 
     def write_1d(
         self,
@@ -259,23 +322,87 @@ class RegionZarrWriterProtocol(Protocol):
         array_name: str,
         ts_index: int,
         data: np.ndarray,
-    ) -> None: ...
+    ) -> None:
+        """Write exactly one timestamp slot.
 
-    def resolve_timestamp_index(self, group: str, timestamp_val: Any) -> int: ...
+        For a 1-D target the slot is the single element at *ts_index* and
+        *data* must hold exactly one value. For a higher-rank target the slot
+        is ``arr[ts_index]`` and *data* must match ``arr.shape[1:]``.
+        Multi-slot payloads are rejected: the control plane records writes at
+        ``(group, ts_index)`` granularity, so a wider write would leave an
+        unrecorded data-integrity gap.
+
+        Args:
+            group: Data group path.
+            array_name: Target array name.
+            ts_index: Timestamp slot index.
+            data: The single value to write at the slot.
+
+        Raises:
+            ValueError: If a 1-D target receives a payload with ``size != 1``,
+                or a higher-rank target receives a payload whose shape does
+                not match ``arr.shape[1:]``.
+        """
+        ...
+
+    def resolve_timestamp_index(self, group: str, timestamp_val: Any) -> int:
+        """Return the slot index *timestamp_val* occupies in *group*.
+
+        Resolution is idempotent: a timestamp already present in the group's
+        time coordinate resolves to its existing index, so a replayed write
+        lands on the same slot. An unseen timestamp resolves to the next
+        available slot, which equals the current coordinate length.
+
+        Args:
+            group: Data group path.
+            timestamp_val: Timestamp to place, in any form the implementation
+                normalizes to the group's time dtype.
+
+        Returns:
+            The zero-based slot index for *timestamp_val*.
+        """
+        ...
 
     def write_timestamp(
         self,
         group: str,
         ts_index: int,
         timestamp_val: Any,
-    ) -> None: ...
+    ) -> None:
+        """Write the time coordinate value for one slot.
+
+        Grows the time coordinate and every timestamped array in *group* as
+        needed so *ts_index* is addressable before the value is stored.
+
+        Args:
+            group: Data group path.
+            ts_index: Timestamp slot index to stamp.
+            timestamp_val: Timestamp to write at that slot.
+        """
+        ...
 
     def write_static(
         self,
         group: str,
         array_name: str,
         data: np.ndarray,
-    ) -> None: ...
+    ) -> None:
+        """Write a static (non-time-indexed) array at its declared shape.
+
+        The array must already exist from schema setup. The write is a full
+        overwrite of the array contents and touches no time axis.
+
+        Args:
+            group: Data group path.
+            array_name: Target array name.
+            data: Payload with the same ndim and shape as the stored array.
+
+        Raises:
+            KeyError: If the array does not exist in the store.
+            ValueError: If ``data.ndim`` or ``data.shape`` does not match the
+                stored array.
+        """
+        ...
 
 
 class RegionZarrWriter:
@@ -285,7 +412,7 @@ class RegionZarrWriter:
         store_uri: Target store URI/path (local path, ``file://`` URI, or
             ``s3://`` URI).
         coord_names: Array names treated as coordinate axes.  These are
-            skipped by :meth:`ensure_timestamp_slot` when resizing timestamped
+            skipped by `ensure_timestamp_slot` when resizing timestamped
             arrays.  Defaults to ``{"y", "x", "channel"}``.
     """
 
@@ -356,14 +483,12 @@ class RegionZarrWriter:
                 inspect undersized arrays and raise their own drift errors.
             shards: Optional Zarr v3 shard shape for newly created arrays.
             attrs: Optional user attributes to write at array creation.
-                Reserved keys (see
-                :data:`firecube.core.zarr._reserved_attrs.RESERVED_ARRAY_ATTRS`)
-                are rejected. ``ensure_group`` is creation-only — drift
-                detection for the attrs of existing arrays is handled by
-                :meth:`verify_array_spec`.
+                Reserved keys (see `RESERVED_ARRAY_ATTRS`) are rejected.
+                ``ensure_group`` is creation-only — drift detection for the
+                attrs of existing arrays is handled by `verify_array_spec`.
             dimension_names: Optional Zarr v3 ``dimension_names`` for newly
                 created arrays. On resume, a mismatch against an existing
-                array raises :class:`SchemaDriftError`; firecube does not
+                array raises `SchemaDriftError`; firecube does not
                 perform in-place dimension renames.
 
         Returns:
@@ -453,7 +578,7 @@ class RegionZarrWriter:
 
         Writes ``attrs`` verbatim onto the Zarr group's ``zarr.json``; the writer
         does not interpret the mapping. Reserved firecube-internal attribute names
-        are rejected (see :func:`assert_attrs_safe`). A falsy ``attrs`` is a no-op.
+        are rejected (see `assert_attrs_safe`). A falsy ``attrs`` is a no-op.
         Idempotent — re-stamping the same attrs is safe.
         """
         if not attrs:

--- a/src/firecube/ingestor/contracts/interfaces.py
+++ b/src/firecube/ingestor/contracts/interfaces.py
@@ -134,9 +134,33 @@ class SourceFile(Protocol):
 class Ingestor(Protocol):
     """Protocol defining the core contract for an ingestor."""
 
-    def run(self, ctx: IngestContext) -> IngestResult: ...
+    def run(self, ctx: IngestContext) -> IngestResult:
+        """Execute a full ingest run and return its result.
 
-    def ingest(self, ctx: IngestContext) -> IngestResult: ...
+        This is the top-level orchestration entry point: it opens the run in
+        the control plane, drives batching and writes, and closes the run in a
+        terminal state. Framework-owned — plugin authors implement the hooks
+        it calls, not this method.
+
+        Args:
+            ctx: Resolved run context: source, target, storage binding, and
+                effective options.
+
+        Returns:
+            The run outcome, including output paths and run-level metrics.
+        """
+        ...
+
+    def ingest(self, ctx: IngestContext) -> IngestResult:
+        """Perform the ingest work for *ctx* without run-level orchestration.
+
+        Args:
+            ctx: Resolved run context.
+
+        Returns:
+            The ingest outcome.
+        """
+        ...
 
 
 class PipelineHost(Protocol):
@@ -157,24 +181,77 @@ class PipelineHost(Protocol):
     ) -> Mapping[str, Any]: ...
 
     # Lifecycle hooks called by PipelineRunner
-    def on_pipeline_start(self, ctx: PluginContext, state: PipelineRunState) -> None: ...
+    def on_pipeline_start(self, ctx: PluginContext, state: PipelineRunState) -> None:
+        """Called once on the main thread before any batch runs.
+
+        The place for shared resource setup that must happen before the first
+        write (a persistent database schema, a warmed cache). Raising here
+        aborts the run before any batch is attempted.
+
+        Args:
+            ctx: Plugin-facing run context.
+            state: Snapshot of run state at start, including the effective
+                worker count and batch size.
+        """
+        ...
+
     def on_batch_success(
         self,
         ctx: PluginContext,
         state: PipelineRunState,
         batch: PipelineBatch,
         result: PipelineResult,
-    ) -> None: ...
+    ) -> None:
+        """Called on the main thread after each successful batch.
+
+        Never called from a worker thread, so implementations may touch
+        non-thread-safe state. The engine records the batch's control-plane
+        span here; a hook failure is logged as a bookkeeping error and does
+        not demote the batch to a failure.
+
+        Args:
+            ctx: Plugin-facing run context.
+            state: Run state as of this batch.
+            batch: The batch that completed.
+            result: The batch outcome, including its metrics and outputs.
+        """
+        ...
+
     def on_batch_failure(
         self,
         ctx: PluginContext,
         state: PipelineRunState,
         batch: PipelineBatch,
         result: PipelineResult,
-    ) -> None: ...
-    def finalize_pipeline(
-        self, ctx: RuntimeIngestContext, state: PipelineRunState
-    ) -> IngestResult: ...
+    ) -> None:
+        """Called on the main thread after each failed batch.
+
+        The engine records the failure against the batch's control-plane span
+        here. A hook failure is logged and does not mask the original error.
+
+        Args:
+            ctx: Plugin-facing run context.
+            state: Run state as of this batch.
+            batch: The batch that failed.
+            result: The batch outcome; ``result.error`` carries the cause.
+        """
+        ...
+
+    def finalize_pipeline(self, ctx: RuntimeIngestContext, state: PipelineRunState) -> IngestResult:
+        """Assemble the run result after the last batch has been processed.
+
+        Framework-owned — it delegates to the pipeline executor. Plugins
+        aggregate their own numbers through the metrics hooks instead.
+
+        Args:
+            ctx: Runtime run context.
+            state: Final accumulated run state.
+
+        Returns:
+            The run outcome reported to the caller.
+        """
+        ...
+
     def _process_batch(self, batch: PipelineBatch, ctx: PluginContext) -> PipelineResult: ...
     def _resolve_time_dim_name(self) -> str:
         """Resolve the firecube time-dim coordinate name for this ingestor.

--- a/src/firecube/ingestor/extensions/_binning.py
+++ b/src/firecube/ingestor/extensions/_binning.py
@@ -17,8 +17,8 @@
 A *binner* maps irregular ``(lat, lon)`` input samples onto a 1-D **target
 axis** of cells, recording for each usable input point the integer position of
 its target cell. Aggregation then scatters values onto that axis. This pattern
-is grid-agnostic: a regular lat/lon grid (:mod:`.grid`) and a HEALPix grid
-(:mod:`.healpix`) differ only in how the axis and the point->position mapping
+is grid-agnostic: a regular lat/lon grid (`grid`) and a HEALPix grid
+(`healpix`) differ only in how the axis and the point->position mapping
 are computed, not in how values are aggregated.
 
 The target axis can be **derived from the data** or **supplied explicitly** by
@@ -80,7 +80,7 @@ def aggregate_by_position(
         position: For each kept point, the target-axis index in
             ``[0, n_targets)``.
         n_targets: Length of the output axis.
-        aggregation: One of :data:`AGGREGATIONS`. ``any`` returns a ``uint8``
+        aggregation: One of `AGGREGATIONS`. ``any`` returns a ``uint8``
             presence mask; all others return ``float32`` with ``NaN`` in empty
             cells.
     """

--- a/src/firecube/ingestor/extensions/duck.py
+++ b/src/firecube/ingestor/extensions/duck.py
@@ -72,6 +72,13 @@ class DuckDbMixin:
 
     @property
     def con(self) -> duckdb.DuckDBPyConnection:
+        """This thread's DuckDB connection.
+
+        Raises:
+            RuntimeError: If accessed outside a batch, i.e. before
+                ``batch_setup`` has opened a connection on this thread or
+                after ``batch_teardown`` has closed it.
+        """
         if not hasattr(self._db_local, "con"):
             raise RuntimeError("DuckDB connection not initialized for this thread")
         return self._db_local.con
@@ -112,6 +119,22 @@ class DuckDbMixin:
             del self._db_local.con
 
     def batch_setup(self, ctx: PluginContext) -> None:
+        """Open this thread's connection and prepare its schema.
+
+        Uses an in-memory database unless the run opts into
+        ``duckdb_persist_batches``, in which case each worker gets its own
+        file under the run's temp workspace. Calls the
+        ``prepare_duckdb_schema`` hook, then cooperates with the MRO so
+        stacked mixins keep their own setup.
+
+        Args:
+            ctx: Plugin-facing run context supplying the effective options.
+
+        Raises:
+            Exception: Whatever ``prepare_duckdb_schema`` raises, after
+                logging. Schema failure aborts the batch rather than leaving a
+                half-prepared connection in use.
+        """
         # Memory vs persist decision:
         #   ctx.in_memory=True  → always use in-memory (test mode or explicit flag).
         #   ctx.in_memory=False → default to in-memory unless duckdb_persist_batches=true,
@@ -142,6 +165,13 @@ class DuckDbMixin:
             super_setup(ctx)
 
     def batch_teardown(self, ctx: PluginContext) -> None:
+        """Close and discard this thread's connection.
+
+        Cooperates with the MRO so stacked mixins keep their own teardown.
+
+        Args:
+            ctx: Plugin-facing run context, passed on to the next teardown.
+        """
         self.teardown_duckdb()
         # Optional by design: if no parent hook exists in the MRO, this is a no-op.
         super_teardown = getattr(super(), "batch_teardown", None)

--- a/src/firecube/ingestor/extensions/grid.py
+++ b/src/firecube/ingestor/extensions/grid.py
@@ -29,8 +29,8 @@ Design notes
   half-cell edges around centers, so all centers correspond to a real cell.
   This fixes the common off-by-one and "extra empty last row/col" issues that
   arise when treating centers as edges.
-- The binning/aggregation core is shared with :mod:`.healpix` via
-  :mod:`._binning`. Performance: mean/min/max/first/last/any are vectorized;
+- The binning/aggregation core is shared with `healpix` via
+  `_binning`. Performance: mean/min/max/first/last/any are vectorized;
   median is supported but may be expensive on large grids.
 """
 

--- a/src/firecube/ingestor/extensions/healpix.py
+++ b/src/firecube/ingestor/extensions/healpix.py
@@ -16,19 +16,19 @@
 
 These helpers bin irregular ``(lat, lon, value)`` samples onto a HEALPix
 discrete global grid system (DGGS) without interpolation. They are the
-spherical sibling of :mod:`firecube.ingestor.extensions.grid`: where that module
-bins onto a regular lat/lon grid, this one bins onto equal-area HEALPix cells.
-Both share the binning/aggregation core in :mod:`._binning`.
+spherical sibling of `grid`: where that module bins onto a regular lat/lon
+grid, this one bins onto equal-area HEALPix cells.
+Both share the binning/aggregation core in `_binning`.
 
 Design notes
 ------------
-- The lat/lon -> cell mapping is delegated to :mod:`healpix_geo` (built on the
+- The lat/lon -> cell mapping is delegated to `healpix_geo` (built on the
   ``cdshealpix`` Rust crate). ``healpix_geo`` is the same backend ``xdggs`` uses,
   so cells produced here align with ``xdggs``-decoded HEALPix cubes at the same
   ``depth`` and ``ellipsoid``.
 - ``depth`` is the HEALPix order/level; the sphere has ``12 * 4**depth`` cells.
 - The target cell axis can be **derived** from the input (the unique cells it
-  touches) or **supplied** via ``target_cells`` -- e.g. from :func:`cells_in_bbox`
+  touches) or **supplied** via ``target_cells`` -- e.g. from `cells_in_bbox`
   -- so every granule/timestep lands on one fixed axis and results can be
   appended. The result carries the absolute cell ids as a coordinate.
 - Aggregations mean/min/max/first/last/median mirror the lat/lon module; ``any``

--- a/src/firecube/ingestor/runtime/base.py
+++ b/src/firecube/ingestor/runtime/base.py
@@ -360,6 +360,11 @@ class BaseIngestor(BaseIngestorHookMixin, Ingestor, ABC):
 
     @property
     def batch_id_prefix(self) -> str:
+        """Prefix applied to every batch ID this ingestor produces.
+
+        Derived from the ingestor's ``name`` so batch IDs stay attributable to
+        their plugin in logs, metrics, and control-plane records.
+        """
         return f"{self.name}_"
 
     def discover_source_files(self, ctx: PluginContext) -> Iterable[Any]:

--- a/src/firecube/ingestor/runtime/coverage.py
+++ b/src/firecube/ingestor/runtime/coverage.py
@@ -16,8 +16,8 @@
 
 Extracted from the MTG FCI plugin as a generic runtime utility.
 Accumulates per-group writes, tracks time bounds, merges contiguous
-index ranges, and produces :class:`SpanCoverage` objects compatible
-with :meth:`SpanRecorder.record_batch_success`.
+index ranges, and produces `SpanCoverage` objects compatible
+with `SpanRecorder.record_batch_success`.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ from firecube.core.controlplane.types import SpanCoverage
 class CoverageTracker:
     """Collect per-group write coverage entries for span recording.
 
-    Coverage entries emitted by :meth:`build_coverage` follow the schema
+    Coverage entries emitted by `build_coverage` follow the schema
     expected by ingestion runtime span extraction.
     """
 
@@ -155,7 +155,7 @@ class CoverageTracker:
                 entry; falls back to the tracker's constructor value.
 
         Returns:
-            List of :class:`SpanCoverage` objects, one per recorded group.
+            List of `SpanCoverage` objects, one per recorded group.
         """
         effective_dim = time_dim_name or self._time_dim_name
         coverage: list[SpanCoverage] = []

--- a/src/firecube/ingestor/runtime/engine.py
+++ b/src/firecube/ingestor/runtime/engine.py
@@ -129,7 +129,7 @@ class _PipelineRunAccumulator:
 
         ``cpu_time_total``/``io_time_total`` override the per-batch sums when
         provided. The final run snapshot passes a single process-wide CPU
-        measurement (see :meth:`PipelineRunner.run_state`); interim snapshots
+        measurement (see `PipelineRunner.run_state`); interim snapshots
         used by lifecycle hooks fall back to the per-batch accumulation.
         """
         return PipelineRunState(
@@ -161,7 +161,7 @@ def _process_batch_timed(
     Per-batch ``cpu_time_s`` uses ``time.thread_time()`` (this thread only) and
     is a diagnostic lower bound — it misses CPU spent in shared dask/C-extension
     worker threads. The authoritative run-level CPU total is measured separately
-    over the whole processing window in :meth:`PipelineRunner.run_state`.
+    over the whole processing window in `PipelineRunner.run_state`.
     """
     start_wall = time.perf_counter()
     start_cpu = time.thread_time()

--- a/src/firecube/ingestor/runtime/recording.py
+++ b/src/firecube/ingestor/runtime/recording.py
@@ -347,8 +347,8 @@ def _coverage_from_nested_mapping(metrics: Any) -> Any | None:
 
     Checks the batch-level top-level ``coverage`` key first, then the run-level
     ``zarr.coverage`` / ``pipeline.coverage`` nested locations that
-    :func:`merge_batch_metrics` and the pipeline summary populate. Works for
-    both plain dicts and the mapping-compatible :class:`ResultMetrics`.
+    `merge_batch_metrics` and the pipeline summary populate. Works for
+    both plain dicts and the mapping-compatible `ResultMetrics`.
     """
     coverage = metrics.get("coverage")
     if coverage:

--- a/src/firecube/ingestor/runtime/workspace.py
+++ b/src/firecube/ingestor/runtime/workspace.py
@@ -46,12 +46,23 @@ class LocalSourceFile:
 
     @property
     def uri(self) -> str:
+        """The file's absolute ``file://`` URI."""
         return self._path.as_uri()
 
     def open(self) -> IO[bytes]:
+        """Open the file for seekable binary reading.
+
+        Returns:
+            An open binary handle the caller is responsible for closing.
+        """
         return self._path.open("rb")
 
     def local_path(self) -> Path | None:
+        """Return the resolved local path.
+
+        Always a path for this implementation; the protocol allows ``None``
+        for sources that are not cheaply available on local disk.
+        """
         return self._path
 
 

--- a/src/firecube/ingestor/runtime/zarr/contracts.py
+++ b/src/firecube/ingestor/runtime/zarr/contracts.py
@@ -33,7 +33,22 @@ class AppendWriteStrategy(Protocol):
         dataset_for_batch: Callable[[str, Sequence[Any]], xr.Dataset | None],
         batch_size: int,
         claim_for_group: Callable[[str], Any] | None = None,
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        """Append each group's timestamps to the store and report metrics.
+
+        Args:
+            group_to_timestamps: Timestamps to append, keyed by group path.
+                Order within a group is the order they are appended in.
+            dataset_for_batch: Called as ``(group, timestamps)`` to build the
+                dataset for one append. Returning ``None`` skips that batch.
+            batch_size: Maximum number of timestamps per append call.
+            claim_for_group: Called as ``(group)`` to obtain a write claim
+                guarding that group. ``None`` writes without coordination.
+
+        Returns:
+            Write metrics for the call, merged across all groups.
+        """
+        ...
 
 
 @runtime_checkable
@@ -57,4 +72,27 @@ class RegionWriteStrategy(Protocol):
         slot_group: str | None = None,
         codec_pipelines_by_array: Mapping[tuple[str, str], tuple[Any, Any, Any]] | None = None,
         region_write_concurrency: int = 1,
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        """Dispatch each group's write intents into the store and report metrics.
+
+        Args:
+            group_to_intents: Write intents to dispatch, keyed by group path.
+            schema: Array specs used for schema setup and drift checks.
+                ``None`` writes against the store as it already stands.
+            claim_for_group: Called as ``(group)`` to obtain a write claim. It
+                guards schema setup when *claim_for_slot* is also given, and
+                the whole dispatch otherwise.
+            claim_for_slot: Called as ``(group, ts_index)`` to obtain a
+                per-slot write claim guarding intent dispatch.
+            slot_range: Half-open ``(start, stop)`` slot window this caller
+                owns. ``None`` accepts every slot the intents address.
+            slot_group: Group whose slots *slot_range* applies to.
+            codec_pipelines_by_array: Per-array ``(filters, serializer,
+                compressors)`` overrides, keyed by ``(group, array_name)``.
+            region_write_concurrency: Maximum region writes in flight at once;
+                ``1`` writes serially.
+
+        Returns:
+            Write metrics for the call, merged across all groups.
+        """
+        ...

--- a/src/firecube/ingestor/runtime/zarr/strategies/append.py
+++ b/src/firecube/ingestor/runtime/zarr/strategies/append.py
@@ -52,12 +52,12 @@ def _session_for_store(store_uri: str, storage_config: StorageConfig) -> Storage
 class AppendStrategy:
     """Xarray-append write strategy for Zarr stores.
 
-    Wraps :func:`~firecube.ingestor.runtime.zarr.append.append_time_groups`
+    Wraps `append_time_groups`
     behind the ``AppendWriteStrategy`` Protocol so that
     ``GenericZarrIngestor`` can treat append and region writes uniformly.
 
     All static configuration is captured at construction time; only
-    per-batch dynamic inputs are passed to :meth:`write_groups`.
+    per-batch dynamic inputs are passed to `write_groups`.
     """
 
     def __init__(

--- a/src/firecube/ingestor/runtime/zarr/strategies/indexed_region.py
+++ b/src/firecube/ingestor/runtime/zarr/strategies/indexed_region.py
@@ -149,6 +149,38 @@ class IndexedRegionStrategy:
         static_owner_slot_start: int | None = None,
         zarr_write_empty_chunks: bool = False,
     ) -> dict[str, Any]:
+        """Dispatch write intents into the store under a scoped Zarr config.
+
+        Implements `RegionWriteStrategy.write_groups` and adds the DirectZarr
+        knobs: static-write ownership and the ``write_empty_chunks`` setting,
+        which is applied only for the duration of this call so it cannot leak
+        into other Zarr operations in the same process.
+
+        Args:
+            group_to_intents: Write intents to dispatch, keyed by group path.
+            schema: Array specs used for schema setup and drift checks.
+            claim_for_group: Called as ``(group)`` to obtain a write claim
+                guarding schema setup.
+            claim_for_slot: Called as ``(group, ts_index)`` to obtain a
+                per-slot write claim guarding intent dispatch.
+            slot_range: Half-open ``(start, stop)`` slot window this caller
+                owns. ``None`` accepts every slot the intents address.
+            slot_group: Group whose slots *slot_range* applies to.
+            codec_pipelines_by_array: Per-array ``(filters, serializer,
+                compressors)`` overrides, keyed by ``(group, array_name)``.
+            region_write_concurrency: Maximum region writes in flight at once.
+            suppress_static_emission_for_non_owner: Skip static write intents
+                unless this caller owns them, so parallel pods do not all
+                rewrite the same static arrays.
+            static_owner_slot_start: Slot start of the pod that owns static
+                writes, compared against this run's own slot start.
+            zarr_write_empty_chunks: Whether to persist chunks holding only
+                fill values. ``False`` keeps sparse arrays compact.
+
+        Returns:
+            Write metrics for the call, including
+            ``zarr_write_empty_chunks_effective``.
+        """
         with _array_write_empty_chunks_config(zarr_write_empty_chunks):
             result = self._write_groups_unscoped(
                 group_to_intents=group_to_intents,
@@ -1020,7 +1052,7 @@ class IndexedRegionStrategy:
           read, so first writes stay O(1) in store reads.
         - marker present → committed previously: the incoming data must replay
           the identical bytes (NaN/NaT-aware via ``equal_nan=True``), else
-          :class:`SchemaDriftError`. Re-writing is skipped on an exact match.
+          `SchemaDriftError`. Re-writing is skipped on an exact match.
         """
         arr_path = f"{intent.group}/{intent.array}"
         # callable() is the right duck-type check; typing.Callable would treat

--- a/src/firecube/ingestor/templates/config.py
+++ b/src/firecube/ingestor/templates/config.py
@@ -133,7 +133,7 @@ class TemplateConfig:
     ``ZarrTemplateConfig`` for ``GenericZarrIngestor``); the dataclass
     fields of that class become the validated, typed options accepted for
     the template. Instances are built from raw caller options via
-    :meth:`from_options`, which rejects unknown keys and coerces values to
+    `from_options`, which rejects unknown keys and coerces values to
     the annotated field types.
     """
 

--- a/src/firecube/ingestor/templates/direct_zarr.py
+++ b/src/firecube/ingestor/templates/direct_zarr.py
@@ -580,13 +580,13 @@ class WriteIntent:
         Use this for 1-D arrays that grow along the time axis — per-slot
         scalars, per-slot vectors, or any array where each slot contributes
         one row. The array must be declared with ``time_indexed=True`` in
-        :class:`ZarrArraySpec`.
+        `ZarrArraySpec`.
 
         ``data`` must be an eager ``np.ndarray``; callable payloads are not
         supported for ``kind="1d"`` and raise ``TypeError`` at construction.
 
         Args:
-            group: Zarr group name matching a :class:`ZarrGroupSpec` in the schema.
+            group: Zarr group name matching a `ZarrGroupSpec` in the schema.
             array: Array name within the group.
             index: Time-slot index for this write.
             data: Array data to write at this slot.
@@ -619,13 +619,13 @@ class WriteIntent:
 
         Use this for the main image arrays — counts, radiances, quality flags,
         pixel times — where each slot contributes a spatial tile. The array
-        must be declared with ``time_indexed=True`` in :class:`ZarrArraySpec`.
+        must be declared with ``time_indexed=True`` in `ZarrArraySpec`.
 
         ``data`` may be an eager ``np.ndarray`` or a zero-arg callable
         ``Callable[[], np.ndarray]``; the callable is resolved at dispatch time.
 
         Args:
-            group: Zarr group name matching a :class:`ZarrGroupSpec` in the schema.
+            group: Zarr group name matching a `ZarrGroupSpec` in the schema.
             array: Array name within the group.
             index: Time-slot index for this write.
             data: 2-D array data, or a callable that returns it.
@@ -665,7 +665,7 @@ class WriteIntent:
         coordinate array so the output cube is self-describing.
 
         Args:
-            group: Zarr group name matching a :class:`ZarrGroupSpec` in the schema.
+            group: Zarr group name matching a `ZarrGroupSpec` in the schema.
             index: Time-slot index for this coordinate.
             value: The coordinate value for this slot — typically a
                 ``datetime``, ``numpy.datetime64``, or integer. Must not be
@@ -704,20 +704,20 @@ class WriteIntent:
         Use this for arrays that are the same across every time slot: latitude/
         longitude grids, channel names, calibration tables, spatial references.
         The array must be declared with ``time_indexed=False`` in
-        :class:`ZarrArraySpec`; the engine pre-creates it at its declared shape
+        `ZarrArraySpec`; the engine pre-creates it at its declared shape
         during schema setup.
 
         **Write-once contract**: the engine writes the array on the first ingest
         run and stamps a marker attribute. On any subsequent run (resume or
         re-ingest) the incoming data must be byte-identical to what was already
-        written, or the ingest fails with :class:`SchemaDriftError`. There is no
+        written, or the ingest fails with `SchemaDriftError`. There is no
         partial-update path for static arrays.
 
         ``data`` may be an eager ``np.ndarray`` or a zero-arg callable
         ``Callable[[], np.ndarray]``; the callable is resolved at dispatch time.
 
         Args:
-            group: Zarr group name matching a :class:`ZarrGroupSpec` in the schema.
+            group: Zarr group name matching a `ZarrGroupSpec` in the schema.
             array: Array name declared with ``time_indexed=False`` in that group.
             data: Data to write, or a callable that returns it.
 
@@ -736,7 +736,7 @@ class WriteIntent:
 
 
 def _compile_indexed_write(iw: IndexedWrite, resolved_index: ResolvedIndex) -> list[WriteIntent]:
-    """Compile an :class:`IndexedWrite` into a :class:`WriteIntent` by resolving its slot.
+    """Compile an `IndexedWrite` into a `WriteIntent` by resolving its slot.
 
     Pure function. No I/O, no logging, no state mutation, no caching side
     effects — the same ``(iw, resolved_index)`` inputs always produce equal
@@ -802,8 +802,8 @@ class DirectZarrIngestor(BaseIngestor):
     Plugins that write directly to Zarr (bypassing xarray) should subclass
     this template and implement:
 
-    - :meth:`zarr_schema` — declare groups and arrays.
-    - :meth:`build_write_intents` — convert a batch into write operations.
+    - `zarr_schema` — declare groups and arrays.
+    - `build_write_intents` — convert a batch into write operations.
 
     The template orchestrates store setup, write execution via a region write
     strategy, coverage tracking, and metrics aggregation.
@@ -863,10 +863,9 @@ class DirectZarrIngestor(BaseIngestor):
         """Compile a single source item into one or more indexed writes.
 
         Called once per element of ``batch.items`` by the default
-        :meth:`build_write_intents` implementation. Each returned
-        :class:`IndexedWrite` is compiled against the plugin's resolved
-        :class:`IndexSpec` via :func:`_compile_indexed_write` and appended
-        to the batch's :class:`WriteIntent` list.
+        `build_write_intents` implementation. Each returned `IndexedWrite` is
+        compiled against the plugin's resolved `IndexSpec` and appended to the
+        batch's `WriteIntent` list.
 
         Return options:
 
@@ -878,13 +877,13 @@ class DirectZarrIngestor(BaseIngestor):
 
         Static (non-time-indexed) arrays are *not* emitted through this hook
         — they carry no slot coordinate to resolve. To emit statics alongside
-        indexed writes, override :meth:`build_write_intents` instead, call
+        indexed writes, override `build_write_intents` instead, call
         ``super().build_write_intents(batch, ctx)`` for the indexed
-        compilation, then append :meth:`WriteIntent.static` items:
+        compilation, then append `WriteIntent.static` items:
 
         If a plugin overrides both hooks, the engine calls
-        :meth:`build_write_intents` directly and this hook is reached only via
-        the default :meth:`build_write_intents` implementation below.
+        `build_write_intents` directly and this hook is reached only via
+        the default `build_write_intents` implementation below.
 
         .. code-block:: python
 
@@ -896,20 +895,20 @@ class DirectZarrIngestor(BaseIngestor):
                 return intents
 
         Default raises ``NotImplementedError``. Plugins must override either
-        this hook or :meth:`build_write_intents`; overriding neither raises
-        ``NotImplementedError`` from :meth:`build_write_intents` at first call.
+        this hook or `build_write_intents`; overriding neither raises
+        ``NotImplementedError`` from `build_write_intents` at first call.
 
         Args:
             item: A single element from ``batch.items``.
             ctx: The plugin context for this run.
 
         Returns:
-            A single :class:`IndexedWrite`, a sequence of them, or ``None``
+            A single `IndexedWrite`, a sequence of them, or ``None``
             to drop the item.
 
         Raises:
             NotImplementedError: If not overridden and
-                :meth:`build_write_intents` is also not overridden.
+                `build_write_intents` is also not overridden.
         """
         _ = item, ctx
         raise NotImplementedError(
@@ -1015,25 +1014,24 @@ class DirectZarrIngestor(BaseIngestor):
         """Convert a batch into a list of write operations.
 
         Default implementation: iterates ``batch.items``, calls
-        :meth:`build_indexed_write` per item, compiles each returned
-        :class:`IndexedWrite` via :func:`_compile_indexed_write` against
-        :meth:`resolved_index`, and returns the concatenated
-        :class:`WriteIntent` list.
+        `build_indexed_write` per item, compiles each returned `IndexedWrite`
+        against `resolved_index`, and returns the concatenated `WriteIntent`
+        list.
 
         Plugins have two override options:
 
-        - **Override :meth:`build_indexed_write`** (recommended for
+        - **Override `build_indexed_write`** (recommended for
           time-indexed writes) — return coordinate-keyed writes per item;
           the engine resolves slot indices for you.
         - **Override this method directly** (needed for statics or when
           the batch requires cross-item state) — return the
-          :class:`WriteIntent` list yourself. Call
+          `WriteIntent` list yourself. Call
           ``super().build_write_intents(batch, ctx)`` first if you want
           to keep the indexed-write compilation path and just append
           statics.
 
         If a plugin overrides both hooks, this method wins: the engine calls
-        :meth:`build_write_intents` directly. :meth:`build_indexed_write` is
+        `build_write_intents` directly. `build_indexed_write` is
         reached only through the default implementation here.
 
         Overriding neither raises ``NotImplementedError``.
@@ -1044,7 +1042,7 @@ class DirectZarrIngestor(BaseIngestor):
         enabled.
 
         Examples:
-            Emit one region write per item via :meth:`build_indexed_write`
+            Emit one region write per item via `build_indexed_write`
             (the default fallback compiles them for you):
 
                 def build_indexed_write(self, item, ctx):
@@ -1200,7 +1198,7 @@ class DirectZarrIngestor(BaseIngestor):
         intent generation → strategy execution → coverage and metrics assembly.
         ``cleanup_batch_data`` and ``batch_teardown`` fire in ``finally`` on
         success, empty-intents, and failure paths — mirroring
-        :meth:`GenericZarrIngestor._process_batch` verbatim so plugin authors
+        `GenericZarrIngestor._process_batch` verbatim so plugin authors
         get the same lifecycle contract across both templates.
         """
         from firecube.ingestor.api import IndexedRegionStrategy

--- a/src/firecube/ingestor/templates/generic.py
+++ b/src/firecube/ingestor/templates/generic.py
@@ -125,7 +125,7 @@ def _build_zarr_batch_runtime(
 
 
 class GenericZarrIngestor(BaseIngestor):
-    """Thin facade over :class:`AppendStrategy` for Zarr-based batch ingestion.
+    """Thin facade over `AppendStrategy` for Zarr-based batch ingestion.
 
     Resolves URIs/storage, acquires write claims, then delegates all append
     logic to ``AppendStrategy.write_groups()``.

--- a/src/firecube/ingestor/templates/generic_tensogram.py
+++ b/src/firecube/ingestor/templates/generic_tensogram.py
@@ -157,9 +157,9 @@ class GenericTensogramIngestor(BaseIngestor):
     """Template for plugins that write directly to Tensogram ``.tgm`` archives.
 
     Subclasses implement ``build_dataset(group, items, ctx)`` returning an
-    :class:`xarray.Dataset` (or ``None`` to skip); the template writes each
+    `xarray.Dataset` (or ``None`` to skip); the template writes each
     group's dataset to the local ``.tgm`` target using the options declared
-    in :class:`TensogramTemplateConfig`. Remote targets are not supported.
+    in `TensogramTemplateConfig`. Remote targets are not supported.
     """
 
     template_config_class = TensogramTemplateConfig

--- a/src/firecube/ingestor/types/context.py
+++ b/src/firecube/ingestor/types/context.py
@@ -46,7 +46,7 @@ class StorageContext:
 
     Each field binds one storage role to a session that the engine creates
     from the resolved target and selected storage driver. Plugins reach it
-    through :attr:`PluginContext.storage` and should treat the bound
+    through `PluginContext.storage` and should treat the bound
     sessions as engine-owned handles: use them to inspect the product
     identity and perform storage operations, but do not replace or close
     them.
@@ -224,11 +224,11 @@ class PluginContext:
     """Read-only per-run context handed to every plugin-facing hook.
 
     The engine builds one instance per run from the caller's
-    :class:`IngestContext` plus its own runtime state, and passes it to
+    `IngestContext` plus its own runtime state, and passes it to
     plugin hooks such as ``discover_source_files``, ``get_batch_groups``,
     and ``build_dataset``. Plugin authors never construct it themselves.
 
-    All members are read-only. In particular, :attr:`options` is a detached
+    All members are read-only. In particular, `options` is a detached
     immutable copy taken when the context is created, and attribute access
     outside the documented surface raises ``AttributeError``.
     """
@@ -257,7 +257,7 @@ class PluginContext:
     def target(self) -> str | None:
         """Output target URI for this run, or ``None`` when not provided.
 
-        Taken from the caller's :attr:`IngestContext.target`. The engine
+        Taken from the caller's `IngestContext.target`. The engine
         resolves the actual store location from it together with the
         configured write mode, so plugins should treat it as declarative
         rather than writing to it directly.
@@ -270,7 +270,7 @@ class PluginContext:
 
         Set by the caller (e.g. the ``--in-memory`` CLI flag). When true,
         plugins that stage data (such as DuckDB-backed plugins) should use
-        in-memory state instead of files under :attr:`temp_root`.
+        in-memory state instead of files under `temp_root`.
         """
         return self._ctx.in_memory
 
@@ -288,7 +288,7 @@ class PluginContext:
         """Storage sessions bound to this run, keyed by role, or ``None``.
 
         When output storage is bound, ``storage.output`` is the session for
-        the run's output target. See :class:`StorageContext`.
+        the run's output target. See `StorageContext`.
         """
         return self._ctx.storage
 
@@ -346,7 +346,7 @@ class PluginContext:
         """Plugin options for this run as an immutable mapping.
 
         A detached copy of the caller's options (including ``--option``
-        CLI overrides) wrapped in :class:`types.MappingProxyType` when the
+        CLI overrides) wrapped in `types.MappingProxyType` when the
         context is created: it cannot be mutated, and later changes to
         engine state are not reflected in it.
         """
@@ -365,7 +365,7 @@ class PluginContext:
             default: Value returned when the option is not set.
 
         Returns:
-            The value from :attr:`options`, or ``default`` when missing.
+            The value from `options`, or ``default`` when missing.
         """
         return self._options.get(key, default)
 
@@ -373,7 +373,7 @@ class PluginContext:
         """Ensure a source file is available locally and return its path.
 
         Remote sources (e.g. S3 URIs) are downloaded into the per-run cache
-        under :attr:`temp_root`; already-local paths are returned directly.
+        under `temp_root`; already-local paths are returned directly.
 
         Args:
             source: A local path, URI string, or source-file object.

--- a/src/firecube/ingestor/types/planned_range.py
+++ b/src/firecube/ingestor/types/planned_range.py
@@ -32,7 +32,7 @@ SlotRange = tuple[int, int]
 
 ``slot_start`` is inclusive and ``slot_end`` is exclusive, matching Python
 slicing and engine array indexing. Used for the ``--slot-start`` /
-``--slot-end`` worker assignment; see :class:`PlannedRange` for the
+``--slot-end`` worker assignment; see `PlannedRange` for the
 per-group form.
 """
 

--- a/src/firecube/ingestor/types/result_metrics.py
+++ b/src/firecube/ingestor/types/result_metrics.py
@@ -106,7 +106,7 @@ class ResultMetrics:
             self._compat["storage_handled"] = self.storage_handled
 
     def to_dict(self) -> dict[str, Any]:
-        """Render typed fields as a public dict (no private ``_compat`` leak)."""
+        """Render the typed fields as a plain dict, excluding internal state."""
         rendered: dict[str, Any] = {}
         if self.write_mode is not None:
             rendered["write_mode"] = self.write_mode

--- a/tests/sdk/test_api_docs_coverage.py
+++ b/tests/sdk/test_api_docs_coverage.py
@@ -186,18 +186,54 @@ def test_every_export_documented_or_allowlisted(module_name: str, documented: se
         f"{module_name}: allowlist names no longer exported: {sorted(stale_allowlist)}"
     )
 
-    documented_exports = {name for name in exports if f"{module_name}.{name}" in documented}
+    # A symbol re-exported by more than one facade is the *same object* (see
+    # test_reexports_are_identical_objects). It is documented once, on the page
+    # whose audience it serves, under that page's facade: plugin-authoring
+    # pages carry the ingestor path, core pages the core path. So a directive
+    # under any facade documents the symbol for all of them — requiring one per
+    # facade would render the identical entry two or three times.
+    documented_exports = {
+        name
+        for name in exports
+        if any(f"{module}.{name}" in documented for module in PUBLIC_MODULES)
+    }
     missing = exports - documented_exports - set(allowlist)
     assert not missing, (
         f"{module_name}: exports missing from docs/reference and not "
-        f"allowlisted: {sorted(missing)}. Add a `::: {module_name}.<name>` "
-        "directive or an INTENTIONALLY_UNDOCUMENTED entry with a reason."
+        f"allowlisted: {sorted(missing)}. Add a `::: <facade>.<name>` directive "
+        "on the page serving that symbol's audience, or an "
+        "INTENTIONALLY_UNDOCUMENTED entry with a reason."
     )
 
-    over_allowlisted = documented_exports & set(allowlist)
+    over_allowlisted = {name for name in allowlist if f"{module_name}.{name}" in documented}
     assert not over_allowlisted, (
         f"{module_name}: names both documented and allowlisted (remove the "
         f"stale allowlist entries): {sorted(over_allowlisted)}"
+    )
+
+
+def test_reexports_are_identical_objects() -> None:
+    """A name shared by two facades must resolve to one object, not two.
+
+    ``test_every_export_documented_or_allowlisted`` accepts a directive under
+    any facade as documenting the symbol for all of them. That is only sound
+    while the facades re-export the same object: two distinct types sharing a
+    name would leave one of them silently undocumented.
+    """
+    modules = {name: import_module(name) for name in PUBLIC_MODULES}
+    divergent: list[str] = []
+    for i, left in enumerate(PUBLIC_MODULES):
+        for right in PUBLIC_MODULES[i + 1 :]:
+            shared = set(modules[left].__all__) & set(modules[right].__all__)
+            divergent.extend(
+                f"{name}: {left} and {right} export different objects"
+                for name in sorted(shared)
+                if getattr(modules[left], name) is not getattr(modules[right], name)
+            )
+
+    assert not divergent, (
+        "facades re-export the same name as different objects, so a single "
+        f"reference entry cannot cover both: {divergent}"
     )
 
 

--- a/tests/sdk/test_facade_exports.py
+++ b/tests/sdk/test_facade_exports.py
@@ -1,3 +1,17 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from firecube.core.api import FIRECUBE_STATIC_WRITTEN_ATTR as core_static_written_attr
 from firecube.core.api import RESERVED_ARRAY_ATTRS as core_reserved_array_attrs
 from firecube.core.api import ExtentUnknownError as CoreExtentUnknownError

--- a/tests/unit/_helpers/counting_fs.py
+++ b/tests/unit/_helpers/counting_fs.py
@@ -36,6 +36,10 @@ class _CountingAtomicWriter:
         self._counts["write_atomic"] = self._counts.get("write_atomic", 0) + 1
         self._writer.write_atomic(uri, data)
 
+    def replace_atomic(self, uri: StorageUri, data: bytes) -> None:
+        self._counts["replace_atomic"] = self._counts.get("replace_atomic", 0) + 1
+        self._writer.replace_atomic(uri, data)
+
     def __getattr__(self, name: str) -> Any:
         return getattr(self._writer, name)
 

--- a/tests/unit/test_bulk_abandon_stale_runs.py
+++ b/tests/unit/test_bulk_abandon_stale_runs.py
@@ -21,13 +21,21 @@ Covers:
 - Mid-sweep race where a previewed run receives a fresh heartbeat.
 - Empty-input no-op.
 - Repeated-call idempotency.
+- Crash-recovery idempotency: partial abandon followed by a rerun.
+- Concurrent-operator idempotency: two overlapping --all-stale sweeps against
+  the same product must not double-abandon any run.
+- Orphan run directory (segments present, run.json missing) behavior lock.
+- Enumeration-cost regression (CountingFilesystem): sweep must bound the number
+  of runs-directory listings independent of stale count S.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -35,10 +43,10 @@ from firecube.core.controlplane import ChunkManager
 from firecube.core.controlplane.types import (
     EVENT_RUN_ABANDONED,
     AbandonSweepResult,
-    RunInfo,
 )
 from firecube.core.storage.uri import StorageUri
 from tests.helpers.storage import make_test_binding
+from tests.unit._helpers.counting_fs import CountingFilesystem, make_counting_local_fs
 
 pytestmark = pytest.mark.unit
 
@@ -47,6 +55,38 @@ def _manager(tmp_path: Path, *, product: str = "product.zarr") -> ChunkManager:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return ChunkManager(binding=make_test_binding(tmp_path, product=product), workspace=workspace)
+
+
+class _PathCountingFilesystem(CountingFilesystem):
+    """CountingFilesystem variant that records which paths were listed."""
+
+    def __init__(self, fs: Any) -> None:
+        super().__init__(fs)
+        self.ls_paths: list[str] = []
+
+    def ls(self, uri: StorageUri, detail: bool = False) -> list[Any]:
+        self.ls_paths.append(uri.path)
+        return super().ls(uri, detail=detail)
+
+
+def _counting_manager(
+    tmp_path: Path, *, product: str = "product.zarr"
+) -> tuple[ChunkManager, _PathCountingFilesystem]:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    _wrapped, real_fs = make_counting_local_fs(tmp_path)
+    counting_fs = _PathCountingFilesystem(real_fs)
+    manager = ChunkManager(
+        binding=make_test_binding(tmp_path, product=product),
+        workspace=workspace,
+        filesystem=counting_fs,
+    )
+    return manager, counting_fs
+
+
+def _runs_ls_count(counting_fs: _PathCountingFilesystem) -> int:
+    """Count list calls targeting the ``.firecube/runs`` directory."""
+    return sum(1 for path in counting_fs.ls_paths if path.endswith("/.firecube/runs"))
 
 
 def _runs_dir(tmp_path: Path, product: str) -> Path:
@@ -204,18 +244,22 @@ def test_race_run_becomes_terminal(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         tmp_path, product=product, run_id=r_other, status="started", updated_at=now - 7200
     )
 
-    original_list_runs = manager.repo.list_runs
-    call_count = {"n": 0}
+    manager.repo._ensure_bound()
+    wal_reader = manager.repo._wal_reader
+    assert wal_reader is not None
+    original_read_run_entry = wal_reader.read_run_entry
+    read_counts = {r_race: 0}
 
-    def racy_list_runs(
-        *, product: str, status: str | None = None, non_terminal: bool = False
-    ) -> list[RunInfo]:
-        call_count["n"] += 1
-        # Call #1 is the preview inside list_stale_runs; leave state untouched
-        # so both runs appear in ``previewed``. Trigger on the first re-check
-        # (call #2) to simulate a concurrent finalizer flipping r_race to
-        # terminal between preview and mutation.
-        if call_count["n"] == 2:
+    def racy_read_run_entry(
+        *, product: str, run_dir: StorageUri, run_uri: str, run_id: str | None = None
+    ) -> dict[str, Any] | None:
+        if run_id == r_race:
+            read_counts[r_race] += 1
+        # Call #1 for r_race is the preview inside list_stale_runs; leave state
+        # untouched so both runs appear in ``previewed``. Trigger on the first
+        # targeted re-check to simulate a concurrent finalizer flipping r_race
+        # to terminal between preview and mutation.
+        if run_id == r_race and read_counts[r_race] == 2:
             _write_run_json(
                 tmp_path,
                 product=product,
@@ -224,9 +268,21 @@ def test_race_run_becomes_terminal(tmp_path: Path, monkeypatch: pytest.MonkeyPat
                 updated_at=time.time(),
                 completed_at=time.time(),
             )
-        return original_list_runs(product=product, status=status, non_terminal=non_terminal)
+        return original_read_run_entry(
+            product=product, run_dir=run_dir, run_uri=run_uri, run_id=run_id
+        )
 
-    monkeypatch.setattr(manager.repo, "list_runs", racy_list_runs)
+    abandon_attempts: list[str] = []
+    original_abandon_run = manager.repo.abandon_run
+
+    def tracked_abandon_run(
+        *, product: str, run_id: str, reason: str, meta: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        abandon_attempts.append(run_id)
+        return original_abandon_run(product=product, run_id=run_id, reason=reason, meta=meta)
+
+    monkeypatch.setattr(wal_reader, "read_run_entry", racy_read_run_entry)
+    monkeypatch.setattr(manager.repo, "abandon_run", tracked_abandon_run)
 
     try:
         result = manager.abandon_stale_runs(product=product, reason="race-test", dry_run=False)
@@ -236,6 +292,7 @@ def test_race_run_becomes_terminal(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     assert r_race in result.previewed and r_other in result.previewed
     assert r_race in result.skipped_already_terminal
     assert r_race not in result.abandoned
+    assert r_race not in abandon_attempts
     assert r_other in result.abandoned
 
     race_events = _read_wal_event_types(tmp_path, product, r_race)
@@ -262,17 +319,21 @@ def test_race_run_receives_fresh_heartbeat(tmp_path: Path, monkeypatch: pytest.M
         tmp_path, product=product, run_id=r_other, status="started", updated_at=now - 7200
     )
 
-    original_list_runs = manager.repo.list_runs
-    call_count = {"n": 0}
+    manager.repo._ensure_bound()
+    wal_reader = manager.repo._wal_reader
+    assert wal_reader is not None
+    original_read_run_entry = wal_reader.read_run_entry
+    read_counts = {r_race: 0}
 
-    def racy_list_runs(
-        *, product: str, status: str | None = None, non_terminal: bool = False
-    ) -> list[RunInfo]:
-        call_count["n"] += 1
-        # Trigger on the first re-check (call #2), not the preview (call #1
-        # inside list_stale_runs) — otherwise r_race would be filtered out of
+    def racy_read_run_entry(
+        *, product: str, run_dir: StorageUri, run_uri: str, run_id: str | None = None
+    ) -> dict[str, Any] | None:
+        if run_id == r_race:
+            read_counts[r_race] += 1
+        # Trigger on the first targeted re-check, not the preview inside
+        # list_stale_runs; otherwise r_race would be filtered out of
         # ``previewed`` and the race condition would never be exercised.
-        if call_count["n"] == 2:
+        if run_id == r_race and read_counts[r_race] == 2:
             _write_run_json(
                 tmp_path,
                 product=product,
@@ -280,9 +341,21 @@ def test_race_run_receives_fresh_heartbeat(tmp_path: Path, monkeypatch: pytest.M
                 status="started",
                 updated_at=time.time(),
             )
-        return original_list_runs(product=product, status=status, non_terminal=non_terminal)
+        return original_read_run_entry(
+            product=product, run_dir=run_dir, run_uri=run_uri, run_id=run_id
+        )
 
-    monkeypatch.setattr(manager.repo, "list_runs", racy_list_runs)
+    abandon_attempts: list[str] = []
+    original_abandon_run = manager.repo.abandon_run
+
+    def tracked_abandon_run(
+        *, product: str, run_id: str, reason: str, meta: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        abandon_attempts.append(run_id)
+        return original_abandon_run(product=product, run_id=run_id, reason=reason, meta=meta)
+
+    monkeypatch.setattr(wal_reader, "read_run_entry", racy_read_run_entry)
+    monkeypatch.setattr(manager.repo, "abandon_run", tracked_abandon_run)
 
     try:
         result = manager.abandon_stale_runs(product=product, reason="race-test", dry_run=False)
@@ -292,6 +365,7 @@ def test_race_run_receives_fresh_heartbeat(tmp_path: Path, monkeypatch: pytest.M
     assert r_race in result.previewed and r_other in result.previewed
     assert r_race in result.skipped_fresh
     assert r_race not in result.abandoned
+    assert r_race not in abandon_attempts
     assert r_other in result.abandoned
 
     race_events = _read_wal_event_types(tmp_path, product, r_race)
@@ -350,3 +424,354 @@ def test_idempotent_second_call(tmp_path: Path) -> None:
     for rid in stale_ids:
         events = _read_wal_event_types(tmp_path, product, rid)
         assert events.count(EVENT_RUN_ABANDONED) == 1
+
+
+def test_partial_abandon_crash_recoverable_on_rerun(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A crash mid-sweep leaves partial state that a second sweep completes.
+
+    Simulates the operator running abandon-stale-runs, having the process
+    killed (SIGKILL, OOM, node lost) after partially abandoning runs, and
+    re-invoking the command. Idempotency must hold across the crash: no
+    duplicate EVENT_RUN_ABANDONED, no re-abandon attempt on terminal runs,
+    and every stale run is terminal after the recovery pass.
+    """
+    manager = _manager(tmp_path)
+    product = "product.zarr"
+    now = time.time()
+
+    stale_ids = [f"stale-{i}" for i in range(5)]
+    for rid in stale_ids:
+        _write_run_json(
+            tmp_path, product=product, run_id=rid, status="started", updated_at=now - 7200
+        )
+
+    original_abandon_run = manager.repo.abandon_run
+    call_count = {"n": 0}
+    crash_after = 3
+
+    def crashing_abandon_run(
+        *, product: str, run_id: str, reason: str, meta: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        call_count["n"] += 1
+        if call_count["n"] > crash_after:
+            raise RuntimeError(f"simulated crash after {crash_after} abandonments")
+        return original_abandon_run(product=product, run_id=run_id, reason=reason, meta=meta)
+
+    monkeypatch.setattr(manager.repo, "abandon_run", crashing_abandon_run)
+
+    try:
+        with pytest.raises(RuntimeError, match=f"simulated crash after {crash_after}"):
+            manager.abandon_stale_runs(product=product, reason="first-pass", dry_run=False)
+    finally:
+        monkeypatch.setattr(manager.repo, "abandon_run", original_abandon_run)
+
+    abandoned_after_crash = []
+    still_started_after_crash = []
+    for rid in stale_ids:
+        payload = json.loads(
+            (_run_dir(tmp_path, product, rid) / "run.json").read_text(encoding="utf-8")
+        )
+        if payload["status"] == "abandoned":
+            abandoned_after_crash.append(rid)
+        elif payload["status"] == "started":
+            still_started_after_crash.append(rid)
+    assert len(abandoned_after_crash) == crash_after, (
+        f"crash simulation should leave exactly {crash_after} runs abandoned; "
+        f"got abandoned={abandoned_after_crash}, still_started={still_started_after_crash}"
+    )
+    assert len(still_started_after_crash) == len(stale_ids) - crash_after
+
+    try:
+        second = manager.abandon_stale_runs(product=product, reason="recovery-pass", dry_run=False)
+    finally:
+        manager.close()
+
+    assert sorted(second.abandoned) == sorted(still_started_after_crash)
+    assert sorted(second.previewed) == sorted(still_started_after_crash)
+    assert second.skipped_fresh == []
+    assert set(second.abandoned).isdisjoint(abandoned_after_crash)
+
+    total_abandoned = set(abandoned_after_crash) | set(second.abandoned)
+    assert total_abandoned == set(stale_ids)
+    for rid in stale_ids:
+        payload = json.loads(
+            (_run_dir(tmp_path, product, rid) / "run.json").read_text(encoding="utf-8")
+        )
+        assert payload["status"] == "abandoned", (
+            f"{rid} must be terminal after recovery pass; got {payload['status']}"
+        )
+        events = _read_wal_event_types(tmp_path, product, rid)
+        assert events.count(EVENT_RUN_ABANDONED) == 1, (
+            f"{rid} must have exactly one EVENT_RUN_ABANDONED across two sweeps; "
+            f"got events={events}"
+        )
+
+
+def test_concurrent_all_stale_sweeps_are_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two overlapping --all-stale sweeps must not double-abandon any run.
+
+    Simulates two operators (two ``ChunkManager`` instances against the same
+    on-disk control-plane root) running ``abandon_stale_runs`` concurrently.
+    Uses deterministic monkeypatch interleaving instead of threads: when
+    operator A is about to call ``abandon_run`` on the 5th stale run, operator
+    B's full sweep runs first, then A resumes.
+
+    Operator B's ``list_stale_runs`` is captured up-front so its preview holds
+    all 10 stale runs — as it would if both operators listed at nearly the
+    same wall time in a real race. The mutation-time re-check inside each
+    sweep is what must actually keep the sweeps idempotent.
+
+    Invariants proven:
+      - Neither operator raises.
+      - Every stale run reaches ``status="abandoned"``.
+      - Every stale run has exactly ONE ``EVENT_RUN_ABANDONED`` — no duplicate
+        emission from the overlap, no run left non-terminal.
+      - Runs the other operator already abandoned surface as
+        ``skipped_already_terminal`` on the losing side (no exception, no
+        silent double-count into ``abandoned``).
+    """
+    manager_a = _manager(tmp_path)
+    manager_b = _manager(tmp_path)
+    product = "product.zarr"
+    now = time.time()
+
+    n_stale = 10
+    stale_ids = [f"stale-{i}" for i in range(n_stale)]
+    for rid in stale_ids:
+        _write_run_json(
+            tmp_path, product=product, run_id=rid, status="started", updated_at=now - 7200
+        )
+
+    cached_b_preview = manager_b.list_stale_runs(product=product)
+    assert len(cached_b_preview) == n_stale
+    assert sorted(run.run_id for run in cached_b_preview) == sorted(stale_ids)
+
+    def cached_list_stale_runs_for_b(*, product: str) -> list[Any]:
+        return list(cached_b_preview)
+
+    monkeypatch.setattr(manager_b.repo, "list_stale_runs", cached_list_stale_runs_for_b)
+
+    original_a_abandon_run = manager_a.repo.abandon_run
+    a_call_count = {"n": 0}
+    b_result_holder: dict[str, Any] = {}
+    trigger_at = 5
+
+    def racy_a_abandon_run(
+        *, product: str, run_id: str, reason: str, meta: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        a_call_count["n"] += 1
+        if a_call_count["n"] == trigger_at and "result" not in b_result_holder:
+            b_result_holder["result"] = manager_b.abandon_stale_runs(
+                product=product, reason="op-b-sweep", dry_run=False
+            )
+        return original_a_abandon_run(product=product, run_id=run_id, reason=reason, meta=meta)
+
+    monkeypatch.setattr(manager_a.repo, "abandon_run", racy_a_abandon_run)
+
+    try:
+        result_a = manager_a.abandon_stale_runs(product=product, reason="op-a-sweep", dry_run=False)
+    finally:
+        manager_a.close()
+        manager_b.close()
+
+    assert "result" in b_result_holder, "interleave did not fire; test setup is broken"
+    result_b = b_result_holder["result"]
+
+    assert isinstance(result_a, AbandonSweepResult)
+    assert isinstance(result_b, AbandonSweepResult)
+
+    a_won = set(result_a.abandoned)
+    b_won = set(result_b.abandoned)
+
+    assert len(a_won) == trigger_at - 1, (
+        f"Op A must abandon exactly {trigger_at - 1} runs before the interleave; "
+        f"got {sorted(a_won)}"
+    )
+    assert len(b_won) == n_stale - (trigger_at - 1), (
+        f"Op B must abandon the remaining {n_stale - (trigger_at - 1)} runs; got {sorted(b_won)}"
+    )
+
+    assert a_won.isdisjoint(b_won), (
+        f"concurrent sweeps must not both claim the same abandonment: "
+        f"overlap={sorted(a_won & b_won)}"
+    )
+    assert a_won | b_won == set(stale_ids), (
+        f"union of both operators' abandoned sets must cover all stale ids; "
+        f"missing={set(stale_ids) - (a_won | b_won)}"
+    )
+
+    assert set(result_a.skipped_already_terminal) == b_won, (
+        "Op A must report runs Op B abandoned as skipped_already_terminal"
+    )
+    assert result_a.skipped_fresh == []
+
+    assert set(result_b.skipped_already_terminal) == a_won, (
+        "Op B must report runs Op A abandoned as skipped_already_terminal"
+    )
+    assert result_b.skipped_fresh == []
+
+    for rid in stale_ids:
+        payload = json.loads(
+            (_run_dir(tmp_path, product, rid) / "run.json").read_text(encoding="utf-8")
+        )
+        assert payload["status"] == "abandoned", (
+            f"{rid} must be terminal after both concurrent sweeps; got {payload['status']}"
+        )
+        events = _read_wal_event_types(tmp_path, product, rid)
+        assert events.count(EVENT_RUN_ABANDONED) == 1, (
+            f"{rid} must have exactly one EVENT_RUN_ABANDONED across concurrent sweeps; "
+            f"got events={events}"
+        )
+
+
+def test_orphan_run_directory_handling(tmp_path: Path) -> None:
+    """Behavior lock: sweep handling of orphan run dirs (segments, no run.json).
+
+    An "orphan" is a run directory that WalReader.read_run_entry synthesizes when
+    segment files exist but run.json is missing (``error="missing_run_meta"``).
+    Task 8 will rewrite ``_get_run_entry`` to route through ``read_run_entry``;
+    this test pins the current end-to-end sweep outcome so that migration cannot
+    silently change how orphans are cleaned up.
+    """
+    manager = _manager(tmp_path)
+    product = "product.zarr"
+    now = time.time()
+
+    stale_ids = [f"stale-{i}" for i in range(5)]
+    for rid in stale_ids:
+        _write_run_json(
+            tmp_path, product=product, run_id=rid, status="started", updated_at=now - 7200
+        )
+
+    orphan_id = "orphan-run"
+    orphan_dir = _run_dir(tmp_path, product, orphan_id)
+    orphan_dir.mkdir(parents=True)
+    orphan_segment = orphan_dir / "events-00000.jsonl"
+    orphan_segment.write_text('{"event_type": "noop"}\n', encoding="utf-8")
+    old_ts = now - 7200
+    os.utime(orphan_segment, (old_ts, old_ts))
+
+    try:
+        result = manager.abandon_stale_runs(product=product, reason="orphan-lock", dry_run=False)
+    finally:
+        manager.close()
+
+    all_ids = set(stale_ids) | {orphan_id}
+    assert set(result.previewed) == all_ids, (
+        "Behavior lock: orphan runs appear in previewed because status='orphaned' "
+        "is non-terminal and updated_at derived from segment mtime is > threshold "
+        "(WalReader.build_orphan_run_entry + RunInfo.is_terminal)."
+    )
+    assert set(result.abandoned) == all_ids, (
+        "Behavior lock: orphan runs are abandoned via abandon_run → "
+        "record_run_terminal(status='abandoned') per current implementation "
+        "(_wal_writer.abandon_run does not special-case status='orphaned')."
+    )
+    assert result.skipped_fresh == []
+    assert result.skipped_already_terminal == []
+
+    orphan_meta_path = orphan_dir / "run.json"
+    assert orphan_meta_path.exists(), (
+        "Behavior lock: abandoning an orphan materializes run.json via "
+        "RunEventWriter.finalize → _write_run_meta."
+    )
+    orphan_payload = json.loads(orphan_meta_path.read_text(encoding="utf-8"))
+    assert orphan_payload["status"] == "abandoned"
+
+    orphan_events = _read_wal_event_types(tmp_path, product, orphan_id)
+    assert EVENT_RUN_ABANDONED in orphan_events
+
+
+def test_enumeration_bounded_by_stale_count(tmp_path: Path) -> None:
+    """abandon_stale_runs must not re-list the runs directory once per stale item.
+
+    The mutation loop re-checks each candidate with a targeted single-file
+    read, so the number of runs-directory listings stays bounded by the
+    preview regardless of how many runs turn out to be stale. Re-listing per
+    candidate would make a sweep cost O(N x S) on a product with thousands of
+    runs.
+    """
+    manager, counting_fs = _counting_manager(tmp_path)
+    product = "product.zarr"
+    now = time.time()
+
+    stale_ids = [f"stale-{i}" for i in range(10)]
+    fresh_ids = [f"fresh-{i}" for i in range(10)]
+    for rid in stale_ids:
+        _write_run_json(
+            tmp_path, product=product, run_id=rid, status="started", updated_at=now - 7200
+        )
+    for rid in fresh_ids:
+        _write_run_json(
+            tmp_path, product=product, run_id=rid, status="started", updated_at=now - 60
+        )
+
+    counting_fs.reset()
+    counting_fs.ls_paths.clear()
+
+    try:
+        result = manager.abandon_stale_runs(product=product, reason="bound-test", dry_run=False)
+    finally:
+        manager.close()
+
+    observed = _runs_ls_count(counting_fs)
+    assert observed <= 2, (
+        f"abandon_stale_runs listed runs_dir {observed} times for N=20, S=10; "
+        "must be bounded (<= 2) independent of stale count. "
+        f"Recorded ls paths on runs_dir: "
+        f"{[p for p in counting_fs.ls_paths if p.endswith('/.firecube/runs')]}"
+    )
+    assert len(result.abandoned) == len(stale_ids)
+
+
+def test_enumeration_bounded_scales_with_N_not_S(tmp_path: Path) -> None:
+    """Enumeration cost is constant across differing stale counts.
+
+    Runs (N=50, S=5) and (N=20, S=15) and asserts the number of
+    runs-directory listings is bounded in each and varies by at most 1
+    between the two, pinning the cost to N rather than S.
+    """
+    product = "product.zarr"
+    now = time.time()
+
+    def _run_case(root: Path, *, stale: int, fresh: int) -> tuple[int, int]:
+        root.mkdir()
+        mgr, counting = _counting_manager(root, product=product)
+        for i in range(stale):
+            _write_run_json(
+                root,
+                product=product,
+                run_id=f"stale-{i}",
+                status="started",
+                updated_at=now - 7200,
+            )
+        for i in range(fresh):
+            _write_run_json(
+                root,
+                product=product,
+                run_id=f"fresh-{i}",
+                status="started",
+                updated_at=now - 60,
+            )
+        counting.reset()
+        counting.ls_paths.clear()
+        try:
+            result = mgr.abandon_stale_runs(product=product, reason="scale-test", dry_run=False)
+        finally:
+            mgr.close()
+        return _runs_ls_count(counting), len(result.abandoned)
+
+    ls_a, abandoned_a = _run_case(tmp_path / "case_a", stale=5, fresh=45)
+    ls_b, abandoned_b = _run_case(tmp_path / "case_b", stale=15, fresh=5)
+
+    assert abandoned_a == 5
+    assert abandoned_b == 15
+    assert ls_a <= 2, f"case A (N=50, S=5): {ls_a} runs_dir listings"
+    assert ls_b <= 2, f"case B (N=20, S=15): {ls_b} runs_dir listings"
+    assert abs(ls_a - ls_b) <= 1, (
+        f"listing count scales with stale count S: A(S=5)={ls_a}, B(S=15)={ls_b}"
+    )

--- a/tests/unit/test_bulk_clear_stale_claims.py
+++ b/tests/unit/test_bulk_clear_stale_claims.py
@@ -21,6 +21,10 @@ Covers:
 - Mid-sweep race where another operator deletes a previewed claim.
 - Empty-input no-op.
 - Repeated-call idempotency.
+- Concurrent-operator idempotency: two overlapping --all-stale sweeps against
+  the same product must not double-clear any claim.
+- Enumeration-cost regression (CountingFilesystem): sweep must bound the number
+  of claims-directory listings independent of stale count S.
 """
 
 from __future__ import annotations
@@ -28,21 +32,57 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from firecube.core.controlplane import ChunkManager
+from firecube.core.controlplane.claims import FilesystemClaimService
 from firecube.core.controlplane.types import ClaimInfo, ClearSweepResult, WriteDomain
 from firecube.core.storage.uri import StorageUri
 from tests.helpers.storage import make_test_binding
-
-pytestmark = pytest.mark.unit
+from tests.unit._helpers.counting_fs import CountingFilesystem, make_counting_local_fs
 
 
 def _manager(tmp_path: Path, *, product: str = "product.zarr") -> ChunkManager:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return ChunkManager(binding=make_test_binding(tmp_path, product=product), workspace=workspace)
+
+
+class _PathCountingFilesystem(CountingFilesystem):
+    """CountingFilesystem variant that records which paths were listed."""
+
+    def __init__(self, fs: Any) -> None:
+        super().__init__(fs)
+        self.ls_paths: list[str] = []
+
+    def ls(self, uri: StorageUri, detail: bool = False) -> list[Any]:
+        self.ls_paths.append(uri.path)
+        return super().ls(uri, detail=detail)
+
+
+def _counting_manager(
+    tmp_path: Path, *, product: str = "product.zarr"
+) -> tuple[ChunkManager, _PathCountingFilesystem]:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    _wrapped, real_fs = make_counting_local_fs(tmp_path)
+    counting_fs = _PathCountingFilesystem(real_fs)
+    manager = ChunkManager(
+        binding=make_test_binding(tmp_path, product=product),
+        workspace=workspace,
+        filesystem=counting_fs,
+    )
+    return manager, counting_fs
+
+
+def _claims_ls_count(counting_fs: _PathCountingFilesystem) -> int:
+    """Count list calls targeting the ``.firecube/claims`` directory."""
+    return sum(1 for path in counting_fs.ls_paths if path.endswith("/.firecube/claims"))
+
+
+pytestmark = pytest.mark.unit
 
 
 def _claims_dir(tmp_path: Path, product: str) -> Path:
@@ -156,10 +196,12 @@ def test_race_claim_becomes_fresh(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
         tmp_path, product=product, domain=d_other, last_heartbeat_at=now - 300
     )
 
-    original_list_claims = manager.repo.list_claims
+    original_read_claim_by_domain = FilesystemClaimService.read_claim_by_domain
     call_count = {"n": 0}
 
-    def racy_list_claims(*, product: str | None = None) -> list[ClaimInfo]:
+    def racy_read_claim_by_domain(
+        self: FilesystemClaimService, *, product: str, domain: str
+    ) -> ClaimInfo | None:
         call_count["n"] += 1
         # First re-check corresponds to d_race (first in sort order): simulate
         # a live pod refreshing d_race's heartbeat before we see it.
@@ -170,9 +212,9 @@ def test_race_claim_becomes_fresh(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
                 domain=d_race,
                 last_heartbeat_at=time.time(),
             )
-        return original_list_claims(product=product)
+        return original_read_claim_by_domain(self, product=product, domain=domain)
 
-    monkeypatch.setattr(manager.repo, "list_claims", racy_list_claims)
+    monkeypatch.setattr(FilesystemClaimService, "read_claim_by_domain", racy_read_claim_by_domain)
 
     try:
         result = manager.clear_stale_claims(product=product, dry_run=False)
@@ -205,18 +247,20 @@ def test_race_claim_deleted_by_another_operator(
         tmp_path, product=product, domain=d_other, last_heartbeat_at=now - 300
     )
 
-    original_list_claims = manager.repo.list_claims
+    original_read_claim_by_domain = FilesystemClaimService.read_claim_by_domain
     call_count = {"n": 0}
 
-    def racy_list_claims(*, product: str | None = None) -> list[ClaimInfo]:
+    def racy_read_claim_by_domain(
+        self: FilesystemClaimService, *, product: str, domain: str
+    ) -> ClaimInfo | None:
         call_count["n"] += 1
         # First re-check corresponds to d_gone: simulate another operator
         # unlinking the file concurrently before this iteration sees it.
         if call_count["n"] == 1 and gone_file.exists():
             gone_file.unlink()
-        return original_list_claims(product=product)
+        return original_read_claim_by_domain(self, product=product, domain=domain)
 
-    monkeypatch.setattr(manager.repo, "list_claims", racy_list_claims)
+    monkeypatch.setattr(FilesystemClaimService, "read_claim_by_domain", racy_read_claim_by_domain)
 
     try:
         result = manager.clear_stale_claims(product=product, dry_run=False)
@@ -285,3 +329,187 @@ def test_repeated_call_is_idempotent(tmp_path: Path) -> None:
     assert second.skipped_missing == []
     for f in files:
         assert not f.exists()
+
+
+def test_concurrent_all_stale_clears_are_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two overlapping --all-stale claim sweeps must not double-clear any claim.
+
+    Simulates two operators (two ``ChunkManager`` instances against the same
+    on-disk control-plane root) running ``clear_stale_claims`` concurrently.
+    Uses deterministic monkeypatch interleaving instead of threads: when
+    operator A is about to call ``clear_claim`` on the 5th stale claim,
+    operator B's full sweep runs first, then A resumes.
+
+    Operator B's ``list_stale_claims`` is captured up-front so its preview
+    holds all 10 stale claims — as it would if both operators listed at nearly
+    the same wall time in a real race. The mutation-time re-check inside each
+    sweep is what must actually keep the sweeps idempotent.
+
+    Invariants proven:
+      - Neither operator raises.
+      - Every stale claim file is removed exactly once — the union of
+        ``cleared`` across both operators covers all stale domains with no
+        overlap.
+      - Claims the other operator already removed surface as
+        ``skipped_missing`` on the losing side (no exception, no silent
+        double-count into ``cleared``).
+      - No stale claim file remains on disk.
+    """
+    manager_a = _manager(tmp_path)
+    manager_b = _manager(tmp_path)
+    product = "product.zarr"
+    now = time.time()
+
+    n_stale = 10
+    stale_domains = [
+        WriteDomain(product=product, category="zarr_append", name=f"stale-{i}")
+        for i in range(n_stale)
+    ]
+    stale_files = [
+        _write_claim(tmp_path, product=product, domain=d, last_heartbeat_at=now - 300)
+        for d in stale_domains
+    ]
+
+    cached_b_preview = manager_b.list_stale_claims(product=product)
+    assert len(cached_b_preview) == n_stale
+    assert sorted(c.domain for c in cached_b_preview) == sorted(d.identifier for d in stale_domains)
+
+    def cached_list_stale_claims_for_b(*, product: str) -> list[ClaimInfo]:
+        return list(cached_b_preview)
+
+    monkeypatch.setattr(manager_b.repo, "list_stale_claims", cached_list_stale_claims_for_b)
+
+    original_a_clear_claim = manager_a.repo.clear_claim
+    a_call_count = {"n": 0}
+    b_result_holder: dict[str, Any] = {}
+    trigger_at = 5
+
+    def racy_a_clear_claim(*, product: str, domain_id: str, force: bool = False) -> bool:
+        a_call_count["n"] += 1
+        if a_call_count["n"] == trigger_at and "result" not in b_result_holder:
+            b_result_holder["result"] = manager_b.clear_stale_claims(product=product, dry_run=False)
+        return original_a_clear_claim(product=product, domain_id=domain_id, force=force)
+
+    monkeypatch.setattr(manager_a.repo, "clear_claim", racy_a_clear_claim)
+
+    try:
+        result_a = manager_a.clear_stale_claims(product=product, dry_run=False)
+    finally:
+        manager_a.close()
+        manager_b.close()
+
+    assert "result" in b_result_holder, "interleave did not fire; test setup is broken"
+    result_b = b_result_holder["result"]
+
+    assert isinstance(result_a, ClearSweepResult)
+    assert isinstance(result_b, ClearSweepResult)
+
+    a_pre_interleave = sorted(stale_domains[i].identifier for i in range(trigger_at - 1))
+    a_post_interleave = sorted(stale_domains[i].identifier for i in range(trigger_at - 1, n_stale))
+
+    assert sorted(result_a.cleared) == a_pre_interleave
+    assert sorted(result_a.skipped_missing) == a_post_interleave
+    assert result_a.skipped_fresh == []
+
+    assert sorted(result_b.cleared) == a_post_interleave
+    assert sorted(result_b.skipped_missing) == a_pre_interleave
+    assert result_b.skipped_fresh == []
+
+    assert set(result_a.cleared).isdisjoint(result_b.cleared), (
+        "concurrent sweeps must not both claim the same clear"
+    )
+    all_domain_ids = {d.identifier for d in stale_domains}
+    assert set(result_a.cleared) | set(result_b.cleared) == all_domain_ids
+
+    for f in stale_files:
+        assert not f.exists(), f"stale claim file {f} must be removed after both sweeps"
+
+
+def test_enumeration_bounded_by_stale_claim_count(tmp_path: Path) -> None:
+    """clear_stale_claims must not re-list the claims directory once per stale item.
+
+    Both the mutation loop's re-check and the delete itself derive the claim
+    path directly, so the number of claims-directory listings stays bounded by
+    the preview regardless of how many claims turn out to be stale. Re-listing
+    per candidate would make a sweep cost O(N x S).
+    """
+    manager, counting_fs = _counting_manager(tmp_path)
+    product = "product.zarr"
+    now = time.time()
+
+    stale_domains = [
+        WriteDomain(product=product, category="zarr_append", name=f"stale-{i}") for i in range(10)
+    ]
+    fresh_domains = [
+        WriteDomain(product=product, category="zarr_append", name=f"fresh-{i}") for i in range(10)
+    ]
+    for d in stale_domains:
+        _write_claim(tmp_path, product=product, domain=d, last_heartbeat_at=now - 300)
+    for d in fresh_domains:
+        _write_claim(tmp_path, product=product, domain=d, last_heartbeat_at=now - 30)
+
+    counting_fs.reset()
+    counting_fs.ls_paths.clear()
+
+    try:
+        result = manager.clear_stale_claims(product=product, dry_run=False)
+    finally:
+        manager.close()
+
+    observed = _claims_ls_count(counting_fs)
+    assert observed <= 2, (
+        f"clear_stale_claims listed claims_dir {observed} times for N=20, S=10; "
+        "must be bounded (<= 2) independent of stale count. "
+        f"Recorded ls paths on claims_dir: "
+        f"{[p for p in counting_fs.ls_paths if p.endswith('/.firecube/claims')]}"
+    )
+    assert len(result.cleared) == len(stale_domains)
+
+
+def test_enumeration_bounded_scales_with_N_not_S_claims(tmp_path: Path) -> None:
+    """Enumeration cost is constant across differing stale counts.
+
+    Runs (N=50, S=5) and (N=20, S=15) and asserts the number of
+    claims-directory listings is bounded in each and varies by at most 1
+    between the two, pinning the cost to N rather than S.
+    """
+    product = "product.zarr"
+    now = time.time()
+
+    def _run_case(root: Path, *, stale: int, fresh: int) -> tuple[int, int]:
+        root.mkdir()
+        mgr, counting = _counting_manager(root, product=product)
+        for i in range(stale):
+            _write_claim(
+                root,
+                product=product,
+                domain=WriteDomain(product=product, category="zarr_append", name=f"stale-{i}"),
+                last_heartbeat_at=now - 300,
+            )
+        for i in range(fresh):
+            _write_claim(
+                root,
+                product=product,
+                domain=WriteDomain(product=product, category="zarr_append", name=f"fresh-{i}"),
+                last_heartbeat_at=now - 30,
+            )
+        counting.reset()
+        counting.ls_paths.clear()
+        try:
+            result = mgr.clear_stale_claims(product=product, dry_run=False)
+        finally:
+            mgr.close()
+        return _claims_ls_count(counting), len(result.cleared)
+
+    ls_a, cleared_a = _run_case(tmp_path / "case_a", stale=5, fresh=45)
+    ls_b, cleared_b = _run_case(tmp_path / "case_b", stale=15, fresh=5)
+
+    assert cleared_a == 5
+    assert cleared_b == 15
+    assert ls_a <= 2, f"case A (N=50, S=5): {ls_a} claims_dir listings"
+    assert ls_b <= 2, f"case B (N=20, S=15): {ls_b} claims_dir listings"
+    assert abs(ls_a - ls_b) <= 1, (
+        f"listing count scales with stale count S: A(S=5)={ls_a}, B(S=15)={ls_b}"
+    )

--- a/tests/unit/test_controlplane_events.py
+++ b/tests/unit/test_controlplane_events.py
@@ -124,3 +124,34 @@ def test_replacement_committed_idempotent(temp_workspace):
     ]
 
     assert len(replacement_events) == 1
+
+
+def test_run_meta_rewritten_atomically_across_run_lifecycle(temp_workspace):
+    """run.json is written at run start and rewritten at terminal state. Both
+    writes must go through the atomic-replace path: a create-only write would
+    raise FileExistsError on the rewrite, and a plain open("w") would expose a
+    0-byte window to concurrent resume guards listing runs."""
+    product = "product"
+    run_id = "run-001"
+    repo = ManifestRepository(binding=make_test_binding(temp_workspace), workspace=temp_workspace)
+    _record_run_started(repo, product=product, run_id=run_id)
+
+    run_dir = temp_workspace / product / ".firecube" / "runs" / run_id
+    meta_path = run_dir / "run.json"
+    started = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert started["run_id"] == run_id
+
+    repo.record_run_terminal(
+        product=product,
+        run_id=run_id,
+        output_path=str(temp_workspace / product),
+        output_format="zarr",
+        size=0,
+        meta={"plugin": "test"},
+        status="complete",
+    )
+
+    completed = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert completed["status"] == "complete"
+    leftovers = [p.name for p in run_dir.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == [], f"atomic-replace temp file leaked: {leftovers!r}"

--- a/tests/unit/test_filesystem_claim_service_read_by_domain.py
+++ b/tests/unit/test_filesystem_claim_service_read_by_domain.py
@@ -1,0 +1,109 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for targeted filesystem claim reads by write-domain identifier."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from firecube.core.controlplane.claims import FilesystemClaimService
+from firecube.core.controlplane.types import CLAIMS_DIRNAME, CONTROL_DIRNAME, WriteDomain
+from firecube.core.errors import ControlPlaneCorruptionError
+from firecube.core.filesystem import FsspecFilesystem
+from firecube.core.storage.uri import StorageUri
+from tests.helpers.storage import make_test_binding
+
+pytestmark = pytest.mark.unit
+
+
+class _Resolver:
+    base_uri: StorageUri
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self.base_uri = StorageUri.from_local_path(root)
+
+    def __call__(self, product: str) -> tuple[StorageUri, StorageUri]:
+        control_path = StorageUri.from_local_path(self._root / product / CONTROL_DIRNAME)
+        return control_path, control_path
+
+
+def _service(tmp_path: Path, *, product: str) -> FilesystemClaimService:
+    binding = make_test_binding(tmp_path, product=product)
+    fs = FsspecFilesystem.from_binding(binding)
+    return FilesystemClaimService(fs=fs, control_root_resolver=_Resolver(tmp_path))
+
+
+def _claim_path(tmp_path: Path, *, product: str, domain: WriteDomain) -> Path:
+    return tmp_path / product / CONTROL_DIRNAME / CLAIMS_DIRNAME / domain.claim_name
+
+
+def _write_claim(tmp_path: Path, *, product: str, domain: WriteDomain) -> Path:
+    claim_path = _claim_path(tmp_path, product=product, domain=domain)
+    claim_path.parent.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    payload = {
+        "product": product,
+        "domain": domain.identifier,
+        "owner_id": "owner-1",
+        "claim_path": StorageUri.from_local_path(claim_path).to_str(),
+        "acquired_at": now,
+        "last_heartbeat_at": now,
+        "heartbeat_interval_s": 30,
+        "stale_threshold_s": 120,
+    }
+    claim_path.write_text(json.dumps(payload), encoding="utf-8")
+    return claim_path
+
+
+def test_read_claim_by_domain_returns_claim_info_for_existing_domain(tmp_path: Path) -> None:
+    product = "product.zarr"
+    domain = WriteDomain(product=product, category="zarr_append", name="slot-0")
+    claim_path = _write_claim(tmp_path, product=product, domain=domain)
+    service = _service(tmp_path, product=product)
+
+    info = service.read_claim_by_domain(product=product, domain=domain.identifier)
+
+    assert info is not None
+    assert info.product == product
+    assert info.domain == domain.identifier
+    assert info.owner_id == "owner-1"
+    assert info.claim_path == StorageUri.from_local_path(claim_path).to_str()
+    assert info.heartbeat_interval_s == 30
+    assert info.stale_threshold_s == 120
+
+
+def test_read_claim_by_domain_returns_none_for_missing_domain(tmp_path: Path) -> None:
+    product = "product.zarr"
+    domain = WriteDomain(product=product, category="zarr_append", name="missing")
+    service = _service(tmp_path, product=product)
+
+    assert service.read_claim_by_domain(product=product, domain=domain.identifier) is None
+
+
+def test_read_claim_by_domain_raises_on_malformed_json(tmp_path: Path) -> None:
+    product = "product.zarr"
+    domain = WriteDomain(product=product, category="zarr_append", name="bad-json")
+    claim_path = _claim_path(tmp_path, product=product, domain=domain)
+    claim_path.parent.mkdir(parents=True, exist_ok=True)
+    claim_path.write_text("{not-json", encoding="utf-8")
+    service = _service(tmp_path, product=product)
+
+    with pytest.raises(ControlPlaneCorruptionError, match="Corrupt claim file"):
+        service.read_claim_by_domain(product=product, domain=domain.identifier)

--- a/tests/unit/test_fsspec_atomic_writer.py
+++ b/tests/unit/test_fsspec_atomic_writer.py
@@ -14,7 +14,7 @@
 
 """Unit tests for fsspec atomic create-if-not-exists conflict normalization.
 
-The :class:`AtomicWriter` contract (``protocol.py``) requires ``write_atomic`` to
+The `AtomicWriter` contract (``protocol.py``) requires ``write_atomic`` to
 raise ``FileExistsError`` on an exclusive-create conflict, regardless of backend.
 Local fs signals the conflict with ``errno EEXIST``; s3fs implements ``"xb"`` as a
 conditional ``PutObject`` and signals a lost race with an HTTP 412
@@ -25,7 +25,13 @@ claim layer and crashing concurrent pods. These tests pin the normalization.
 
 from __future__ import annotations
 
+import contextlib
 import errno
+import json
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -222,3 +228,176 @@ def test_local_write_atomic_leaves_no_temp_files(tmp_path: Any) -> None:
 
     leftovers = [p.name for p in tmp_path.iterdir() if p.name != "current.json"]
     assert leftovers == [], f"temp file leaked: {leftovers!r}"
+
+
+@pytest.mark.unit
+def test_local_replace_atomic_creates_when_missing(tmp_path: Any) -> None:
+    target = tmp_path / "run.json"
+
+    _local_writer().replace_atomic(_local_uri(target), b'{"status":"started"}')
+
+    assert target.read_bytes() == b'{"status":"started"}'
+
+
+@pytest.mark.unit
+def test_local_replace_atomic_overwrites_existing(tmp_path: Any) -> None:
+    """Unlike write_atomic, replace_atomic must succeed over an existing file."""
+    target = tmp_path / "run.json"
+    writer = _local_writer()
+
+    writer.replace_atomic(_local_uri(target), b'{"status":"started"}')
+    writer.replace_atomic(_local_uri(target), b'{"status":"completed"}')
+
+    assert target.read_bytes() == b'{"status":"completed"}'
+
+
+@pytest.mark.unit
+def test_local_replace_atomic_leaves_no_temp_files(tmp_path: Any) -> None:
+    target = tmp_path / "run.json"
+    writer = _local_writer()
+
+    writer.replace_atomic(_local_uri(target), b"{}")
+    writer.replace_atomic(_local_uri(target), b'{"n":2}')
+
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name != "run.json"]
+    assert leftovers == [], f"temp file leaked: {leftovers!r}"
+
+
+class _CapturingReplaceFs:
+    """Fake remote fs recording the buffered whole-body write replace_atomic emits."""
+
+    protocol = "s3"
+
+    def __init__(self) -> None:
+        self.written: bytes | None = None
+        self.mode: str | None = None
+
+    def open(self, path: str, mode: str = "rb") -> Any:
+        fs = self
+        fs.mode = mode
+
+        class _Handle:
+            def __enter__(self) -> _Handle:
+                return self
+
+            def __exit__(self, *_: object) -> None:
+                return None
+
+            def write(self, data: bytes) -> None:
+                fs.written = data
+
+        return _Handle()
+
+
+@pytest.mark.unit
+def test_remote_replace_atomic_is_single_buffered_put() -> None:
+    """On object stores the write must be one whole-body PUT ('wb'), never
+    an exclusive create ('xb') that would fail on an existing object."""
+    fs = _CapturingReplaceFs()
+    writer = FsspecAtomicWriter(fs)
+
+    writer.replace_atomic(_URI, b'{"status":"started"}')
+
+    assert fs.mode == "wb"
+    assert fs.written == b'{"status":"started"}'
+
+
+def _payload(n: int) -> bytes:
+    """A distinct, self-describing JSON body large enough to span a partial write."""
+    return json.dumps({"generation": n, "filler": "x" * 4096}).encode("utf-8")
+
+
+def _observe_while_writing(
+    target: Path,
+    write: Callable[[bytes], None],
+    *,
+    generations: int,
+) -> list[bytes]:
+    """Rewrite *target* *generations* times while a reader thread samples it.
+
+    Returns every non-missing sample the reader observed. The reader only ever
+    sees bytes on disk, so any truncated, empty, or half-written state the
+    writer exposes lands in the returned list.
+    """
+    stop = threading.Event()
+    seen: list[bytes] = []
+
+    def reader() -> None:
+        while not stop.is_set():
+            with contextlib.suppress(FileNotFoundError):
+                seen.append(target.read_bytes())
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+    try:
+        for n in range(generations):
+            write(_payload(n))
+    finally:
+        stop.set()
+        thread.join(timeout=10)
+    return seen
+
+
+def _corrupt_samples(seen: list[bytes]) -> list[bytes]:
+    """Samples that are not a complete payload a writer actually published."""
+    bad = []
+    for sample in seen:
+        try:
+            decoded = json.loads(sample)
+        except (ValueError, UnicodeDecodeError):
+            bad.append(sample)
+            continue
+        if sample != _payload(int(decoded["generation"])):
+            bad.append(sample)
+    return bad
+
+
+@pytest.mark.unit
+def test_local_replace_atomic_never_exposes_a_partial_read(tmp_path: Any) -> None:
+    """A concurrent reader observes whole generations only — the core contract.
+
+    ``AtomicWriter.replace_atomic`` promises a reader sees either the previous
+    content or the new content in full, never a truncated or empty file. This
+    is the invariant the control plane depends on: peer pods list runs and
+    parse ``run.json`` while a live run rewrites it, and a torn read surfaces
+    as ``ControlPlaneCorruptionError``.
+    """
+    target = tmp_path / "run.json"
+    writer = _local_writer()
+    uri = _local_uri(target)
+
+    seen = _observe_while_writing(
+        target, lambda data: writer.replace_atomic(uri, data), generations=200
+    )
+
+    assert seen, "reader never sampled the file; the race harness did not run"
+    assert _corrupt_samples(seen) == [], (
+        f"replace_atomic exposed {len(_corrupt_samples(seen))} torn read(s) "
+        f"out of {len(seen)} samples"
+    )
+    assert target.read_bytes() == _payload(199)
+
+
+@pytest.mark.unit
+def test_partial_read_harness_catches_a_truncating_writer(tmp_path: Any) -> None:
+    """The harness above must actually be able to see a torn read.
+
+    Guards `test_local_replace_atomic_never_exposes_a_partial_read` against
+    passing vacuously: the same reader, pointed at the plain ``open(path, "w")``
+    that ``replace_atomic`` replaced, must catch the 0-byte window between
+    truncate and write.
+    """
+    target = tmp_path / "run.json"
+
+    def truncating_write(data: bytes) -> None:
+        with open(target, "wb") as fh:
+            fh.flush()  # truncated to 0 bytes and visible to any reader
+            time.sleep(0.001)
+            fh.write(data)
+
+    seen = _observe_while_writing(target, truncating_write, generations=20)
+
+    assert _corrupt_samples(seen), (
+        "harness saw no torn read from a truncating writer, so it cannot prove "
+        "replace_atomic is atomic"
+    )

--- a/tests/unit/test_obstore_atomic_writer.py
+++ b/tests/unit/test_obstore_atomic_writer.py
@@ -35,3 +35,16 @@ def test_obstore_atomic_writer_uses_put_mode_create() -> None:
         writer.write_atomic(uri, b'{"owner": "thread-2"}')
 
     assert bytes(store.get(uri.path).bytes()) == b'{"owner": "thread-1"}'
+
+
+def test_obstore_replace_atomic_overwrites_existing() -> None:
+    """replace_atomic must succeed over an existing object (default-mode put),
+    unlike write_atomic's create-only contract."""
+    store = MemoryStore()
+    writer = ObstoreAtomicWriter(store)
+    uri = StorageUri.parse("memory:///test-bucket/runs/run-1/run.json")
+
+    writer.replace_atomic(uri, b'{"status":"started"}')
+    writer.replace_atomic(uri, b'{"status":"completed"}')
+
+    assert bytes(store.get(uri.path).bytes()) == b'{"status":"completed"}'

--- a/tests/unit/test_run_dir_for.py
+++ b/tests/unit/test_run_dir_for.py
@@ -1,0 +1,96 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``run_dir_for``."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from firecube.core.controlplane._paths import run_dir_for
+from firecube.core.controlplane.types import RUNS_DIRNAME
+from firecube.core.storage.uri import StorageUri
+
+pytestmark = pytest.mark.unit
+
+
+def test_run_dir_for_happy_path(tmp_path) -> None:
+    product = "product.zarr"
+    control_path = StorageUri.from_local_path(tmp_path / product / ".firecube")
+    control_uri = StorageUri.from_local_path(tmp_path / product / ".firecube")
+
+    def resolver(requested_product: str) -> tuple[StorageUri, StorageUri]:
+        assert requested_product == product
+        return control_path, control_uri
+
+    run_dir, run_uri = run_dir_for(resolver, product, "run-123")
+
+    expected = control_path.join(RUNS_DIRNAME).join("run-123")
+    assert run_dir == expected
+    assert run_uri == expected.to_str()
+
+
+def test_run_dir_for_zero_io() -> None:
+    """Derivation touches the resolver and path joins only — never the store.
+
+    Asserts the derived paths, not the sequence of ``join`` calls that built
+    them: how many segments each join takes is an implementation detail.
+    """
+
+    class SpyStorageUri:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
+        def join(self, *segments: str) -> SpyStorageUri:
+            return SpyStorageUri("/".join((self.label, *segments)))
+
+        def to_str(self) -> str:
+            return self.label
+
+        def exists(self) -> None:  # pragma: no cover - defensive sentinel
+            raise AssertionError("run_dir_for must not check filesystem existence")
+
+        def ls(self) -> None:  # pragma: no cover - defensive sentinel
+            raise AssertionError("run_dir_for must not list filesystem contents")
+
+        def info(self) -> None:  # pragma: no cover - defensive sentinel
+            raise AssertionError("run_dir_for must not inspect filesystem metadata")
+
+    resolver_calls: list[str] = []
+
+    def resolver(product: str) -> tuple[StorageUri, StorageUri]:
+        resolver_calls.append(product)
+        return cast(StorageUri, SpyStorageUri("control-path")), cast(
+            StorageUri, SpyStorageUri("control-uri")
+        )
+
+    run_dir, run_uri = run_dir_for(resolver, "product.zarr", "run-123")
+
+    assert resolver_calls == ["product.zarr"]
+    spy_run_dir = cast(SpyStorageUri, run_dir)
+    assert isinstance(spy_run_dir, SpyStorageUri)
+    assert spy_run_dir.label == f"control-path/{RUNS_DIRNAME}/run-123"
+    assert run_uri == f"control-uri/{RUNS_DIRNAME}/run-123"
+
+
+@pytest.mark.parametrize("run_id", ["../escape", "./escape", "a//b", "/escape", ".."])
+def test_run_dir_for_unsafe_run_id(run_id: str) -> None:
+    def resolver(_product: str) -> tuple[StorageUri, StorageUri]:
+        uri = StorageUri.from_local_path("/tmp/product/.firecube")
+        return uri, uri
+
+    with pytest.raises(ValueError, match="run_id"):
+        run_dir_for(resolver, "product.zarr", run_id)

--- a/tests/unit/test_wal_reader_read_run_entry.py
+++ b/tests/unit/test_wal_reader_read_run_entry.py
@@ -1,0 +1,142 @@
+# Copyright 2025-2026 EUMETSAT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from firecube.core.controlplane._wal_reader import WalReader
+from firecube.core.filesystem import FsspecFilesystem
+from firecube.core.storage.uri import StorageUri
+from tests.helpers.storage import make_test_binding
+
+pytestmark = pytest.mark.unit
+
+
+def _reader(tmp_root: Path, product: str = "product.zarr") -> WalReader:
+    binding = make_test_binding(tmp_root, product=product)
+    return WalReader(
+        fs=FsspecFilesystem(binding),
+        resolver=lambda _product: (binding.identity.product_uri, binding.identity.product_uri),
+        log=logging.getLogger(__name__),
+        run_stale_threshold_s=3600,
+    )
+
+
+def _run_dir(tmp_root: Path, product: str, run_id: str) -> Path:
+    return tmp_root / product / ".firecube" / "runs" / run_id
+
+
+def test_read_run_entry_missing_dir_returns_none(tmp_path: Path) -> None:
+    tmp_root = tmp_path
+    reader = _reader(tmp_root)
+    run_dir = StorageUri.from_local_path(_run_dir(tmp_root, "product.zarr", "missing"))
+
+    entry = reader.read_run_entry(
+        product="product.zarr",
+        run_dir=run_dir,
+        run_uri=run_dir.to_str(),
+        run_id="missing",
+    )
+
+    assert entry is None
+
+
+def test_read_run_entry_orphan_dir_returns_orphan_entry(tmp_path: Path) -> None:
+    tmp_root = tmp_path
+    reader = _reader(tmp_root)
+    run_dir_path = _run_dir(tmp_root, "product.zarr", "orphan")
+    run_dir_path.mkdir(parents=True)
+    (run_dir_path / "events-0001.jsonl").write_text('{"event_type": "noop"}\n', encoding="utf-8")
+    run_dir = StorageUri.from_local_path(run_dir_path)
+
+    entry = reader.read_run_entry(
+        product="product.zarr",
+        run_dir=run_dir,
+        run_uri=run_dir.to_str(),
+        run_id="orphan",
+    )
+
+    assert entry is not None
+    assert entry["status"] == "orphaned"
+    assert entry["error"] == "missing_run_meta"
+    assert entry["parts"] == 1
+
+
+def test_read_run_entry_malformed_json_behavior(tmp_path: Path) -> None:
+    tmp_root = tmp_path
+    reader = _reader(tmp_root)
+    run_dir_path = _run_dir(tmp_root, "product.zarr", "malformed")
+    run_dir_path.mkdir(parents=True)
+    (run_dir_path / "run.json").write_text("{NOT VALID JSON", encoding="utf-8")
+    (run_dir_path / "events-0001.jsonl").write_text('{"event_type": "noop"}\n', encoding="utf-8")
+    run_dir = StorageUri.from_local_path(run_dir_path)
+
+    entry = reader.read_run_entry(
+        product="product.zarr",
+        run_dir=run_dir,
+        run_uri=run_dir.to_str(),
+        run_id="malformed",
+    )
+
+    assert entry is not None
+    assert entry["status"] == "orphaned"
+    assert entry["error"] == "unreadable_run_meta"
+    assert entry["parts"] == 1
+
+
+def test_read_run_entry_pending_empty_meta_no_segments_returns_none(tmp_path: Path) -> None:
+    """A zero-byte run.json with no WAL segments is a peer's first meta write
+    still in flight, not corruption: skip it exactly as if the file did not
+    exist yet. Regression for the 12-pod startup race where a resume guard
+    crashed with ControlPlaneCorruptionError ("Expecting value: ... char 0")
+    while another pod was between open("w") and json.dump."""
+    tmp_root = tmp_path
+    reader = _reader(tmp_root)
+    run_dir_path = _run_dir(tmp_root, "product.zarr", "pending")
+    run_dir_path.mkdir(parents=True)
+    (run_dir_path / "run.json").write_text("", encoding="utf-8")
+    run_dir = StorageUri.from_local_path(run_dir_path)
+
+    entry = reader.read_run_entry(
+        product="product.zarr",
+        run_dir=run_dir,
+        run_uri=run_dir.to_str(),
+        run_id="pending",
+    )
+
+    assert entry is None
+
+
+def test_read_run_entry_garbage_meta_no_segments_still_raises(tmp_path: Path) -> None:
+    """Non-empty unparseable run.json without segments stays a hard error:
+    the pending-meta tolerance is scoped to zero-byte files only, so genuine
+    corruption still surfaces."""
+    tmp_root = tmp_path
+    reader = _reader(tmp_root)
+    run_dir_path = _run_dir(tmp_root, "product.zarr", "garbage")
+    run_dir_path.mkdir(parents=True)
+    (run_dir_path / "run.json").write_text("{NOT VALID JSON", encoding="utf-8")
+    run_dir = StorageUri.from_local_path(run_dir_path)
+
+    with pytest.raises(Exception, match="Expecting"):
+        reader.read_run_entry(
+            product="product.zarr",
+            run_dir=run_dir,
+            run_uri=run_dir.to_str(),
+            run_id="garbage",
+        )


### PR DESCRIPTION
## What changed

`abandon_stale_runs` and `clear_stale_claims` re-listed the whole runs/claims directory once per stale candidate. Both re-checks now do a targeted single-file read, so a sweep costs O(N + S) listings instead of O(N × S). `_get_run_entry`
and `clear_claim` lost their enumerations the same way.

Also: `run.json` is published via a new `AtomicWriter.replace_atomic` instead of a truncating `open(..., "w")`, and the WAL reader skips a zero-byte peer `run.json` rather than raising.

## Why

Closes #26.

## Affected behavior

- User / CLI:  N/A
- Plugin authors: N/A
- Operators / production: sweeps get materially cheaper on large products;
- Stored formats or control-plane state: N/A

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (CLI flags, plugin contract, config, or stored format)
- [x] Documentation
- [ ] CI / build / chore

## Checks run

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run --with bandit bandit -c pyproject.toml -r src scripts -lll`
- [x] `uv run pytest --strict-deps -m "not slow and not s3" -q`
- [x] Docs build (if docs changed): `uv run mkdocs build --strict`

All clean. Bandit skips `scripts` (no such directory).

## Follow-up work

N/A

## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.