### PR TITLE
chore: release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and Firecube package versions follow PEP 440-compatible Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-09-03
+
 ### Added
 
 - New concepts page `docs/concepts/reproducibility.md`: the tiered
@@ -317,6 +319,15 @@ class, implement `index_spec()` returning an `IndexSpec`, and implement
 item in the resolved index. See `docs/operations/firecube-index.md` for
 the migration procedure including `firecube zarr index rebuild`.
 
+### Stats
+
+- pytest: full local suite under `-W error::DeprecationWarning` (`not s3 and
+  not race`): 3251 collected, 3244 passed, 6 skipped, 1 failed. 
+- pyright: 0 errors, 0 warnings.
+- ruff: `check` and `format --check` clean.
+- docs: `mkdocs build --strict` succeeds; docs-static and snapshot tests green.
+- package: `uv build` produces the `0.1.5` wheel + sdist; `twine check` PASSED.
+
 ## [0.1.4.post1] - 2026-07-24
 
 ### Changed
@@ -542,7 +553,8 @@ the migration procedure including `firecube zarr index rebuild`.
 - `uv build`: built `firecube-0.1.1.tar.gz` and `firecube-0.1.1-py3-none-any.whl`.
 - `uv run --with twine twine check dist/*`: passed.
 
-[Unreleased]: https://github.com/eumetsat/firecube/compare/v0.1.4.post1...HEAD
+[Unreleased]: https://github.com/eumetsat/firecube/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/eumetsat/firecube/compare/v0.1.4.post1...v0.1.5
 [0.1.4.post1]: https://github.com/eumetsat/firecube/compare/v0.1.4.post0...v0.1.4.post1
 [0.1.4.post0]: https://github.com/eumetsat/firecube/compare/v0.1.4...v0.1.4.post0
 [0.1.4]: https://github.com/eumetsat/firecube/releases/tag/v0.1.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firecube"
-version = "0.1.4.post1"
+version = "0.1.5"
 description = "A plugin-based batch ingestion CLI for turning Earth Observation products into analysis-ready datacubes."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "firecube"
-version = "0.1.4.post1"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "botocore", extra = ["crt"] },


### PR DESCRIPTION
## What changed

Release 0.1.5: version bump in `pyproject.toml` and `uv.lock`, and the `[Unreleased]` changelog moved under `## [0.1.5] - 2026-09-03` with a Stats section.

## Why

Cuts the release carrying the golden-path indexed writes, dense time-coordinate materialization, and the redesigned plugin scaffolding (whose generated projects now require `firecube>=0.1.5`). 

Milestone: https://github.com/eumetsat/firecube/milestone/2

## Affected behavior

- User / CLI: `firecube --version` reports 0.1.5. No behavior change in this PR.
- Plugin authors: none beyond what 0.1.5's changelog already lists.
- Operators / production: N/A.
- Stored formats or control-plane state: N/A
- 
## Type of change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (CLI flags, plugin contract, config, or stored format)
- [x] Documentation
- [x] CI / build / chore

## Checks run

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run --with bandit bandit -c pyproject.toml -r src scripts -lll`
- [x] `uv run pytest --strict-deps -m "not slow and not s3" -q`
- [x] Docs build (if docs changed): `uv run mkdocs build --strict`

## Follow-up work

After merge: tag from clean `main` with `make release VERSION=0.1.5`, then publish the GitHub Release to trigger PyPI and docs deployment.

## Contributor certification

- [x] Commits are signed off (`git commit -s`) with my real name and a reachable email.
- [x] No credentials, generated products, caches, or virtualenvs are included in this PR.
- [ ] If AI assistance materially shaped this change, I disclosed it here and added an `Assisted-by` trailer.
